### PR TITLE
docs: guides refresh — CLI exit codes, Jinja default-ON, multi-GPU EP, registry truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ the prefill MMQ redesign log is at
 | [BENCHMARKS.md](docs/BENCHMARKS.md) | Measured perf per arch, vs ollama |
 | [ARCHITECTURE.md](docs/ARCHITECTURE.md) | Engine layout, dispatch, two model paths |
 | [QUANTIZATION.md](docs/QUANTIZATION.md) | MQ4 / HF4 design, asym KV cache, FWHT math |
-| [multi-gpu.md](docs/multi-gpu.md) | Pipeline-parallel (pp≥2) — memory budget, deployment, refusals |
+| [CHAT.md](docs/CHAT.md) | `hipfire chat` TUI — keybindings, slash commands |
+| [JINJA.md](docs/JINJA.md) | Jinja chat templates (default ON) — resolution order, opt-out, tool rendering |
+| [MULTI-GPU.md](docs/MULTI-GPU.md) | Multi-GPU serving — expert-parallel (`--tp N`) and pipeline-parallel (pp≥2) |
 | [methodology/perf-benchmarking.md](docs/methodology/perf-benchmarking.md) | Bench protocol — read before claiming a perf win |
 
 ## License

--- a/crates/hipfire-runtime/examples/pp2_vram_probe.rs
+++ b/crates/hipfire-runtime/examples/pp2_vram_probe.rs
@@ -6,7 +6,7 @@
 //! given model with `load_weights_multi`, builds `Qwen35ScratchSet` +
 //! `KvCache::new_gpu_asym3_capped_multi` + `DeltaNetState` (Q8), and
 //! reports per-card VRAM deltas at each stage. Output is a markdown
-//! table row suitable for `docs/multi-gpu.md`.
+//! table row suitable for `docs/MULTI-GPU.md`.
 //!
 //! Run: HIP_VISIBLE_DEVICES=0,1 cargo run -p hipfire-runtime \
 //!         --release --features deltanet --example pp2_vram_probe -- \
@@ -111,7 +111,7 @@ fn main() {
     fmt_per_card("after DN state", &after_dn);
     fmt_per_card("Δ DN state", &dn_delta);
 
-    // Aggregate and emit a markdown row matching docs/multi-gpu.md schema:
+    // Aggregate and emit a markdown row matching docs/MULTI-GPU.md schema:
     //   model | quant | n_layers | dim | KV mode | ctx |
     //   weights | KV | scratch | total | per-card PP=2 | fits 24 GB?
     let weights_max = weights_delta.iter().cloned().fold(0.0_f64, f64::max);

--- a/docs/CHAT.md
+++ b/docs/CHAT.md
@@ -33,8 +33,9 @@ Requires a running `hipfire serve` or auto-spawns a dedicated daemon.
 |---------|-------------|
 | `/help`, `/?` | Show help |
 | `/clear` | Clear conversation history |
-| `/stats` | Show model stats |
-| `/trim` | Drop old messages to free context |
+| `/stats` | Show model stats (tok/s, context usage) |
+| `/trim [pct]` | Drop oldest turns (default trim to 50% of context) |
+| `/set <key> <val>` | Adjust `temperature`, `top_p`, `max_tokens`, `repeat_penalty` for this session |
 | `/exit`, `/quit` | Exit chat |
 
 ## Features

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -16,15 +16,26 @@ flag-level detail; this page is the index.
 
 | Command | Purpose |
 |---|---|
-| `hipfire run <tag\|path> [prompt...]` | Generate. Auto-pulls if missing. Routes through the running `serve` daemon if one is up; otherwise spawns a one-shot daemon. |
-| `hipfire chat <tag>` | Interactive TUI chat with streaming, markdown, multi-line input. Reuses running serve or spawns a dedicated daemon. |
-| `hipfire serve [host] [port] [-d]` | Start the OpenAI-compatible HTTP server. Accepts `host port` or `host:port` such as `hipfire serve 0.0.0.0:11435`. `-d` detaches into the background and writes a pid file. Defaults: host `0.0.0.0`, port `11435` (`hipfire config set host ...`, `hipfire config set port ...`). |
+| `hipfire run <tag\|path> [prompt...]` | Generate. Auto-pulls if missing. Routes through the running `serve` daemon if one is up; otherwise spawns a one-shot daemon. `--max-tokens` defaults to 4096. |
+| `hipfire chat <tag>` | Interactive TUI chat with streaming, markdown, multi-line input. Reuses running serve or spawns a dedicated daemon. Requires a TTY. Full keybinding / slash-command reference: [CHAT.md](CHAT.md). |
+| `hipfire serve [host] [port] [-d] [--tp N]` | Start the OpenAI-compatible HTTP server. Accepts `host port` or `host:port` such as `hipfire serve 0.0.0.0:11435`. `-d` detaches into the background and writes a pid file. `--tp N` enables expert-parallel serving across N GPUs (MiniMax-M2 / DeepSeek-V4 — see [MULTI-GPU.md](MULTI-GPU.md)). Defaults: host `0.0.0.0`, port `11435` (`hipfire config set host ...`, `hipfire config set port ...`). |
 | `hipfire stop` | Graceful shutdown of the background daemon. |
 | `hipfire bench <tag>` | Measure prefill + decode tok/s on a fixed prompt set. |
 
 `hipfire run` accepts either a registry tag (`qwen3.5:9b`) or a literal
 file path (`./my.mq4`). For a prompt with shell-special characters,
 quote it: `hipfire run qwen3.5:9b "What's 2+2?"`.
+
+`hipfire serve` takes a bind address, **not** a model. The server loads
+models per-request (or pre-warms `default_model`). Passing a model tag
+(`hipfire serve qwen3.5:9b`) is detected and refused with a hint
+(exit 1) instead of silently binding to host `"qwen3.5:9b"`:
+
+```
+hipfire run qwen3.5:9b "hello"                # one-shot (uses running serve if any)
+hipfire config set default_model qwen3.5:9b   # make serve pre-warm this model
+hipfire serve [host] [port]
+```
 
 ## Configuration
 
@@ -107,7 +118,24 @@ See [CONFIG.md](CONFIG.md) for CASK-related configuration keys.
 | Command | Purpose |
 |---|---|
 | `hipfire diag` | GPU arch, VRAM, HIP version, ROCm version, kernel blob hashes, model directory. First place to check if anything misbehaves. |
-| `hipfire update` | `git pull` + rebuild + refresh kernel blobs. Use when upstream pushes a fix. |
+| `hipfire profile [model]` | Kernel efficiency profiler (`--json`, `--kernel <name>`). |
+| `hipfire update` | `git pull` + rebuild + refresh kernel blobs. Use when upstream pushes a fix. Also how new registry tags arrive (the model registry ships with the CLI). |
+
+## Exit codes
+
+The CLI keeps a script-friendly contract:
+
+| Code | Meaning |
+|---|---|
+| `0` | Success. Also explicit help requests: `hipfire help`, `-h`, `--help`, and bare `hipfire` (prints help, plus a first-run setup banner when no config/models exist yet). |
+| `1` | Any error: unknown command (`Unknown command: <cmd>` on stderr — typos no longer print full help on stdout with exit 0), invalid usage / missing required args (`run`, `rm`, `quantize`, `sidecar-gen` without their positional arg), model not found (`rm`, `chat`), `chat` without a TTY, the `serve` model-tag-as-host guard, invalid `--tp` values. |
+| daemon's code (or `1`) | One-shot `run` / `bench`: if the spawned daemon dies, its own nonzero exit code is propagated. |
+| `130` | Interactive TUI (`config`, profile picker) interrupted with CTRL+C / CTRL+D (standard 128+SIGINT). |
+
+Error hints ride on stderr — e.g. `hipfire rm` with a missing or unknown
+model prints `See installed models: hipfire list`, and the DFlash-on-A3B
+auto-off path prints the real override syntax
+(`hipfire config <tag> set dflash_mode on`).
 
 ## Where files live
 
@@ -115,6 +143,7 @@ See [CONFIG.md](CONFIG.md) for CASK-related configuration keys.
 - Config: `~/.hipfire/config.json`
 - Per-model overlay: `~/.hipfire/per_model_config.json`
 - Local model aliases: `~/.hipfire/models.json`
+- Per-model chat-template overrides: `~/.hipfire/templates/<model-file>.j2` (see [JINJA.md](JINJA.md))
 - Pre-compiled kernels: `~/.hipfire/bin/kernels/<arch>/`
 - Daemon log: `~/.hipfire/serve.log`
 - Daemon pid file: `~/.hipfire/serve.pid`
@@ -125,9 +154,12 @@ Single-invocation overrides bypass the config file:
 
 | Variable | Effect |
 |---|---|
-| `HIPFIRE_KV_MODE=asym3\|q8\|asym4\|asym2` | Override KV cache layout. |
+| `HIPFIRE_KV_MODE=q8\|asym4\|asym3\|asym2\|fwht4\|fwht3\|fwht2\|turbo*` | Override KV cache layout (same value set as the `kv_cache` config key). |
 | `HIPFIRE_ATTN_FLASH=auto\|always\|never` | Force or disable FlashAttention. |
 | `HIPFIRE_NORMALIZE_PROMPT=0` | Opt out of `\n{3,}` → `\n\n` prompt collapse (default ON). |
+| `HIPFIRE_JINJA_CHAT=0` | Opt out of Jinja chat-template rendering (default ON) — falls back to the hand-rolled ChatML scaffold. See [JINJA.md](JINJA.md). |
+| `HIPFIRE_CHAT_TEMPLATE_FILE=<path>` | Override the chat template for the next model load. See [JINJA.md](JINJA.md). |
+| `HIPFIRE_TP=N` | Expert-parallel degree for model loads (what `hipfire serve --tp N` sets). See [MULTI-GPU.md](MULTI-GPU.md). |
 | `HIPFIRE_LOCAL=1` | `hipfire run` skips the HTTP daemon and spawns a fresh one-shot. |
 | `HIPFIRE_HIPCC_EXTRA_FLAGS=...` | Append flags to JIT kernel compilations. |
 | `HIPFIRE_PROMPT_TOKEN_HEAT=1` | Dump per-position BPE merge-rank heat to stderr. |

--- a/docs/JINJA.md
+++ b/docs/JINJA.md
@@ -1,0 +1,151 @@
+# Jinja chat templates
+
+Since **2026-06-09** the daemon renders chat prompts through a Jinja
+`chat_template` **by default, for every architecture** — the same
+template mechanism HuggingFace's `tokenizer.apply_chat_template` uses.
+Before this flip, prompts were built by a hand-rolled ChatML scaffold
+that had drifted from what the models were actually trained on (JSON
+tool calls where Qwen 3.5/3.6 expects the XML `<function=NAME>` form,
+`<|im_start|>user` wrapping for tool responses instead of
+`<|im_start|>tool`, missing default system prompts, LFM2.5's
+`<|startoftext|>` BOS dropped entirely). Rendering the trained template
+fixes that class of bug at the source.
+
+Opt out (revert to the hand-rolled ChatML scaffold) with:
+
+```bash
+HIPFIRE_JINJA_CHAT=0 hipfire serve
+```
+
+## Template resolution order
+
+At model load the daemon resolves which template to use
+(`resolve_chat_template` in `crates/hipfire-runtime/examples/daemon.rs`),
+first match wins:
+
+1. **`HIPFIRE_CHAT_TEMPLATE_FILE=<path>`** — operator escape hatch /
+   debugging knob. If set and readable, this template wins for any
+   model loaded by that daemon.
+2. **Per-model override file** at
+   `~/.hipfire/templates/<model-file-basename>.j2`
+   (e.g. `qwen3.5-9b.mq4` → `~/.hipfire/templates/qwen3.5-9b.mq4.j2`).
+   Lets you override one model without env-var globalness.
+3. **Arch-default bundled templates:**
+   - Qwen 3.5 / 3.6, dense + MoE (arch_id 5 / 6) → the bundled
+     **froggeric** template
+     (`crates/hipfire-runtime/templates/eval/qwen35-froggeric-v20.jinja`,
+     from [froggeric/Qwen-Fixed-Chat-Templates](https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates),
+     Apache-2.0). Byte-equivalent to the official Qwen template for
+     standard renders, with agentic-loop fixes and engine
+     compatibility; render-equivalence is locked by a durability test
+     (`templates/eval/DURABILITY-2026-06-09.md`).
+   - LFM2.5 (arch_id 11) → the `.hfq`-embedded template when present
+     (the 350M ships one), else the bundled **LiquidAI** template
+     (`templates/eval/lfm2-liquidai.jinja`) — the 8B-A1B export ships
+     no embedded template and renders garbage under plain ChatML, so
+     the bundle is what makes it work out of the box.
+4. **`.hfq`-embedded `tokenizer_config.chat_template`** for every other
+   architecture.
+5. **None of the above** → the render path falls back to the
+   hand-rolled ChatML scaffold (`ChatFrame::Plain`).
+
+A failed render (template parse error, missing context var, template
+`raise_exception`) also falls back to Plain at generate time, with a
+`[daemon] jinja render failed (…) — falling back to Plain` note on
+stderr — a bad template never hard-fails a request.
+
+**Exception:** DeepSeek V4 (arch_id 9) does not render through Jinja at
+all. It has a dedicated DSML prompt builder
+(`<｜User｜>…<｜Assistant｜>` framing plus grammar-constrained tool
+calls) used by both the single-GPU and expert-parallel paths.
+
+## HF byte-exactness
+
+The render environment is set up to byte-match
+`transformers.apply_chat_template` output:
+
+- `trim_blocks=true, lstrip_blocks=true` — matches HF's Jinja
+  environment construction. Without these, `{% … %}` tags leak
+  surrounding whitespace, and for templates with
+  history-length-dependent control flow (MiniMax-M2's
+  `last_user_index` scan) the leak *varies by turn*, collapsing the
+  prompt cache to LCP=1.
+- **Strict undefined** — a missing context variable raises an error
+  (and falls back to Plain) instead of silently rendering a malformed
+  prompt.
+- **pycompat method callback** — Python-style `.startswith` / `.split`
+  / `.rstrip` / `|items` etc. work; the Qwen3 family template calls
+  these throughout its tool branches.
+- **`raise_exception`** is registered so templates can fail fast on
+  malformed input (e.g. a system message mid-conversation).
+- **HF-spaced `tojson`** — minijinja's builtin `tojson` is compact
+  (`,`/`:`); hipfire overrides it with `", "` / `": "` separators
+  (Python `json.dumps` defaults) and serializes with `serde_json`'s
+  `preserve_order` feature, so tool definitions and mapping-valued
+  tool-call arguments render with the exact bytes and key order the
+  model saw in training.
+
+Context passed to the template: `messages`,
+`add_generation_prompt=true`, `enable_thinking`, `bos_token`, `tools`,
+`documents` (empty), `tool_call_kwargs`.
+
+- `enable_thinking` maps from the request's think budget
+  (`max_think_tokens != 1`); for Qwen thinking models `false` renders
+  the empty-think pattern.
+- `bos_token` defaults to decoding the tokenizer's `bos_id`; loaders
+  can pass an explicit string when the cosmetic decode doesn't match
+  the canonical BOS the template expects.
+
+## Tools and multi-turn
+
+When the request carries a `tools` array or a `messages` history, the
+daemon renders through the multi-turn entry point
+(`JinjaChatFrame::render_messages`) so the template's `{% if tools %}`
+and history branches fire. With neither, the single-turn `render()`
+convenience synthesizes `[system?, user]`. Messages carry `role`,
+`content`, `tool_calls` (`{name, arguments}`), and optional
+`tool_call_id` — all four probed-safe under strict-undefined.
+
+## Prompt cache under Jinja (thinking models)
+
+Jinja renders the **full conversation every turn** (stateless render);
+the daemon then takes the longest common prefix against what's already
+prefilled and forward-extends. The catch for thinking models: the
+template renders a historical assistant turn from its API-visible
+`content`, but the model's actual emission included `<think>…</think>`
+tokens that the API stripped — a naive re-render diverges at the first
+assistant turn and the cache misses.
+
+The fix is **verbatim splice**
+(`prompt_frame::build_cached_history_jinja`): each cached assistant
+turn's content is substituted with an atomic reserved special-token
+sentinel, the conversation is rendered through the trained template,
+and the sentinel is then replaced with the verbatim generated tokens of
+that turn (including reasoning and the generation primer). The spliced
+stream byte-matches what was actually prefilled, so the LCP
+forward-extension cache hits. Substitution is verified (exactly one
+sentinel occurrence per cached turn); any mismatch falls back to a
+plain render — always valid, just uncached.
+
+Debug knobs: `HIPFIRE_QWEN_CACHE_TRACE=1` (cache eligibility + lookup
+trace), `HIPFIRE_QWEN_PROMPT_CACHE=0` (kill switch).
+
+## Debugging a template
+
+```bash
+# Dump the rendered prompt for a model + message set (byte-compare vs
+# transformers' apply_chat_template):
+cargo run --release -p hipfire-runtime --example render_chat_template
+cargo run --release -p hipfire-runtime --example jinja_render_dump
+
+# Force a candidate template for one daemon:
+HIPFIRE_CHAT_TEMPLATE_FILE=/tmp/candidate.j2 hipfire serve
+
+# Prefix-cache behavior of a template (forward-extension eval):
+cargo run --release -p hipfire-runtime --example template_cache_eval
+```
+
+Bundled template provenance and the official-vs-froggeric
+render-equivalence audit live in
+`crates/hipfire-runtime/templates/eval/PROVENANCE.md` and
+`templates/eval/DURABILITY-2026-06-09.md`.

--- a/docs/MODELS.md
+++ b/docs/MODELS.md
@@ -1,8 +1,16 @@
 # Models
 
-hipfire ships with a curated registry of Qwen 3.5 / 3.6 family tags
-(small + dense + MoE) and supports running any GGUF or safetensors model
-you bring yourself.
+hipfire ships with a curated registry of model tags — Qwen 3.5 / 3.6
+(dense + MoE), Qwen 3 standard-attention, LFM2.5 (dense + MoE),
+DeepSeek V4 Flash, and several fine-tunes — and supports running any
+GGUF or safetensors model you bring yourself.
+
+> **Registry mechanics:** the registry is a static JSON
+> (`cli/registry.json`) baked into the CLI at build time. `hipfire list
+> -r` reads it; new tags arrive with `hipfire update` (git pull +
+> rebuild). A dynamic registry — published from the HuggingFace org and
+> fetched/cached by the CLI with fallback to the bundled copy — is in
+> development; until it lands, a stale checkout means stale tags.
 
 ## Curated tags
 
@@ -20,7 +28,23 @@ sizes when you want more headroom; pull with the `:<size>-mq6` suffix.
 | `qwen3.5:35b-a3b` | 19.7 GB | 22 GB | MoE 35B / 3B-active |
 | `qwen3.6:27b` | 15 GB | 16 GB | 3.6 refresh, same hybrid arch as 3.5 |
 | `qwen3.6:35b-a3b` | 22.9 GB | 24 GB | 3.6 MoE refresh |
-| `deepseek-v4-flash` | 82 GB | 96 GB | DeepSeek V4 Flash (arch_id=9): MQ2-Lloyd routed-expert MoE, Q8_0 attn KV, Hyper-Connections + compressed-KV indexer + tail-only RoPE. `hipfire pull` also fetches the MTP sidecar for K=2 spec-decode (+29% TG on code). |
+| `deepseek-v4-flash` | 82 GB | 96 GB | DeepSeek V4 Flash (arch_id=9): MQ2-Lloyd routed-expert MoE, Q8_0 attn KV, Hyper-Connections + compressed-KV indexer + tail-only RoPE. `hipfire pull` also fetches the MTP sidecar for K=2 spec-decode (+29% TG on code). Multi-GPU EP serving: [MULTI-GPU.md](MULTI-GPU.md). |
+
+LFM2.5 family (LiquidAI, arch_id=11 — hybrid short-conv + GQA):
+
+| Tag | File | VRAM floor | Notes |
+|---|---|---|---|
+| `lfm2.5:350m` | 0.23 GB | 2 GB | Dense, MQ4, embedded chat template |
+| `lfm2.5:1.2b` | 1.25 GB | 3 GB | 1.2B Instruct dense, Q8 |
+| `lfm2.5:1.2b-thinking` | 1.25 GB | 3 GB | 1.2B Thinking dense, Q8, reasoning |
+| `lfm2.5:8b-a1b` | 4.9 GB | 7 GB | MoE 8B / 1B-active, MQ4. Ships no embedded chat template — the engine bundles LiquidAI's Jinja template (see [JINJA.md](JINJA.md)) |
+
+Qwen 3 standard-attention (no DeltaNet — LLaMA-family loader path):
+
+| Tag | File | VRAM floor | Notes |
+|---|---|---|---|
+| `qwen3:0.6b` | 0.4 GB | 1 GB | HF4 |
+| `qwen3:8b` | 4.1 GB | 6 GB | HF4, ~60 tok/s |
 
 Higher-quality variants:
 
@@ -85,9 +109,13 @@ hipfire quantize ./my-finetune/ --format mq4 -o my-finetune.mq4
 ```
 
 Any directory that contains a `config.json` plus one or more
-`.safetensors` files. Architectures supported by the engine: `llama`,
-`qwen3`, `qwen3_5`, `qwen3_5_moe`. Other architectures are accepted by
-the quantizer but won't load at inference.
+`.safetensors` files. Architectures auto-detected by the quantizer
+(`config.json:model_type`): `llama`, `qwen3` / `qwen2`, `qwen3_5`,
+`qwen3_5_moe`, `dots_ocr`, `deepseek_v4`, `lfm2` / `lfm2_moe`. Plain
+Qwen2 models that need the Q/K/V-bias loader should be stamped with
+`--arch-id 7` (the `hipfire-arch-qwen2` crate) — the default
+LLaMA-family path silently drops the bias tensors. Other architectures
+are accepted by the quantizer but won't load at inference.
 
 ### From GGUF
 
@@ -197,9 +225,14 @@ respectively.
 
 ### Chat template
 
-hipfire applies the **ChatML** template for Qwen 3.5 / 3.6 / Carnice /
-Qwopus; the daemon expects messages already serialized by the CLI
-into:
+Since 2026-06-09 the daemon renders prompts through the model's **Jinja
+chat template by default** (the same `chat_template` HuggingFace's
+`apply_chat_template` uses), for all architectures. Qwen 3.5 / 3.6 (and
+the Carnice / Qwopus fine-tunes) render through a bundled
+community-fixed template; LFM2.5 through LiquidAI's; everything else
+through the template embedded in the `.hfq`. When no template resolves
+— or a render fails — the daemon falls back to the legacy hand-rolled
+ChatML scaffold:
 
 ```
 <|im_start|>system
@@ -209,11 +242,11 @@ into:
 <|im_start|>assistant
 ```
 
-`hipfire run` and the OpenAI server both build this string from
-`messages[]` before sending to the daemon. Per-model template tweaks
-live in `cli/registry.json` under each model entry; you don't normally
-edit them. Custom system prompts are forwarded as a `system` role
-message and inserted at the top of the ChatML envelope.
+Opt out of Jinja rendering with `HIPFIRE_JINJA_CHAT=0`. Resolution
+order, per-model overrides, tool-call rendering, and the
+thinking-model prompt cache are documented in [JINJA.md](JINJA.md).
+DeepSeek V4 is the exception: it renders through its dedicated DSML
+prompt builder (`<｜User｜>…<｜Assistant｜>`), not Jinja.
 
 One implicit normalization step: the engine collapses runs of three or
 more `\n` characters down to exactly two before tokenization
@@ -241,10 +274,13 @@ Extension legend:
 | `.mq6` | MQ6G256 (FWHT-rotated 6-bit) | Qwen3.5+ higher quality |
 | `.hf4` | HFQ4-G256 (raw 4-bit) | Llama / Qwen3 / Mistral / dense |
 | `.hf6` | HFQ6-G256 (raw 6-bit) | Dense, higher quality |
+| `.q8` | Q8 (8-bit) | Small models where quality > size (e.g. `lfm2.5:1.2b`) |
+| `.mq2lloyd` | MQ2-Lloyd (2-bit expert MoE) | DeepSeek V4 / MiniMax-M2 big-MoE tiers |
 | `.hfq` | Legacy HFQ4 (pre-0.1.5 naming) | Loads, no new files written here |
 
-CLI discovery (`hipfire list`, fuzzy `hipfire run` lookup) recognizes
-all five extensions.
+Fuzzy CLI discovery (`hipfire list`, `hipfire run` substring lookup)
+scans for `.mq4` / `.mq6` / `.hf4` / `.hf6` / `.hfq` / `.mq2lloyd`;
+registry tags resolve by exact filename regardless of extension.
 
 ## Current local family status
 
@@ -259,8 +295,9 @@ is a custom non-Hipfire architecture target.
 | Qwen 3.5 / 3.6 dense hybrid | `qwen3.5-{0.8b,2b,4b,9b}`, `qwen3.6-27b` | Supported as Qwen35 dense (`arch_id=5`). | Supported for paired dense drafts when target lm_head dtype is Q8/HFQ4/MQ4, plus MQ3 on gfx11/gfx12; MQ6 targets need AR. | Present as native Qwen35 speculative-verify/MTP surfaces for validated dense paths; still correctness-first and not the same as DFlash drafts. | Supported with TriAttention/CASK sidecars on FullAttention layers. | Supported only on Qwen35 path when incompatible features are off. | Supported via Qwen35 batched prefill path. | Smoke refs exist for `qwen3.5-{0.8b,2b,9b}`; no full refs yet. | Dense Qwen35 decode/prefill kernels cover BF16/MQ4/MQ6 and selected MQ3. Missing DFlash batched lm_head/verify support for MQ6/MQ8/MQ2/F16 targets. |
 | Qwen 3.5 / 3.6 MoE | `qwen3.6-35b-a3b`, `qwen3.5-122b-a10b` | Supported as Qwen35 MoE (`arch_id=6`) when quantized in Qwen3.5-MoE tensor layout. | Limited: dense-style DFlash works only where target/draft dtypes hit supported batched verify paths; MQ3 MoE is refused for DFlash. | MoE MTP code exists, but admission is narrower than dense and still gated by MoE dtype/layout validation. | Supported on FullAttention layers; no MoE-specific eviction of expert weights unless using the separate pager path. | Supported only on Qwen35 path when incompatible features are off. | Supported; MoE batched prefill admits MQ4 control and newer MQ6/MQ3 surfaces on validated arches. | `qwen3.6-35b-a3b-bf16` KLD producer is currently skipped on error; no completed refs for MoE rows. | Indexed MoE gate/up/down, shared expert, router, and grouped GEMM kernels exist for Qwen35 MoE. Missing broad MQ3/MQ2/MQ8 MoE DFlash coverage and full validation for every local MoE artifact. |
 | Qwen3-MoE / Qwen3-Coder (`qwen3_moe`) | `qwen3-coder-30b-a3b-instruct`, `tiny-random/qwen3-moe` | Not currently first-class. Local Coder HFQs are stamped `arch_id=0`, but source configs are `qwen3_moe`; that does not match the Qwen35-MoE loader layout. | No. | No. | No. | No. | No. | Listed as a desired KLD target for Coder, but no completed ref. | Needs a `qwen3_moe` architecture mapping and loader/kernel audit. Existing Qwen35 MoE kernels assume Qwen3.5 hybrid layer/tensor layout, not plain Qwen3-MoE/Coder layout. |
-| DeepSeek V4 Flash | `deepseek-v4-flash.mq4.hfq` | Supported as dedicated DeepSeek V4 path (`arch_id=9`). | No Qwen-style DFlash drafter. | Supported as DeepSeek V4's own optional MTP speculative decode path. | No. | No. | Supported by DeepSeek V4 chunked batched prefill / MTP fill. | Not currently targeted for KLD refs. | Dedicated DeepSeek V4 kernels cover Hyper-Connections, compressed-KV indexer, SWA attention, routed MoE, MQ2/MQ3-Lloyd expert variants, and MTP. Missing CASK, PP, and Qwen-style DFlash integration. |
-| LFM2.5-MoE | `lfm2.5-8b-a1b` | Supported as LFM2.5-MoE (`arch_id=11`) when compiled with `arch-lfm2moe`. Minimal AR bring-up. | No. | No. | No. | No. | No; prefill is per-token `decode_step`. | No completed refs yet. | Short-conv, attention, router, top-4 MoE, MQ4/MQ6 expert kernels are present. Missing batched prefill, DFlash/spec decode, CASK, PP, and grammar/tool-exec integration. |
-| Dense LFM2.5 | `lfm2.5-350m`, `lfm2.5-1.2b-instruct` | Not supported as dense LFM2. Local MQ artifacts stamped `arch_id=11` are suspect because the LFM2-MoE parser requires MoE-only fields. | No. | No. | No. | No. | No. | KLD producer currently skipped on error for dense LFM2 rows. | Needs a dense LFM2 architecture crate or a generalized LFM2 loader. Current `hipfire-arch-lfm2moe` kernels/config assume `lfm2_moe` layer types, experts, and MoE FFN fields. |
+| DeepSeek V4 Flash | `deepseek-v4-flash.mq4.hfq` | Supported as dedicated DeepSeek V4 path (`arch_id=9`). Multi-GPU expert-parallel serving via `hipfire serve --tp N` ([MULTI-GPU.md](MULTI-GPU.md)). | No Qwen-style DFlash drafter. | Supported as DeepSeek V4's own optional MTP speculative decode path (single-GPU; the EP path decodes plain greedy AR). | No. | No (PP refused; EP is the multi-GPU path). | Supported by DeepSeek V4 chunked batched prefill / MTP fill. | Not currently targeted for KLD refs. | Dedicated DeepSeek V4 kernels cover Hyper-Connections, compressed-KV indexer, SWA attention, routed MoE, MQ2/MQ3-Lloyd expert variants, and MTP. Missing CASK and Qwen-style DFlash integration. |
+| LFM2.5-MoE | `lfm2.5-8b-a1b` | Supported as LFM2.5-MoE (`arch_id=11`, `hipfire-arch-lfm2moe`). AR decode; registry tag `lfm2.5:8b-a1b`. Chat framing via the bundled LiquidAI Jinja template (the A1B export ships no embedded template — see [JINJA.md](JINJA.md)). | No. | No. | No. | No. | No; prefill is per-token `decode_step`. | No completed refs yet. | Short-conv, attention, router, top-4 MoE, MQ4/MQ6 expert kernels are present. Missing batched prefill, DFlash/spec decode, CASK, PP, and grammar/tool-exec integration. |
+| Dense LFM2.5 | `lfm2.5-350m`, `lfm2.5-1.2b-instruct`, `lfm2.5-1.2b-thinking` | Supported through the same `arch_id=11` crate — the config parser treats `num_experts == 0` (plain `lfm2` / `Lfm2ForCausalLM`) as all-dense-SwiGLU (`num_dense_layers == num_hidden_layers`). Registry tags `lfm2.5:350m` (MQ4), `lfm2.5:1.2b` / `lfm2.5:1.2b-thinking` (Q8). | No. | No. | No. | No. | No; per-token prefill like the MoE path. | No completed refs yet. | Same kernel set as LFM2.5-MoE minus the router/expert kernels (unused at `num_experts=0`). Same gaps: batched prefill, spec decode, CASK, PP. |
+| Qwen2 dense (`arch_id=7`) | `qwen2-1.5b-instruct` | Supported via `hipfire-arch-qwen2` (GQA + Q/K/V bias + 1-D RoPE). Validated against the committed HF F32 reference on gfx1151; forward-as-pipeline lowered decode is default-ON after gfx1100+gfx1201 byte-parity. Quantize with `--arch-id 7`. | No. | No. | No. | No. | No. | Smoke ref `qwen2_1p5b_instruct_smoke.json` (16/16 top-1 at Q8). | Q8F16 / HFQ4 / F16 weight paths. Missing DFlash, CASK, PP, batched prefill. |
 | LLaMA-family dense | `llama-3.2-1b-instruct`, `supra-50m-instruct` | Basic dense AR support through LLaMA-family path (`arch_id=0`). | No. | No. | No. | No. | No Qwen35-style batched prefill. | Producer skipped on error for `llama-3.2-1b-instruct-bf16` and `supra-50m-instruct-bf16`. | Dense LLaMA/GGUF-style GEMV, Q8/HFQ/MQ weight paths exist. Missing family-specific optimized prefill, DFlash, CASK, PP, and per-model quality refs. |
 | Gemma 4 | `gemma-4-E2B-it` | Not runnable as a Gemma architecture yet. Prompt/tool-call support scaffolding exists, but no Gemma4 architecture crate is in the workspace. | No. | No. | No. | No. | No. | Not generated. | Needs `hipfire-arch-gemma4`, config/loader/forward kernels, and stop/tool-call policy wiring. Existing Gemma parser support is not model execution support. |

--- a/docs/MULTI-GPU.md
+++ b/docs/MULTI-GPU.md
@@ -79,13 +79,13 @@ logits, and emitted calls stream as structured `tool_calls` events
 with `finish_reason: "tool_calls"`. For MiniMax-M2 the template
 renders tool definitions into the prompt; output streams as text.
 
-> **Known issue (ds4 + tp>1):** `forward_ep` is not yet byte-exact to
-> the single-GPU forward on DeepSeek V4 — the prefill numerics diverge
-> at the first response token, which can degrade DSML tool-call
-> emission under EP even though the identical prompt produces clean
-> `tool_calls` single-GPU. The render/parse wiring is correct; the
-> forward-numerics gap is tracked under task #26 / Ship 6. Plain text
-> generation is coherent.
+> **Fixed in v0.2.1:** earlier ds4 EP builds emitted degraded tool-call
+> syntax on RDNA4 (gfx12) because every F16-weight GEMV fell back to a
+> broken kernel that corrupted the DSA compressor (fixed in 245ae3fe).
+> EP tool-calling on hiptrx-class tp4 now produces token streams
+> identical to the validated single-GPU path; on the canonical weather
+> tool prompt the daemon emits `tool_calls` with
+> `finish_reason: "tool_calls"` in both think and non-think modes.
 
 Caching: MiniMax-M2 EP carries the single-GPU LCP prefix cache — every
 rank's KV cursor rewinds to the longest common prefix of the rendered

--- a/docs/MULTI-GPU.md
+++ b/docs/MULTI-GPU.md
@@ -1,9 +1,147 @@
-# Multi-GPU Pipeline-Parallel
+# Multi-GPU serving
 
-**Status:** v1 feature-complete on `feat/multi-gpu-pp` branch — tracking
+hipfire has two multi-GPU modes, selected per model load and **mutually
+exclusive** (the daemon refuses a load that sets both):
+
+| Mode | Load param | What's sharded | For | Arches |
+|---|---|---|---|---|
+| **Expert-parallel (EP)** | `tp` (`hipfire serve --tp N`) | Routed MoE experts (rank `r` owns experts `e % tp == r`); attention / KV / norms replicated per rank | Big-MoE models whose *weights* don't fit one card (DeepSeek V4 Flash ~82 GB, MiniMax-M2) | DeepSeek V4 (arch 9), MiniMax-M2 (arch 10) |
+| **Pipeline-parallel (PP)** | `pp` | Contiguous layer bands; the residual stream flows dev0 → dev1 → … | Dense / hybrid models that need more *context or headroom* than one card | Qwen 3.5/3.6 dense + MoE (arch 5/6) |
+
+---
+
+# Expert-parallel (EP) — `--tp N`
+
+**Status:** v1 landed (task #26 — design doc
+`docs/plans/daemon-ep-wiring.md`, substrate validation log
+`docs/plans/ship6-substrate-ep.md`). Greedy AR decode, validated on
+4× gfx1201 (32 GiB each) for DeepSeek V4 Flash and MiniMax-M2
+(MiniMax: coherent at 51.7 tok/s decode, ~24 GB/card shard load) —
+models whose MQ2-Lloyd tiers (~82–86 GB) cannot fit any single 32 GB
+card.
+
+## How it works
+
+`Gpus::init_tp(tp, n_layers)` brings up `tp` ranks; each rank loads the
+full non-expert weight set (attention, norms, router, shared expert)
+plus **only its owned routed experts** (`ExpertAssign::Stride`: rank
+`r` owns experts `e % tp == r`; non-owned slots are zeroed dummies that
+contribute 0). Every rank runs the full forward; the routed-expert
+combine is the only cross-GPU step — one peer-direct copy+add
+all-reduce of a `[hidden_size]` partial per MoE layer. Logits land on
+rank 0 and sampling happens on the host, so the EP seam is
+forward-only.
+
+## Serving
+
+```bash
+# DeepSeek V4 Flash across 4 GPUs
+HIP_VISIBLE_DEVICES=0,1,2,3 hipfire serve --tp 4
+hipfire run deepseek-v4-flash "What is the capital of France?"
+```
+
+Driving the daemon JSON directly:
+
+```json
+{"type":"load","model":".../deepseek-v4-flash.mq2lloyd","params":{"max_seq":8192,"tp":4}}
+```
+
+`hipfire serve --tp N` sets `HIPFIRE_TP=N`; the CLI forwards it as
+`params.tp` on every model load (only when > 1, so single-GPU loads
+stay byte-identical). Loads are refused with a structured error when:
+
+- `tp > 1` **and** `pp > 1` (mutually exclusive),
+- `tp > 1` with a DFlash drafter configured (no spec-decode under EP v1),
+- the model's arch_id is not 9 (DeepSeek V4) or 10 (MiniMax-M2),
+- `init_tp` finds fewer devices than `tp` (check
+  `HIP_VISIBLE_DEVICES` / `ROCR_VISIBLE_DEVICES`).
+
+## Generate semantics (v1)
+
+The EP generate path (`generate_ep` in the daemon) accepts the normal
+generate fields — `prompt`, `system_prompt`, `messages` (multi-turn
+history), `tools`, `max_tokens`, `stop`, think mode — with v1 limits:
+
+- **Greedy decode only.** Sampling params (temperature / top_p /
+  penalties) are not applied on the EP path yet; logits are argmax'd
+  host-side from rank 0.
+- **MTP / DFlash / CASK / PFlash / VL: not available** under EP.
+- Prompt rendering matches single-GPU: DeepSeek V4 goes through its
+  DSML prompt builder (`<｜User｜>…<｜Assistant｜>`), MiniMax-M2 through
+  its Jinja chat template with `tools` and the full message history
+  threaded (see [JINJA.md](JINJA.md)).
+
+**Tool calls are wired on the EP path.** For DeepSeek V4 the daemon
+builds per-request tool schemas from the OpenAI `tools` array and runs
+the DSML stream parser plus a **grammar-constrained token mask** during
+decode — tokens that would malform a tool call are masked out of the
+logits, and emitted calls stream as structured `tool_calls` events
+with `finish_reason: "tool_calls"`. For MiniMax-M2 the template
+renders tool definitions into the prompt; output streams as text.
+
+> **Known issue (ds4 + tp>1):** `forward_ep` is not yet byte-exact to
+> the single-GPU forward on DeepSeek V4 — the prefill numerics diverge
+> at the first response token, which can degrade DSML tool-call
+> emission under EP even though the identical prompt produces clean
+> `tool_calls` single-GPU. The render/parse wiring is correct; the
+> forward-numerics gap is tracked under task #26 / Ship 6. Plain text
+> generation is coherent.
+
+Caching: MiniMax-M2 EP carries the single-GPU LCP prefix cache — every
+rank's KV cursor rewinds to the longest common prefix of the rendered
+conversation and only the divergent suffix re-prefills
+(interleaved-thinking partial reuse). The MiniMax `<think>\n` opener is
+re-emitted display-only so the assistant turn stays well-formed.
+DeepSeek V4 EP keeps an assistant-turn cache for verbatim history
+replay.
+
+## Environment / debug knobs (EP)
+
+| Variable | Effect |
+|---|---|
+| `HIP_VISIBLE_DEVICES=0,1,2,3` | Standard ROCm device filter — expose exactly the ranks you want |
+| `HIPFIRE_TP=N` | What `hipfire serve --tp N` sets; any CLI-initiated load forwards it as `params.tp` |
+| `HIPFIRE_UNIFORM_VRAM_TOLERANCE_GB=N` | Pre-flight VRAM-asymmetry tolerance (default 2.0). Raise it when a busy card makes the uniform-VRAM check flag a false asymmetry |
+| `HIPFIRE_DEEPSEEK4_DUMP_PROMPT=1` | Dump the rendered EP prompt (token count + decoded text) to stderr |
+| `HIPFIRE_DEEPSEEK4_CACHE_TRACE=1` | Trace ds4 assistant-turn cache stores |
+| `HIPFIRE_QWEN_CACHE_TRACE=1` | Trace the MiniMax EP LCP prefix-cache decisions |
+
+## Validation harnesses (EP)
+
+GPU-side parity and bring-up harnesses, runnable without the daemon:
+
+```bash
+# DeepSeek V4 Flash EP greedy decode (4× gfx1201 recipe)
+HIP_VISIBLE_DEVICES=0,1,2,3 cargo run --release \
+    -p hipfire-arch-deepseek4 --example ep_deepseek4 -- \
+    --model ~/.hipfire/models/deepseek-v4-flash.mq2lloyd --tp 4 --max 48 \
+    --prompt "The capital of France is"
+
+# MiniMax-M2 EP greedy decode
+HIP_VISIBLE_DEVICES=0,1,2,3 cargo run --release --features deltanet \
+    -p hipfire-arch-minimax --example ep_minimax -- \
+    --model ~/.hipfire/models/minimax-m2.mq2lloyd --tp 4 --max 32 \
+    --prompt "The capital of France is"
+
+# EP ≡ single-GPU decode parity (Qwen3.x-A3B substrate harness):
+# run at tp=1 then tp=2 and diff the printed FNV hash.
+HIP_VISIBLE_DEVICES=0,1 cargo run --release --features deltanet \
+    -p hipfire-runtime --example ep_decode_parity -- \
+    ~/.hipfire/models/qwen3.6-35b-a3b.mq4 2 24 "The capital of France is"
+```
+
+The EP examples print an FNV-1a fingerprint over the emitted token
+ids; a `--tp N` run is expected to match the `--tp 1` / single-GPU
+fingerprint (the EP combine is accumulate-style, so EP ≡ non-EP).
+
+---
+
+# Pipeline-parallel (PP) — `pp ≥ 2`
+
+**Status:** v1 feature-complete — tracking
 issue [#58](https://github.com/Kaden-Schutt/hipfire/issues/58). Stages
 0–9 of the v2 plan are merged; refusal contracts (DFlash / VL / CASK +
-pp>1) are wired and validated. This doc is the source of truth for
+pp>1) are wired and validated. This section is the source of truth for
 memory budget, deployment recipes, throughput, and known limitations.
 
 ## Why PP

--- a/docs/multi-gpu-bringup-lessons.md
+++ b/docs/multi-gpu-bringup-lessons.md
@@ -2,7 +2,7 @@
 
 Captures non-obvious gotchas and root-causes from bringing up hetero
 PP=2 across a cross-arch AMD pair (gfx906 MI50 CDNA1 + gfx1031 RX 6700 XT
-RDNA2). Companion to the operational `docs/multi-gpu.md` — that one
+RDNA2). Companion to the operational `docs/MULTI-GPU.md` — that one
 covers what PP gives you and how to deploy it; this one covers what
 broke and why during bring-up.
 
@@ -237,7 +237,7 @@ day one.**
 
 ## See also
 
-- `docs/multi-gpu.md` — operational guide (memory budgets, deployment recipes, throughput).
+- `docs/MULTI-GPU.md` — operational guide (memory budgets, deployment recipes, throughput).
 - `docs/plans/hetero-pflash-dflash.prd` — the hetero PFlash+DFlash architectural plan.
 - `docs/plans/path_d.md` — same-card spec-decode pipelining design (closed without merge after empirical dominated by chain-mode; preserved for future revival).
 - PR #204 (closed) — full hetero spec-decode prototype with the bind_thread pattern, long-context findings, and the pivot to native MTP as the actual perf lever.

--- a/docs/plans/multi-gpu-pp.md
+++ b/docs/plans/multi-gpu-pp.md
@@ -5,7 +5,7 @@
 **Date:** 2026-05-05
 **Target Release:** v0.2.0 (at maintainer discretion)
 **Related:** issue [#58](https://github.com/Kaden-Schutt/hipfire/issues/58),
-`docs/multi-gpu.md` (user-facing reference), `AGENTS.md` §threading,
+`docs/MULTI-GPU.md` (user-facing reference), `AGENTS.md` §threading,
 `CLAUDE.md` "Coherence Gate"
 
 ---
@@ -233,7 +233,7 @@ New: `crates/hipfire-runtime/src/multi_gpu.rs`.
   `gpus.devices[gpus.output_device]`; per-layer weights →
   `gpus.devices[gpus.device_for_layer(i)]`.
 - `Qwen35Weights::free_gpu_multi` mirrors per-device ownership.
-- Update `docs/multi-gpu.md` memory budget table from real measurements.
+- Update `docs/MULTI-GPU.md` memory budget table from real measurements.
 
 ### Stage 5 — `multi-gpu-pp-5-state-placement` (~4-5d)
 
@@ -317,7 +317,7 @@ within one layer's body and does not cross boundaries.
 `crates/hipfire-arch-qwen35/tests/pp_parity.rs` (new),
 `crates/hipfire-runtime/examples/{pp_parity,pp_parity_chatml,pp2_vram_probe}.rs`
 (new),
-`docs/multi-gpu.md`,
+`docs/MULTI-GPU.md`,
 `tests/speed-baselines/gfx1100x2_pp.txt` (new).
 
 - `coherence-gate.sh --pp N`; for changes touching `multi_gpu.rs` or
@@ -381,7 +381,7 @@ and re-stated here for permanence:
 
 - Issue [#58](https://github.com/Kaden-Schutt/hipfire/issues/58) —
   multi-GPU roadmap
-- `docs/multi-gpu.md` — user-facing reference (memory budget table,
+- `docs/MULTI-GPU.md` — user-facing reference (memory budget table,
   deployment recipes, limitations)
 - `docs/methodology/perf-benchmarking.md` — perf claim discipline
 - `CLAUDE.md` "Coherence Gate" — mandatory gate for forward-pass changes


### PR DESCRIPTION
## What

Docs-only refresh bringing the user-facing guides in line with what shipped on master. Every statement was verified against the code at e2d21ae2 (`cli/index.ts`, `cli/registry.json`, `daemon.rs`, `prompt_frame.rs`, the bundled template durability audit).

### CLI.md
- `chat` row links to CHAT.md; `serve` documents `--tp N` and the new model-tag-as-host guard (`hipfire serve qwen3.5:9b` now refuses with a hint instead of binding to a bogus host)
- `profile` was shipped but undocumented — added
- New **Exit codes** section: `0` success/help, `1` errors (unknown command no longer exits 0 with help on stdout), one-shot daemon code propagation, `130` on TUI SIGINT
- Env table: `HIPFIRE_JINJA_CHAT`, `HIPFIRE_CHAT_TEMPLATE_FILE`, `HIPFIRE_TP`, full kv-mode value set (fwht*/turbo*)

### MODELS.md
- LFM2.5 rows (`lfm2.5:350m` / `:1.2b` / `:1.2b-thinking` / `:8b-a1b`) and Qwen3 standard-attention rows (`qwen3:0.6b` / `:8b`) matching `cli/registry.json`
- Static-registry note (bundled JSON, tags arrive via `hipfire update`; dynamic registry called out as in development — task #47)
- Quantizer arch list updated (`dots_ocr`, `deepseek_v4`, `lfm2`/`lfm2_moe`, `--arch-id 7` for plain Qwen2)
- Chat-template section rewritten for Jinja default-ON; extension legend gains `.q8` + `.mq2lloyd`
- Family-status table: dense LFM2.5 flipped from "Not supported" (stale) to supported (`num_experts==0` → all-dense path in `hipfire-arch-lfm2moe`); Qwen2 `arch_id=7` row added; DeepSeek row notes EP serving

### JINJA.md (new)
Default-ON (2026-06-09), full resolution order (`HIPFIRE_CHAT_TEMPLATE_FILE` → `~/.hipfire/templates/*.j2` → arch defaults froggeric/LiquidAI → embedded → Plain fallback), opt-out, HF byte-exactness mechanics (trim/lstrip_blocks, strict-undefined, pycompat, `hf_tojson` + `preserve_order`), tools/multi-turn rendering, the verbatim-splice prompt cache for thinking models, debugging recipes. DeepSeek V4's DSML exception called out.

### MULTI-GPU.md (renamed from multi-gpu.md)
Renamed to avoid a case-only sibling pair (would break case-insensitive checkouts) and expanded into the umbrella multi-GPU doc:
- **New EP section**: `--tp N` / `HIPFIRE_TP`, supported arches (ds4 / MiniMax-M2), expert sharding (`e % tp == r`), load refusal matrix, `generate_ep` v1 semantics (greedy-only, no MTP/DFlash/CASK/PFlash/VL), ds4 grammar-masked tool calls + the known `forward_ep` non-byte-exactness caveat, MiniMax LCP partial-reuse cache, env/debug knobs, hiptrx tp4 harness recipes, MiniMax 51.7 tok/s validation record (from `ship6-substrate-ep.md`)
- PP content preserved unchanged as its own section; all `multi-gpu.md` references repointed (README, plans, `pp2_vram_probe.rs` comments)

### Misc
- CHAT.md: `/set` slash command documented (existed in code only)
- README docs table: CHAT / JINJA / MULTI-GPU rows

## Verification
- All relative doc links checked (script): no broken targets
- Registry rows cross-checked against `cli/registry.json` at HEAD
- Only non-doc change is comment text in `pp2_vram_probe.rs` (reference repoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)