### PR TITLE
Reconcile PP+MTP daemon path from #382

### DIFF
--- a/crates/hipfire-arch-qwen35/src/mtp_spec.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_spec.rs
@@ -33,8 +33,10 @@
 use crate::mtp_head::{self, Qwen35MtpHead, Qwen35MtpHeadKvCache, Qwen35MtpHeadScratch};
 use crate::qwen35::{self, Qwen35Weights};
 use crate::speculative::{DeltaNetSnapshot, GdnTape, ModelSlot};
-use hip_bridge::{Event, Graph, GraphExec, HipResult, Stream};
+use hip_bridge::{DeviceBuffer, Event, Graph, GraphExec, HipResult, Stream};
 use hipfire_runtime::llama;
+use hipfire_runtime::llama::EmbeddingFormat;
+use hipfire_runtime::multi_gpu::Gpus;
 use rdna_compute::{DType, Gpu, GpuTensor};
 use std::time::Instant;
 
@@ -638,6 +640,111 @@ impl MtpSpecState {
         })
     }
 
+    pub fn new_for_config_with_kv_mode(
+        gpu: &mut Gpu,
+        config: &qwen35::Qwen35Config,
+        dn_state: &qwen35::DeltaNetState,
+        head: &Qwen35MtpHead,
+        max_n: usize,
+        kv_mode: crate::mtp_head::MtpKvMode,
+    ) -> HipResult<Self> {
+        assert!(
+            max_n >= 1,
+            "MtpSpecState::new_for_config: max_n must be >= 1",
+        );
+        let dim = config.dim;
+        let vocab = config.vocab_size;
+        assert_eq!(
+            head.config.n_embd, dim,
+            "MtpSpecState: trunk dim={dim} but head n_embd={}",
+            head.config.n_embd,
+        );
+        assert_eq!(
+            head.config.vocab_size, vocab,
+            "MtpSpecState: trunk vocab={vocab} but head vocab={}",
+            head.config.vocab_size,
+        );
+
+        let prev_hidden = gpu.alloc_tensor(&[dim], DType::F32)?;
+        let verify_hidden = gpu.alloc_tensor(&[(max_n + 1) * dim], DType::F32)?;
+        let verify_logits = gpu.alloc_tensor(&[(max_n + 1) * vocab], DType::F32)?;
+        let verify_rot = gpu.alloc_tensor(&[(max_n + 1) * dim], DType::F32)?;
+        let verify_argmax = gpu.alloc_tensor(&[max_n + 1], DType::F32)?;
+        let trunk_snap = DeltaNetSnapshot::new_for(gpu, dn_state)?;
+        let (trunk_snap_stream, trunk_snap_start_event) = if mtp_snapshot_overlap_enabled_from_env()
+        {
+            (
+                Some(gpu.hip.stream_create()?),
+                Some(gpu.hip.event_create()?),
+            )
+        } else {
+            (None, None)
+        };
+        let trunk_pbs = qwen35::PrefillBatchScratch::new(gpu, config, max_n + 1)?;
+        let trunk_gdn_tape = GdnTape::new_for_config(gpu, config, max_n + 1)?;
+        let mtp_scratch = Qwen35MtpHeadScratch::new(gpu, &head.config)?;
+        let mtp_kv = Qwen35MtpHeadKvCache::new_with_kv_mode(gpu, &head.config, kv_mode)?;
+        let mtp_t_outs = gpu.alloc_tensor(&[max_n * dim], DType::F32)?;
+        let mtp_lm_tmp = gpu.alloc_tensor(&[max_n * dim], DType::F32)?;
+        let mtp_lm_rot = gpu.alloc_tensor(&[max_n * dim], DType::F32)?;
+        let mtp_lm_logits = gpu.alloc_tensor(&[max_n * vocab], DType::F32)?;
+        let mtp_lm_argmax = gpu.alloc_tensor(&[max_n], DType::F32)?;
+        let mtp_token_chain = gpu.alloc_tensor(&[max_n + 1], DType::F32)?;
+        let mtp_token_embed = gpu.alloc_tensor(&[dim], DType::F32)?;
+        let mtp_positions = gpu.alloc_tensor(&[max_n], DType::F32)?;
+        let mtp_topk_idx = gpu.alloc_tensor(&[2], DType::F32)?;
+        let mtp_topk_logp = gpu.alloc_tensor(&[2], DType::F32)?;
+        let mtp_sample_result = gpu.alloc_tensor(&[2], DType::F32)?;
+        let mtp_sample_repeat_buf = gpu.alloc_tensor(&[1], DType::F32)?;
+        let mtp_gather_idx_draft = gpu.alloc_tensor(&[1], DType::F32)?;
+        let mtp_gather_prob_draft = gpu.alloc_tensor(&[1], DType::F32)?;
+        let mtp_gather_idx_verify = gpu.alloc_tensor(&[max_n], DType::F32)?;
+        let mtp_gather_prob_verify = gpu.alloc_tensor(&[max_n], DType::F32)?;
+
+        Ok(Self {
+            prev_hidden,
+            verify_hidden,
+            verify_logits,
+            verify_rot,
+            verify_argmax,
+            trunk_snap,
+            trunk_snap_stream,
+            trunk_snap_start_event,
+            trunk_pbs,
+            trunk_gdn_tape,
+            mtp_scratch,
+            mtp_kv,
+            mtp_t_outs,
+            mtp_lm_tmp,
+            mtp_lm_rot,
+            mtp_lm_logits,
+            mtp_lm_argmax,
+            mtp_token_chain,
+            mtp_token_embed,
+            mtp_positions,
+            mtp_proposal_graph: None,
+            mtp_proposal_graph_exec: None,
+            mtp_proposal_graph_blobs: Vec::new(),
+            mtp_proposal_graph_seq_cap: 0,
+            mtp_proposal_graph_warmed: false,
+            mtp_proposal_graph_disabled: false,
+            mtp_lm_logits_compressed: None,
+            mtp_topk_idx,
+            mtp_topk_logp,
+            mtp_sample_result,
+            mtp_sample_repeat_buf,
+            mtp_gather_idx_draft,
+            mtp_gather_prob_draft,
+            mtp_gather_idx_verify,
+            mtp_gather_prob_verify,
+            gpu_rng_state: 42,
+            max_n,
+            p_min: 0.0,
+            sampling: MtpSamplingConfig::default(),
+            rng: MtpRng::new(42),
+        })
+    }
+
     /// Configure sampling (temp/top_p/top_k/min_p) and reseed the per-state RNG.
     /// `cfg.temp == 0.0` keeps the legacy greedy path. `cfg.temp > 0` enables
     /// residual-acceptance sampling per the Unsloth/llama.cpp MTP recipe.
@@ -784,6 +891,195 @@ impl MtpSpecState {
     }
 }
 
+/// Multi-device backup for a PP `DeltaNetState`.
+///
+/// `DeltaNetSnapshot` is single-device and is correct only when every recurrent
+/// tensor lives on the same `Gpu`. The PP path allocates each LA layer on its
+/// owning band, so rollback needs buffers on those same devices.
+pub struct DeltaNetSnapshotMulti {
+    s_matrix_bufs: Vec<DeviceBuffer>,
+    s_scale_bufs: Vec<DeviceBuffer>,
+    conv_state_bufs: Vec<DeviceBuffer>,
+    la_to_device: Vec<u8>,
+}
+
+impl DeltaNetSnapshotMulti {
+    pub fn new_for(
+        gpus: &mut Gpus,
+        state: &qwen35::DeltaNetState,
+        la_to_device: &[u8],
+    ) -> HipResult<Self> {
+        assert_eq!(
+            state.s_matrices.len(),
+            la_to_device.len(),
+            "DeltaNetSnapshotMulti: la_to_device length mismatch",
+        );
+        let mut s_matrix_bufs = Vec::with_capacity(state.s_matrices.len());
+        let mut s_scale_bufs = Vec::with_capacity(state.s_scales.len());
+        let mut conv_state_bufs = Vec::with_capacity(state.conv_states.len());
+        for (i, t) in state.s_matrices.iter().enumerate() {
+            let g = &mut gpus.devices[la_to_device[i] as usize];
+            g.bind_thread()?;
+            s_matrix_bufs.push(g.hip.malloc(t.buf.size())?);
+        }
+        for (i, t) in state.s_scales.iter().enumerate() {
+            let g = &mut gpus.devices[la_to_device[i] as usize];
+            g.bind_thread()?;
+            s_scale_bufs.push(g.hip.malloc(t.buf.size())?);
+        }
+        for (i, t) in state.conv_states.iter().enumerate() {
+            let g = &mut gpus.devices[la_to_device[i] as usize];
+            g.bind_thread()?;
+            conv_state_bufs.push(g.hip.malloc(t.buf.size())?);
+        }
+        Ok(Self {
+            s_matrix_bufs,
+            s_scale_bufs,
+            conv_state_bufs,
+            la_to_device: la_to_device.to_vec(),
+        })
+    }
+
+    pub fn save_from(&mut self, gpus: &mut Gpus, state: &qwen35::DeltaNetState) -> HipResult<()> {
+        for (i, (dst, src)) in self.s_matrix_bufs.iter().zip(state.s_matrices.iter()).enumerate() {
+            let g = &mut gpus.devices[self.la_to_device[i] as usize];
+            g.bind_thread()?;
+            g.hip.memcpy_dtod(dst, &src.buf, src.buf.size())?;
+        }
+        for (i, (dst, src)) in self.s_scale_bufs.iter().zip(state.s_scales.iter()).enumerate() {
+            let g = &mut gpus.devices[self.la_to_device[i] as usize];
+            g.bind_thread()?;
+            g.hip.memcpy_dtod(dst, &src.buf, src.buf.size())?;
+        }
+        for (i, (dst, src)) in self.conv_state_bufs.iter().zip(state.conv_states.iter()).enumerate() {
+            let g = &mut gpus.devices[self.la_to_device[i] as usize];
+            g.bind_thread()?;
+            g.hip.memcpy_dtod(dst, &src.buf, src.buf.size())?;
+        }
+        Ok(())
+    }
+
+    pub fn restore_to(
+        &self,
+        gpus: &mut Gpus,
+        state: &mut qwen35::DeltaNetState,
+    ) -> HipResult<()> {
+        for (i, (src, dst)) in self.s_matrix_bufs.iter().zip(state.s_matrices.iter()).enumerate() {
+            let g = &mut gpus.devices[self.la_to_device[i] as usize];
+            g.bind_thread()?;
+            g.hip.memcpy_dtod(&dst.buf, src, src.size())?;
+        }
+        for (i, (src, dst)) in self.s_scale_bufs.iter().zip(state.s_scales.iter()).enumerate() {
+            let g = &mut gpus.devices[self.la_to_device[i] as usize];
+            g.bind_thread()?;
+            g.hip.memcpy_dtod(&dst.buf, src, src.size())?;
+        }
+        for (i, (src, dst)) in self.conv_state_bufs.iter().zip(state.conv_states.iter()).enumerate() {
+            let g = &mut gpus.devices[self.la_to_device[i] as usize];
+            g.bind_thread()?;
+            g.hip.memcpy_dtod(&dst.buf, src, src.size())?;
+        }
+        Ok(())
+    }
+
+    pub fn free_gpu(self, gpus: &mut Gpus) {
+        for (i, b) in self.s_matrix_bufs.into_iter().enumerate() {
+            let _ = gpus.devices[self.la_to_device[i] as usize].hip.free(b);
+        }
+        for (i, b) in self.s_scale_bufs.into_iter().enumerate() {
+            let _ = gpus.devices[self.la_to_device[i] as usize].hip.free(b);
+        }
+        for (i, b) in self.conv_state_bufs.into_iter().enumerate() {
+            let _ = gpus.devices[self.la_to_device[i] as usize].hip.free(b);
+        }
+    }
+}
+
+/// Drafter-side state for PP+MTP. Lives on the PP output device with a local
+/// clone of the trunk embedding table and its own MTP KV/scratch.
+pub struct MtpHeteroDrafterState {
+    pub mirrored_token_embd: GpuTensor,
+    pub embd_format: EmbeddingFormat,
+    pub prev_hidden: GpuTensor,
+    pub mtp_scratch: Qwen35MtpHeadScratch,
+    pub mtp_kv: Qwen35MtpHeadKvCache,
+    pub mtp_t_outs: GpuTensor,
+    pub mtp_lm_argmax: GpuTensor,
+    pub mtp_token_chain: GpuTensor,
+    pub mtp_token_embed: GpuTensor,
+    pub trunk_snap: DeltaNetSnapshotMulti,
+    pub max_n: usize,
+}
+
+impl MtpHeteroDrafterState {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_for_pp(
+        gpus: &mut Gpus,
+        output_device: usize,
+        target_dn: &qwen35::DeltaNetState,
+        la_to_device: &[u8],
+        head: &Qwen35MtpHead,
+        max_n: usize,
+        kv_mode: crate::mtp_head::MtpKvMode,
+        mirrored_token_embd: GpuTensor,
+        embd_format: EmbeddingFormat,
+    ) -> HipResult<Self> {
+        assert!(max_n >= 1, "MtpHeteroDrafterState: max_n must be >= 1");
+        let n_embd = head.config.n_embd;
+        let trunk_snap = DeltaNetSnapshotMulti::new_for(gpus, target_dn, la_to_device)?;
+        let g = &mut gpus.devices[output_device];
+        g.bind_thread()?;
+        let prev_hidden = g.alloc_tensor(&[n_embd], DType::F32)?;
+        let mut mtp_scratch = Qwen35MtpHeadScratch::new(g, &head.config)?;
+        if let Some(cvs) = head.weights.compressed_vocab_size {
+            mtp_scratch.ensure_compressed_logits(g, cvs)?;
+        }
+        let mtp_kv = Qwen35MtpHeadKvCache::new_with_kv_mode(g, &head.config, kv_mode)?;
+        let mtp_t_outs = g.alloc_tensor(&[max_n * n_embd], DType::F32)?;
+        let mtp_lm_argmax = g.alloc_tensor(&[max_n], DType::F32)?;
+        let mtp_token_chain = g.alloc_tensor(&[max_n + 1], DType::F32)?;
+        let mtp_token_embed = g.alloc_tensor(&[n_embd], DType::F32)?;
+        Ok(Self {
+            mirrored_token_embd,
+            embd_format,
+            prev_hidden,
+            mtp_scratch,
+            mtp_kv,
+            mtp_t_outs,
+            mtp_lm_argmax,
+            mtp_token_chain,
+            mtp_token_embed,
+            trunk_snap,
+            max_n,
+        })
+    }
+
+    pub fn free_gpu(self, gpus: &mut Gpus, output_device: usize) {
+        let Self {
+            mirrored_token_embd,
+            prev_hidden,
+            mtp_scratch,
+            mtp_kv,
+            mtp_t_outs,
+            mtp_lm_argmax,
+            mtp_token_chain,
+            mtp_token_embed,
+            trunk_snap,
+            ..
+        } = self;
+        trunk_snap.free_gpu(gpus);
+        let g = &mut gpus.devices[output_device];
+        let _ = g.free_tensor(mirrored_token_embd);
+        let _ = g.free_tensor(prev_hidden);
+        mtp_scratch.free_gpu(g);
+        mtp_kv.inner.free_gpu(g);
+        let _ = g.free_tensor(mtp_t_outs);
+        let _ = g.free_tensor(mtp_lm_argmax);
+        let _ = g.free_tensor(mtp_token_chain);
+        let _ = g.free_tensor(mtp_token_embed);
+    }
+}
+
 // ─── One spec-decode cycle ───────────────────────────────────────────────
 
 /// Result of one MTP spec-decode cycle.
@@ -844,6 +1140,23 @@ fn embed_device_token_into(
             gpu.embedding_lookup_q8_batched(&weights.token_embd, out, token_id, 1, dim)
         }
         other => panic!("device-token MTP chain does not support embedding format {other:?}"),
+    }
+}
+
+fn embed_device_token_into_drafter(
+    gpu: &mut Gpu,
+    token_embd: &GpuTensor,
+    embd_format: EmbeddingFormat,
+    out: &GpuTensor,
+    token_id: &GpuTensor,
+    dim: usize,
+) -> HipResult<()> {
+    match embd_format {
+        EmbeddingFormat::HFQ4G256 => {
+            gpu.embedding_lookup_hfq4g256_batched(token_embd, out, token_id, 1, dim)
+        }
+        EmbeddingFormat::Q8_0 => gpu.embedding_lookup_q8_batched(token_embd, out, token_id, 1, dim),
+        other => panic!("PP+MTP device-token chain does not support embedding format {other:?}"),
     }
 }
 
@@ -2991,6 +3304,369 @@ pub fn spec_step_mtp_compressed_serial(
         advance,
         drafts_generated,
         chain_truncated,
+        replay_skipped,
+    })
+}
+
+/// One greedy compressed-MTP cycle for a pipeline-parallel Qwen3.5/Qwen3.6
+/// trunk. The MTP head and drafter state live on `output_device`; verify runs
+/// through `forward_prefill_batch_multi_with_caps`.
+#[allow(clippy::too_many_arguments)]
+pub fn spec_step_mtp_compressed_serial_multi(
+    gpus: &mut Gpus,
+    output_device: usize,
+    target_config: &qwen35::Qwen35Config,
+    trunk_weights: &Qwen35Weights,
+    target_kv: &mut hipfire_runtime::llama::KvCache,
+    target_dn: &mut qwen35::DeltaNetState,
+    pp_scratch_set: &qwen35::Qwen35ScratchSet,
+    head: &Qwen35MtpHead,
+    state: &mut MtpSpecState,
+    drafter_state: &mut MtpHeteroDrafterState,
+    cur_pos: usize,
+    last_committed: u32,
+    eos_token_id: u32,
+) -> HipResult<MtpSpecResult> {
+    let max_n = drafter_state.max_n;
+    assert_eq!(max_n, state.max_n, "PP+MTP state max_n mismatch");
+    assert!(
+        state.sampling.is_greedy(),
+        "PP+MTP v1 is greedy-only; temp={}",
+        state.sampling.temp,
+    );
+    assert!(
+        state.p_min <= 0.0,
+        "PP+MTP v1 does not implement p_min; got {}",
+        state.p_min,
+    );
+    let cvs = head
+        .weights
+        .compressed_vocab_size
+        .expect("PP+MTP requires compressed MTP sidecar");
+    assert!(
+        head.weights.lm_head_draft.is_some()
+            && head.weights.lm_head_draft_vocab_map_gpu.is_some(),
+        "PP+MTP requires compressed lm_head_draft and GPU vocab map",
+    );
+    let dim = target_config.dim;
+    let vocab = target_config.vocab_size;
+    let dim_bytes = dim * 4;
+
+    // 1. Draft K candidates on output_device using an on-device token chain.
+    let mut candidates: Vec<u32> = Vec::with_capacity(max_n);
+    {
+        let drafter_gpu = &mut gpus.devices[output_device];
+        drafter_gpu.bind_thread()?;
+        let seed_token = last_committed as i32;
+        let seed_bytes: &[u8] =
+            unsafe { std::slice::from_raw_parts(&seed_token as *const i32 as *const u8, 4) };
+        drafter_gpu
+            .hip
+            .memcpy_htod(&drafter_state.mtp_token_chain.buf, seed_bytes)?;
+
+        let argmax_view = drafter_state.mtp_lm_argmax.sub_offset(0, 1);
+        let logits_c = drafter_state
+            .mtp_scratch
+            .logits_compressed
+            .as_ref()
+            .expect("drafter compressed logits not allocated");
+        let vocab_map_gpu = head
+            .weights
+            .lm_head_draft_vocab_map_gpu
+            .as_ref()
+            .expect("PP+MTP requires GPU vocab map");
+
+        for k in 0..max_n {
+            let token_slot = drafter_state.mtp_token_chain.sub_offset(k, 1);
+            embed_device_token_into_drafter(
+                drafter_gpu,
+                &drafter_state.mirrored_token_embd,
+                drafter_state.embd_format,
+                &drafter_state.mtp_token_embed,
+                &token_slot,
+                dim,
+            )?;
+
+            if k == 0 {
+                mtp_head::mtp_head_forward_block_only(
+                    drafter_gpu,
+                    head,
+                    &drafter_state.mtp_scratch,
+                    &mut drafter_state.mtp_kv,
+                    0,
+                    &drafter_state.prev_hidden,
+                    Some(&drafter_state.mtp_token_embed),
+                    cur_pos + k,
+                    trunk_weights,
+                )?;
+            } else {
+                let prev_row = drafter_state.mtp_t_outs.sub_offset((k - 1) * dim, dim);
+                mtp_head::mtp_head_forward_block_only(
+                    drafter_gpu,
+                    head,
+                    &drafter_state.mtp_scratch,
+                    &mut drafter_state.mtp_kv,
+                    0,
+                    &prev_row,
+                    Some(&drafter_state.mtp_token_embed),
+                    cur_pos + k,
+                    trunk_weights,
+                )?;
+            }
+            mtp_head::mtp_head_apply_lm_head_draft(
+                drafter_gpu,
+                head,
+                &drafter_state.mtp_scratch,
+            )?;
+            drafter_gpu.argmax_token_chain_f32(
+                logits_c,
+                &argmax_view,
+                &drafter_state.mtp_token_chain,
+                Some(vocab_map_gpu),
+                cvs,
+                k + 1,
+            )?;
+            if k + 1 < max_n {
+                drafter_gpu.memcpy_dtod_at_auto(
+                    &drafter_state.mtp_t_outs.buf,
+                    k * dim_bytes,
+                    &drafter_state.mtp_scratch.t_mtp_out.buf,
+                    0,
+                    dim_bytes,
+                )?;
+            }
+        }
+
+        let candidate_view = drafter_state.mtp_token_chain.sub_offset(1, max_n);
+        let mut candidate_host: Vec<i32> = vec![0; max_n];
+        let bytes: &mut [u8] = unsafe {
+            std::slice::from_raw_parts_mut(candidate_host.as_mut_ptr() as *mut u8, max_n * 4)
+        };
+        drafter_gpu.hip.memcpy_dtoh(bytes, &candidate_view.buf)?;
+        candidates.extend(candidate_host.into_iter().map(|t| t as u32));
+    }
+
+    // 2. Snapshot recurrent state, then verify the trunk through all PP bands.
+    let verify_tokens = build_trunk_spine_verify_tokens(last_committed, &candidates);
+    let n_verify = verify_tokens.len();
+    drafter_state.trunk_snap.save_from(gpus, target_dn)?;
+    qwen35::forward_prefill_batch_multi_with_caps(
+        gpus,
+        trunk_weights,
+        target_config,
+        &verify_tokens,
+        cur_pos,
+        target_kv,
+        target_dn,
+        pp_scratch_set,
+        Some(&state.verify_hidden),
+        None,
+        false,
+    )?;
+
+    // 3. Trunk lm_head + greedy accept on output_device.
+    let committed: Vec<u32>;
+    let accept_count: usize;
+    let hit_eos: bool;
+    {
+        let target_gpu = &mut gpus.devices[output_device];
+        target_gpu.bind_thread()?;
+        let w_out = &trunk_weights.output;
+        let logits_view = state.verify_logits.sub_offset(0, n_verify * vocab);
+        match w_out.gpu_dtype {
+            DType::Q8_0 => {
+                if mtp_q8_verify_wmma_enabled_from_env() {
+                    target_gpu.gemm_q8_0_batched_chunked(
+                        &w_out.buf,
+                        &state.verify_hidden,
+                        &logits_view,
+                        w_out.m,
+                        w_out.k,
+                        n_verify,
+                    )?;
+                } else {
+                    target_gpu.gemm_q8_0_batched(
+                        &w_out.buf,
+                        &state.verify_hidden,
+                        &logits_view,
+                        w_out.m,
+                        w_out.k,
+                        n_verify,
+                    )?;
+                }
+            }
+            DType::HFQ4G256 => target_gpu.gemm_hfq4g256_batched_lmhead(
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
+            )?,
+            DType::MQ4G256 => {
+                let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
+                llama::rotate_x_mq_batched_for(
+                    target_gpu,
+                    w_out,
+                    &state.verify_hidden,
+                    &rot,
+                    w_out.k,
+                    n_verify,
+                )?;
+                target_gpu.gemm_hfq4g256_batched_lmhead(
+                    &w_out.buf,
+                    &rot,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            }
+            DType::MQ3G256 => {
+                let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
+                llama::rotate_x_mq_batched_for(
+                    target_gpu,
+                    w_out,
+                    &state.verify_hidden,
+                    &rot,
+                    w_out.k,
+                    n_verify,
+                )?;
+                target_gpu.gemm_hfq3g256_batched_lmhead(
+                    &w_out.buf,
+                    &rot,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            }
+            DType::HFQ6G256 => target_gpu.gemm_hfq6g256_batched_lmhead(
+                &w_out.buf,
+                &state.verify_hidden,
+                &logits_view,
+                w_out.m,
+                w_out.k,
+                n_verify,
+            )?,
+            DType::MQ6G256 => {
+                let rot = state.verify_rot.sub_offset(0, n_verify * w_out.k);
+                llama::rotate_x_mq_batched_for(
+                    target_gpu,
+                    w_out,
+                    &state.verify_hidden,
+                    &rot,
+                    w_out.k,
+                    n_verify,
+                )?;
+                target_gpu.gemm_hfq6g256_batched_lmhead(
+                    &w_out.buf,
+                    &rot,
+                    &logits_view,
+                    w_out.m,
+                    w_out.k,
+                    n_verify,
+                )?;
+            }
+            _ => {
+                for i in 0..n_verify {
+                    let row = state.verify_hidden.sub_offset(i * dim, dim);
+                    let logits_row = state.verify_logits.sub_offset(i * vocab, vocab);
+                    llama::weight_gemv(target_gpu, w_out, &row, &logits_row)?;
+                }
+            }
+        }
+
+        let argmax_v = state.verify_argmax.sub_offset(0, n_verify);
+        target_gpu.argmax_f32_batched(&logits_view, &argmax_v, vocab, n_verify)?;
+        let candidate_device = drafter_state.mtp_token_chain.sub_offset(1, max_n);
+        let accept_result = state.verify_argmax.sub_offset(0, 2);
+        target_gpu.greedy_accept_from_argmax_i32(
+            &argmax_v,
+            &candidate_device,
+            &accept_result,
+            max_n,
+            eos_token_id,
+        )?;
+        let mut accept_host: [i32; 2] = [0, 0];
+        let bytes: &mut [u8] =
+            unsafe { std::slice::from_raw_parts_mut(accept_host.as_mut_ptr() as *mut u8, 8) };
+        target_gpu.hip.memcpy_dtoh(bytes, &accept_result.buf)?;
+        let accepted = assemble_greedy_accept_from_gpu_result(
+            &candidates,
+            accept_host[0] as usize,
+            accept_host[1],
+            eos_token_id,
+        );
+        committed = accepted.committed;
+        accept_count = accepted.accept_count;
+        hit_eos = accepted.hit_eos;
+    }
+
+    let advance = committed.len();
+    debug_assert!(advance >= 1 && advance <= max_n + 1);
+
+    // 4. Refresh next-cycle prev_hidden on both the PP+MTP drafter and the
+    // generic MTP state for diagnostics / consistency.
+    let prev_hidden_row = advance - 1;
+    let src_row_offset = prev_hidden_row * dim_bytes;
+    {
+        let g = &mut gpus.devices[output_device];
+        g.hip.memcpy_dtod_at(
+            &drafter_state.prev_hidden.buf,
+            0,
+            &state.verify_hidden.buf,
+            src_row_offset,
+            dim_bytes,
+        )?;
+        g.hip.memcpy_dtod_at(
+            &state.prev_hidden.buf,
+            0,
+            &state.verify_hidden.buf,
+            src_row_offset,
+            dim_bytes,
+        )?;
+    }
+
+    // 5. If verify overran past the committed prefix, restore multi-device DN
+    // state and replay only committed tokens. KV rows beyond the committed prefix
+    // will be overwritten by later forwards at their actual positions.
+    let full_accept_no_eos = advance == max_n + 1 && !hit_eos;
+    let replay_skipped = full_accept_no_eos;
+    if !full_accept_no_eos {
+        drafter_state.trunk_snap.restore_to(gpus, target_dn)?;
+        if advance >= 2 {
+            qwen35::forward_prefill_batch_multi(
+                gpus,
+                trunk_weights,
+                target_config,
+                &verify_tokens[..advance],
+                cur_pos,
+                target_kv,
+                target_dn,
+                pp_scratch_set,
+            )?;
+        } else {
+            qwen35::forward_scratch_multi(
+                gpus,
+                trunk_weights,
+                target_config,
+                verify_tokens[0],
+                cur_pos,
+                target_kv,
+                target_dn,
+                pp_scratch_set,
+            )?;
+        }
+    }
+
+    Ok(MtpSpecResult {
+        committed,
+        accept_count,
+        hit_eos,
+        advance,
+        drafts_generated: max_n,
+        chain_truncated: false,
         replay_skipped,
     })
 }

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -14815,9 +14815,9 @@ pub fn forward_scratch_multi(
 ///      `x_batch`) and `is_last_band=true` (does final norm + lm_head).
 ///   5. Repeat for any further bands.
 ///
-/// `tree_verify`, DFlash hidden-rb, GdnTape, and per_token_hidden_out
-/// are pp=1 only in v1. They've been refused at the daemon load-time
-/// gate, so this function does not accept them as parameters.
+/// Default PP prefill surface. Capability-bearing callers such as PP+MTP use
+/// [`forward_prefill_batch_multi_with_caps`] so the output band can capture the
+/// post-output-norm hidden rows without perturbing the AR path.
 #[allow(clippy::too_many_arguments)]
 pub fn forward_prefill_batch_multi(
     gpus: &mut Gpus,
@@ -14829,9 +14829,49 @@ pub fn forward_prefill_batch_multi(
     dn_state: &mut DeltaNetState,
     scratch_set: &Qwen35ScratchSet,
 ) -> HipResult<()> {
+    forward_prefill_batch_multi_with_caps(
+        gpus,
+        weights,
+        config,
+        tokens,
+        start_pos,
+        kv_cache,
+        dn_state,
+        scratch_set,
+        None,
+        None,
+        true,
+    )
+}
+
+/// PP prefill with the narrow capability hooks needed by PP+MTP verify.
+///
+/// `per_token_hidden_out`, when present, must live on the output band. The
+/// final band writes rows at `chunk_start..chunk_start+chunk_n`; earlier bands
+/// keep passing only residual streams across the PP boundary.
+#[allow(clippy::too_many_arguments)]
+pub fn forward_prefill_batch_multi_with_caps(
+    gpus: &mut Gpus,
+    weights: &Qwen35Weights,
+    config: &Qwen35Config,
+    tokens: &[u32],
+    start_pos: usize,
+    kv_cache: &mut llama::KvCache,
+    dn_state: &mut DeltaNetState,
+    scratch_set: &Qwen35ScratchSet,
+    per_token_hidden_out: Option<&GpuTensor>,
+    tree_verify: Option<TreeVerifyCtx<'_>>,
+    needs_last_token_logits: bool,
+) -> HipResult<()> {
     let n_total = tokens.len();
     if n_total == 0 {
         return Ok(());
+    }
+    if tree_verify.is_some() {
+        return Err(hip_bridge::HipError::new(
+            0,
+            "forward_prefill_batch_multi_with_caps: tree_verify under PP is not implemented",
+        ));
     }
 
     let n_bands = gpus.devices.len();
@@ -14903,6 +14943,13 @@ pub fn forward_prefill_batch_multi(
         });
 
     if !eligible {
+        if per_token_hidden_out.is_some() || !needs_last_token_logits {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "forward_prefill_batch_multi_with_caps: requested hidden capture/logit elision \
+                 but this model is not eligible for the batched PP path",
+            ));
+        }
         // Per-token fallback. Correctness over speed when the batched
         // path's preconditions are not met.
         for (i, &tok) in tokens.iter().enumerate() {
@@ -15012,6 +15059,11 @@ pub fn forward_prefill_batch_multi(
                     let pbs_b: &PrefillBatchScratch = &pbs_per_band[b];
                     let s_b = &scratch_set.per_device[b];
                     let g_b = &mut gpus.devices[b];
+                    let hidden_out = if b + 1 == n_bands {
+                        per_token_hidden_out.map(|t| (t, chunk_start))
+                    } else {
+                        None
+                    };
                     forward_prefill_chunk(
                         g_b,
                         weights,
@@ -15023,14 +15075,14 @@ pub fn forward_prefill_batch_multi(
                         s_b,
                         pbs_b,
                         None, // hidden_rb: pp=1 only
-                        None, // per_token_hidden_out: pp=1 only
+                        hidden_out,
                         None, // gdn_tape: pp=1 only
                         0,
                         None,  // tree_verify: pp=1 only
                         false, // pre_uploaded
                         Some(&band_ctx),
                         None, // mask_override: multi-GPU PP path doesn't use the MTP probe hook
-                        true, // needs_last_token_logits: preserve multi-GPU post-condition
+                        needs_last_token_logits || b + 1 < n_bands,
                         None, // max_layer: multi-GPU PP path runs full stack
                         None, // routed_out: PP bands are multi-layer, not EP
                     )?;

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -29,6 +29,8 @@ use hipfire_arch_minimax as minimax;
 use hipfire_arch_dots_ocr::dots_ocr;
 use hipfire_arch_llama::Llama;
 use hipfire_arch_qwen2::qwen2;
+use hipfire_arch_qwen35::mtp_head::{self, MtpKvMode, Qwen35MtpHead};
+use hipfire_arch_qwen35::mtp_spec::{MtpHeteroDrafterState, MtpSpecState};
 use hipfire_arch_qwen35::qwen35;
 use hipfire_arch_qwen35::qwen35::{DeltaNetState, LayerType, Qwen35ScratchSet};
 use hipfire_arch_qwen35::speculative::{
@@ -1057,6 +1059,18 @@ struct DflashState {
     ddtree: Option<DdtreeState>,
 }
 
+/// Optional Qwen3.5/Qwen3.6 MTP speculative-decoding state.
+///
+/// The daemon currently wires the PP+MTP path; single-GPU qwen MTP remains
+/// exercised through `mtp_only_demo`.
+struct MtpState {
+    head: Qwen35MtpHead,
+    spec_state: MtpSpecState,
+    max_n: usize,
+    compressed: bool,
+    drafter_state: Option<MtpHeteroDrafterState>,
+}
+
 /// Side state for DDTree-mode speculative decoding. Allocated alongside
 /// the rest of `DflashState` at model-load time when DDTree is enabled,
 /// reused across all decode cycles.
@@ -1301,6 +1315,8 @@ struct LoadedModel {
     model_path: String,
     // DFlash speculative decoding state (populated when load supplied a draft).
     dflash: Option<DflashState>,
+    // Qwen MTP speculative decoding state. Populated for PP+MTP loads.
+    mtp: Option<MtpState>,
     // Upstream HF Jinja chat_template, extracted from the HFQ
     // `tokenizer_config.chat_template` at load time. `None` when the source
     // model didn't ship one (rare for instruct models). Only consumed when
@@ -1645,6 +1661,25 @@ fn main() {
                     .and_then(|p| p.get("mtp_k"))
                     .and_then(|v| v.as_u64())
                     .unwrap_or(3) as usize;
+                let raw_mtp_head = msg
+                    .get("params")
+                    .and_then(|p| p.get("mtp_head"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string());
+                let mtp_head_path = if mtp_mode == "off" {
+                    if let Some(path) = raw_mtp_head.as_deref() {
+                        eprintln!("[hipfire-daemon] mtp_mode=off — skipping MTP head load ({path})");
+                    }
+                    None
+                } else {
+                    raw_mtp_head
+                };
+                let mtp_kv_mode_str = msg
+                    .get("params")
+                    .and_then(|p| p.get("mtp_kv_mode"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("q8");
 
                 // 0.1.7-alpha: DFlash tuning knobs forwarded from the CLI.
                 // `adaptive_b` matches dflash_spec_demo's --adaptive-b default.
@@ -1719,6 +1754,22 @@ fn main() {
                     core_frac: cask_core_frac,
                     fold_m: cask_fold_m,
                 };
+                if mtp_head_path.is_some() && draft_path.is_some() {
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"error","message":"MTP head and DFlash draft are mutually exclusive speculative decode paths. Remove one and retry."}}"#
+                    );
+                    let _ = stdout.flush();
+                    continue;
+                }
+                if mtp_head_path.is_some() && cask_enabled {
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"error","message":"MTP head and CASK/eviction are not compatible yet; disable one and retry."}}"#
+                    );
+                    let _ = stdout.flush();
+                    continue;
+                }
 
                 // MMQ per-weight screening (#87): detect outlier rows that
                 // cause Q8_1 precision loss and fall back to WMMA for those
@@ -1911,6 +1962,9 @@ fn main() {
                         state_quant_override.as_deref(),
                         &cask,
                         pp,
+                        mtp_head_path.as_deref(),
+                        mtp_k,
+                        mtp_kv_mode_str,
                         &mut gpu,
                     )
                 };
@@ -3301,6 +3355,9 @@ fn load_model(
     state_quant_override: Option<&str>,
     cask: &CaskConfig,
     pp: usize,
+    mtp_head_path: Option<&str>,
+    mtp_k: usize,
+    mtp_kv_mode_str: &str,
     gpu: &mut rdna_compute::Gpu,
 ) -> Result<LoadedModel, String> {
     if pp > 1 {
@@ -3317,7 +3374,16 @@ fn load_model(
             kv_mode_override,
             state_quant_override,
             pp,
+            mtp_head_path,
+            mtp_k,
+            mtp_kv_mode_str,
             gpu,
+        );
+    }
+    if mtp_head_path.is_some() {
+        return Err(
+            "daemon qwen MTP is currently wired for pp>1 only; use mtp_only_demo for single-GPU MTP"
+                .to_string(),
         );
     }
     // Per-load kv_mode (sent in load message params) overrides the env var.
@@ -3560,6 +3626,7 @@ fn load_model(
             decoded_vocab: None,
             model_path: path.to_string(),
             dflash: None,
+            mtp: None,
             chat_template,
         });
     }
@@ -3645,6 +3712,7 @@ fn load_model(
             decoded_vocab: None,
             model_path: path.to_string(),
             dflash: None,
+            mtp: None,
             chat_template,
         });
     }
@@ -3751,6 +3819,7 @@ fn load_model(
             decoded_vocab: None,
             model_path: path.to_string(),
             dflash: None,
+            mtp: None,
             chat_template,
         });
     }
@@ -3850,6 +3919,7 @@ fn load_model(
             decoded_vocab: None,
             model_path: path.to_string(),
             dflash: None,
+            mtp: None,
             chat_template,
         });
     }
@@ -3964,6 +4034,7 @@ fn load_model(
             decoded_vocab: None,
             model_path: path.to_string(),
             dflash: None,
+            mtp: None,
             chat_template,
         });
     }
@@ -4424,6 +4495,7 @@ fn load_model(
             decoded_vocab: None,
             model_path: path.to_string(),
             dflash,
+            mtp: None,
             chat_template,
         })
     } else {
@@ -4499,6 +4571,7 @@ fn load_model(
             decoded_vocab: None,
             model_path: path.to_string(),
             dflash: None,
+            mtp: None,
             chat_template,
         })
     }
@@ -4660,6 +4733,7 @@ fn load_model_safetensors(
             decoded_vocab: None,
             model_path: path.to_string(),
             dflash: None,
+            mtp: None,
             chat_template,
         });
     }
@@ -4803,6 +4877,7 @@ fn load_model_safetensors(
         decoded_vocab: None,
         model_path: path.to_string(),
         dflash: None,
+        mtp: None,
         chat_template,
     })
 }
@@ -4820,6 +4895,9 @@ fn load_model_pp(
     kv_mode_override: Option<&str>,
     state_quant_override: Option<&str>,
     pp: usize,
+    mtp_head_path: Option<&str>,
+    mtp_k: usize,
+    mtp_kv_mode_str: &str,
     _gpu: &mut rdna_compute::Gpu,
 ) -> Result<LoadedModel, String> {
     let kv_mode = kv_mode_override
@@ -4988,6 +5066,110 @@ fn load_model_pp(
         .enable_peer_all()
         .map_err(|e| format!("enable_peer_all: {e}"))?;
 
+    let mut mtp: Option<MtpState> = None;
+    let want_bundled_mtp = mtp_head_path.is_none()
+        && mtp_head::detect_bundled_mtp_offset(Path::new(path))
+            .map_err(|e| format!("detect bundled MTP: {e}"))?
+            .is_some();
+    if mtp_head_path.is_some() || want_bundled_mtp {
+        let output_device = gpus.output_device;
+        let kv_mode = MtpKvMode::parse(mtp_kv_mode_str)?;
+        let head = {
+            let dev = &mut gpus.devices[output_device];
+            dev.bind_thread().map_err(|e| format!("{e}"))?;
+            if let Some(mp) = mtp_head_path {
+                mtp_head::load_mtp_head(Path::new(mp), dev, max_seq).map_err(|e| format!("{e}"))?
+            } else {
+                mtp_head::load_mtp_head_bundled(Path::new(path), dev, max_seq)
+                    .map_err(|e| format!("{e}"))?
+                    .ok_or_else(|| "bundled MTP trailer disappeared during load".to_string())?
+            }
+        };
+        if head.config.n_embd != config.dim {
+            return Err(format!(
+                "MTP head n_embd={} != trunk dim={}",
+                head.config.n_embd, config.dim
+            ));
+        }
+        if head.config.vocab_size != config.vocab_size {
+            return Err(format!(
+                "MTP head vocab_size={} != trunk vocab={}",
+                head.config.vocab_size, config.vocab_size
+            ));
+        }
+        if (head.config.rope_theta - config.rope_theta).abs() > 1e-3 {
+            return Err(format!(
+                "MTP head rope_theta={} != trunk rope_theta={}",
+                head.config.rope_theta, config.rope_theta
+            ));
+        }
+        let cvs = head
+            .weights
+            .compressed_vocab_size
+            .ok_or_else(|| "PP+MTP requires compressed-sidecar .mtp".to_string())?;
+        if head.weights.lm_head_draft.is_none() || head.weights.lm_head_draft_vocab_map_gpu.is_none()
+        {
+            return Err("PP+MTP requires lm_head_draft and GPU vocab map".to_string());
+        }
+        let mut spec_state = {
+            let dev = &mut gpus.devices[output_device];
+            MtpSpecState::new_for_config_with_kv_mode(
+                dev,
+                &config,
+                &dn,
+                &head,
+                mtp_k.max(1),
+                kv_mode,
+            )
+            .map_err(|e| format!("{e}"))?
+        };
+        {
+            let dev = &mut gpus.devices[output_device];
+            spec_state
+                .ensure_compressed_lm_logits(dev, cvs)
+                .map_err(|e| format!("{e}"))?;
+        }
+        let mirrored_token_embd = if output_device == 0 {
+            let dev = &mut gpus.devices[0];
+            hipfire_runtime::mtp_mirror::clone_tensor_same(dev, &weights.token_embd)
+                .map_err(|e| format!("clone token_embd: {e}"))?
+        } else {
+            let (left, right) = gpus.devices.split_at_mut(output_device);
+            let src = &left[0];
+            let dst = &mut right[0];
+            hipfire_runtime::mtp_mirror::clone_tensor_peer(src, dst, &weights.token_embd)
+                .map_err(|e| format!("peer clone token_embd: {e}"))?
+        };
+        let drafter_state = MtpHeteroDrafterState::new_for_pp(
+            &mut gpus,
+            output_device,
+            &dn,
+            &la_to_device,
+            &head,
+            mtp_k.max(1),
+            kv_mode,
+            mirrored_token_embd,
+            weights.embd_format,
+        )
+        .map_err(|e| format!("{e}"))?;
+        eprintln!(
+            "  MTP head loaded on output_device={} (n_embd={}, vocab={}, cvs={}, k={}, kv={:?})",
+            output_device,
+            head.config.n_embd,
+            head.config.vocab_size,
+            cvs,
+            mtp_k.max(1),
+            kv_mode,
+        );
+        mtp = Some(MtpState {
+            head,
+            spec_state,
+            max_n: mtp_k.max(1),
+            compressed: true,
+            drafter_state: Some(drafter_state),
+        });
+    }
+
     eprintln!(
         "  pp={pp} loaded: layer_to_device={:?}, output_device={}, peer_access={}",
         gpus.layer_to_device, gpus.output_device, gpus.peer_access_enabled,
@@ -5045,6 +5227,7 @@ fn load_model_pp(
         decoded_vocab: None,
         model_path: path.to_string(),
         dflash: None,
+        mtp,
         chat_template: resolve_chat_template(&hfq, path),
     })
 }
@@ -5235,6 +5418,7 @@ fn load_model_ep(path: &str, max_seq: usize, tp: usize) -> Result<LoadedModel, S
         decoded_vocab: None,
         model_path: path.to_string(),
         dflash: None,
+        mtp: None,
         chat_template,
     })
 }
@@ -5357,6 +5541,7 @@ fn load_model_ep_minimax(path: &str, max_seq: usize, tp: usize) -> Result<Loaded
         decoded_vocab: None,
         model_path: path.to_string(),
         dflash: None,
+        mtp: None,
         chat_template,
     })
 }
@@ -5828,6 +6013,15 @@ fn unload_model(m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
     // weights, so each free targets a still-live owner.
     if m.pp > 1 {
         let mut gpus = m.pp_gpus.expect("pp>1 must carry pp_gpus");
+        let output_device = gpus.output_device;
+        if let Some(mut mtp) = m.mtp {
+            if let Some(drafter_state) = mtp.drafter_state.take() {
+                drafter_state.free_gpu(&mut gpus, output_device);
+            }
+            let g = &mut gpus.devices[output_device];
+            mtp.spec_state.free_gpu(g);
+            mtp.head.free_gpu(g);
+        }
         if let Some(scratch_set) = m.pp_scratch_set {
             scratch_set.free_gpu_multi(&mut gpus);
         }
@@ -8438,6 +8632,506 @@ fn generate_multi(
 }
 
 #[allow(clippy::too_many_arguments)]
+fn generate_pp_mtp(
+    m: &mut LoadedModel,
+    gpu: &mut rdna_compute::Gpu,
+    stdout: &mut std::io::Stdout,
+    id: &str,
+    prompt: &str,
+    system_prompt: Option<&str>,
+    max_tokens: usize,
+    max_think_tokens: usize,
+    assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix,
+    tools: Option<&[serde_json::Value]>,
+    messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>,
+    stop: &[String],
+) {
+    let tokenizer = m.tokenizer.take().expect("loaded model tokenizer");
+    let chat_template = m.chat_template.clone();
+    let raw_q_tokens = tokenizer.encode(prompt);
+    let prompt_est = raw_q_tokens.len() + 20;
+
+    macro_rules! reset_pp_recurrent {
+        () => {{
+            m.seq_pos = 0;
+            m.conversation_tokens.clear();
+            free_checkpoints(&mut m.prefill_checkpoints, gpu);
+            free_checkpoints(&mut m.dflash_checkpoints, gpu);
+            if let (Some(ref dn), Some(ref mut gpus), Some(ref la)) = (
+                m.dn_state.as_ref(),
+                m.pp_gpus.as_mut(),
+                m.pp_dn_la_to_device.as_ref(),
+            ) {
+                for (i, s) in dn.s_matrices.iter().enumerate() {
+                    let g = &mut gpus.devices[la[i] as usize];
+                    let _ = g.bind_thread();
+                    let _ = g.hip.memset(&s.buf, 0, s.buf.size());
+                }
+                for (i, s) in dn.s_scales.iter().enumerate() {
+                    let g = &mut gpus.devices[la[i] as usize];
+                    let _ = g.bind_thread();
+                    let _ = g.hip.memset(&s.buf, 0, s.buf.size());
+                }
+                for (i, s) in dn.conv_states.iter().enumerate() {
+                    let g = &mut gpus.devices[la[i] as usize];
+                    let _ = g.bind_thread();
+                    let _ = g.hip.memset(&s.buf, 0, s.buf.size());
+                }
+            }
+            if let Some(kv) = m.kv_cache.as_mut() {
+                kv.compact_offset = 0;
+            }
+            if let (Some(mtp), Some(gpus)) = (m.mtp.as_mut(), m.pp_gpus.as_mut()) {
+                let out = gpus.output_device;
+                let g = &mut gpus.devices[out];
+                let _ = mtp.spec_state.mtp_kv.reset(g);
+                if let Some(ds) = mtp.drafter_state.as_mut() {
+                    let _ = ds.mtp_kv.reset(g);
+                }
+            }
+        }};
+    }
+
+    if m.seq_pos + prompt_est + max_tokens > m.max_seq {
+        eprintln!(
+            "[daemon] pp-mtp context full ({}/{}) — resetting conversation",
+            m.seq_pos, m.max_seq
+        );
+        reset_pp_recurrent!();
+    }
+
+    let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
+    let try_jinja = jinja_enabled && chat_template.is_some();
+    let new_tokens = if try_jinja {
+        let template = chat_template.as_ref().unwrap();
+        let frame = hipfire_runtime::prompt_frame::JinjaChatFrame {
+            tokenizer: &tokenizer,
+            template,
+            system: system_prompt,
+            user: prompt,
+            enable_thinking: max_think_tokens != 1,
+            bos_token: None,
+        };
+        let render_result = if tools.is_some() || messages_history.is_some() {
+            let synthesized: Vec<hipfire_runtime::prompt_frame::Message>;
+            let messages_slice: &[hipfire_runtime::prompt_frame::Message] = match messages_history {
+                Some(m) => m,
+                None => {
+                    let mut v = Vec::new();
+                    if let Some(sys) = system_prompt {
+                        v.push(hipfire_runtime::prompt_frame::Message {
+                            role: hipfire_runtime::prompt_frame::Role::System,
+                            content: sys.to_string(),
+                            tool_calls: Vec::new(),
+                            tool_call_id: None,
+                        });
+                    }
+                    v.push(hipfire_runtime::prompt_frame::Message {
+                        role: hipfire_runtime::prompt_frame::Role::User,
+                        content: prompt.to_string(),
+                        tool_calls: Vec::new(),
+                        tool_call_id: None,
+                    });
+                    synthesized = v;
+                    &synthesized
+                }
+            };
+            frame.render_messages(messages_slice, tools, None)
+        } else {
+            frame.render()
+        };
+        match render_result {
+            Ok(rendered) => tokenizer.encode(&rendered),
+            Err(e) => {
+                eprintln!("[daemon] jinja render failed in pp-mtp path ({e}) — falling back to Plain");
+                hipfire_runtime::prompt_frame::ChatFrame {
+                    tokenizer: &tokenizer,
+                    system: if m.seq_pos == 0 { system_prompt } else { None },
+                    user: "",
+                    assistant_prefix,
+                    raw: false,
+                }
+                .build_with_user_tokens(&raw_q_tokens)
+            }
+        }
+    } else {
+        hipfire_runtime::prompt_frame::ChatFrame {
+            tokenizer: &tokenizer,
+            system: if m.seq_pos == 0 { system_prompt } else { None },
+            user: "",
+            assistant_prefix,
+            raw: false,
+        }
+        .build_with_user_tokens(&raw_q_tokens)
+    };
+
+    if try_jinja && m.seq_pos > 0 {
+        reset_pp_recurrent!();
+    }
+
+    let im_end = tokenizer.encode("<|im_end|>");
+    let im_end_token = if im_end.len() == 1 { Some(im_end[0]) } else { None };
+    if new_tokens.is_empty() {
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"error","id":"{}","message":"pp-mtp prompt encoded to zero tokens"}}"#,
+            id
+        );
+        let _ = stdout.flush();
+        m.tokenizer = Some(tokenizer);
+        return;
+    }
+    if m.seq_pos + new_tokens.len() + max_tokens > m.physical_cap {
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"error","id":"{}","message":"request exceeds loaded KV budget: seq_pos={} + prefill={} + max_tokens={} > physical_cap={}"}}"#,
+            id,
+            m.seq_pos,
+            new_tokens.len(),
+            max_tokens,
+            m.physical_cap
+        );
+        let _ = stdout.flush();
+        m.tokenizer = Some(tokenizer);
+        return;
+    }
+
+    let t0 = Instant::now();
+    let config = m.q35_config.as_ref().unwrap().clone();
+    let output_device = m.pp_gpus.as_ref().unwrap().output_device;
+    let dim = config.dim;
+    let start_pos = m.seq_pos;
+    let weights = m.q35_weights.take().expect("q35 weights");
+    let mut kv_cache = m.kv_cache.take().expect("kv cache");
+    let mut dn_state = m.dn_state.take().expect("dn state");
+    let scratch_set = m.pp_scratch_set.take().expect("pp scratch set");
+    let mut mtp_state = m.mtp.take().expect("MTP state");
+    let mut drafter_state = mtp_state
+        .drafter_state
+        .take()
+        .expect("PP+MTP drafter state");
+
+    macro_rules! restore_pp_mtp_state {
+        () => {{
+            mtp_state.drafter_state = Some(drafter_state);
+            m.q35_weights = Some(weights);
+            m.kv_cache = Some(kv_cache);
+            m.dn_state = Some(dn_state);
+            m.pp_scratch_set = Some(scratch_set);
+            m.mtp = Some(mtp_state);
+            m.tokenizer = Some(tokenizer);
+        }};
+    }
+    macro_rules! bail {
+        ($msg:expr) => {{
+            let _ = writeln!(
+                stdout,
+                r#"{{"type":"error","id":"{}","message":{}}}"#,
+                id,
+                serde_json::to_string(&$msg).unwrap_or_default()
+            );
+            let _ = stdout.flush();
+            restore_pp_mtp_state!();
+            return;
+        }};
+    }
+
+    let per_tok_hidden_out = {
+        let g = &mut m.pp_gpus.as_mut().unwrap().devices[output_device];
+        match g.alloc_tensor(&[new_tokens.len() * dim], rdna_compute::DType::F32) {
+            Ok(t) => t,
+            Err(e) => bail!(format!("pp-mtp alloc hidden capture: {e}")),
+        }
+    };
+
+    {
+        let gpus = m.pp_gpus.as_mut().unwrap();
+        if let Err(e) = qwen35::forward_prefill_batch_multi_with_caps(
+            gpus,
+            &weights,
+            &config,
+            &new_tokens,
+            start_pos,
+            &mut kv_cache,
+            &mut dn_state,
+            &scratch_set,
+            Some(&per_tok_hidden_out),
+            None,
+            false,
+        ) {
+            let g = &mut m.pp_gpus.as_mut().unwrap().devices[output_device];
+            let _ = g.free_tensor(per_tok_hidden_out);
+            bail!(format!("pp-mtp prefill: {e}"));
+        }
+    }
+    m.seq_pos += new_tokens.len();
+    m.conversation_tokens.extend_from_slice(&new_tokens);
+
+    {
+        let g = &mut m.pp_gpus.as_mut().unwrap().devices[output_device];
+        let last_row_off = (new_tokens.len() - 1) * dim * 4;
+        if let Err(e) = g.hip.memcpy_dtod_at(
+            &mtp_state.spec_state.prev_hidden.buf,
+            0,
+            &per_tok_hidden_out.buf,
+            last_row_off,
+            dim * 4,
+        ) {
+            let _ = g.free_tensor(per_tok_hidden_out);
+            bail!(format!("pp-mtp seed prev_hidden: {e}"));
+        }
+        if let Err(e) = g.hip.memcpy_dtod_at(
+            &drafter_state.prev_hidden.buf,
+            0,
+            &per_tok_hidden_out.buf,
+            last_row_off,
+            dim * 4,
+        ) {
+            let _ = g.free_tensor(per_tok_hidden_out);
+            bail!(format!("pp-mtp seed drafter prev_hidden: {e}"));
+        }
+    }
+
+    let first_token = {
+        let g = &mut m.pp_gpus.as_mut().unwrap().devices[output_device];
+        let logits = match g.alloc_tensor(&[config.vocab_size], rdna_compute::DType::F32) {
+            Ok(t) => t,
+            Err(e) => {
+                let _ = g.free_tensor(per_tok_hidden_out);
+                bail!(format!("pp-mtp alloc first logits: {e}"));
+            }
+        };
+        let last_row = per_tok_hidden_out.sub_offset((new_tokens.len() - 1) * dim, dim);
+        if let Err(e) = llama::weight_gemv(g, &weights.output, &last_row, &logits) {
+            let _ = g.free_tensor(logits);
+            let _ = g.free_tensor(per_tok_hidden_out);
+            bail!(format!("pp-mtp first lm_head: {e}"));
+        }
+        let logits_host = match g.download_f32(&logits) {
+            Ok(v) => v,
+            Err(e) => {
+                let _ = g.free_tensor(logits);
+                let _ = g.free_tensor(per_tok_hidden_out);
+                bail!(format!("pp-mtp download first logits: {e}"));
+            }
+        };
+        let _ = g.free_tensor(logits);
+        logits_host
+            .iter()
+            .enumerate()
+            .fold((0u32, f32::NEG_INFINITY), |(best, best_v), (i, &v)| {
+                if v > best_v { (i as u32, v) } else { (best, best_v) }
+            })
+            .0
+    };
+    {
+        let g = &mut m.pp_gpus.as_mut().unwrap().devices[output_device];
+        let _ = g.free_tensor(per_tok_hidden_out);
+    }
+
+    let t_prefill = Instant::now();
+    let mut streamed_tokens: Vec<u32> = Vec::new();
+    let mut emitted: Vec<u32> = Vec::new();
+    let mut bytes_fed_to_filter = 0usize;
+    let mut filter = EosFilter::new(EosFilterConfig::default());
+    let mut position = start_pos + new_tokens.len();
+    let mut seed_token = first_token;
+    let mut generated = 0usize;
+    let mut total_cycles = 0usize;
+    let mut total_accepted = 0usize;
+    let mut committed_from_cycles = 0usize;
+    let eos_token = config.eos_token;
+
+    let mut push_token = |tok: u32,
+                          stdout: &mut std::io::Stdout,
+                          generated: &mut usize,
+                          streamed_tokens: &mut Vec<u32>,
+                          bytes_fed_to_filter: &mut usize,
+                          filter: &mut EosFilter| {
+        emitted.push(tok);
+        streamed_tokens.push(tok);
+        emit_committed_event(
+            stdout,
+            id,
+            tok,
+            streamed_tokens.len() - 1,
+            t0.elapsed().as_millis() as u64,
+        );
+        let all_bytes = tokenizer.decode_bytes(streamed_tokens);
+        let new_bytes = &all_bytes[*bytes_fed_to_filter..];
+        *bytes_fed_to_filter = all_bytes.len();
+        if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes) {
+            if let Ok(text) = std::str::from_utf8(&text_bytes) {
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"token","id":"{}","text":{}}}"#,
+                    id,
+                    serde_json::to_string(text).unwrap_or_default()
+                );
+                let _ = stdout.flush();
+            }
+        }
+        *generated += 1;
+    };
+
+    push_token(
+        first_token,
+        stdout,
+        &mut generated,
+        &mut streamed_tokens,
+        &mut bytes_fed_to_filter,
+        &mut filter,
+    );
+
+    let mut hit_terminal = first_token == eos_token
+        || im_end_token == Some(first_token)
+        || tokenizer.is_terminator(first_token);
+    if !stop.is_empty() && stop.iter().any(|s| tokenizer.decode(&streamed_tokens).ends_with(s)) {
+        hit_terminal = true;
+    }
+
+    while generated < max_tokens && !hit_terminal {
+        let cycle_k = (max_tokens - generated)
+            .saturating_sub(1)
+            .min(mtp_state.max_n);
+        if cycle_k == 0 {
+            break;
+        }
+        if position + cycle_k + 1 >= m.physical_cap {
+            break;
+        }
+        let saved_spec_max_n = mtp_state.spec_state.max_n;
+        let saved_drafter_max_n = drafter_state.max_n;
+        mtp_state.spec_state.max_n = cycle_k;
+        drafter_state.max_n = cycle_k;
+        let step = {
+            let gpus = m.pp_gpus.as_mut().unwrap();
+            hipfire_arch_qwen35::mtp_spec::spec_step_mtp_compressed_serial_multi(
+                gpus,
+                output_device,
+                &config,
+                &weights,
+                &mut kv_cache,
+                &mut dn_state,
+                &scratch_set,
+                &mtp_state.head,
+                &mut mtp_state.spec_state,
+                &mut drafter_state,
+                position,
+                seed_token,
+                eos_token,
+            )
+        };
+        mtp_state.spec_state.max_n = saved_spec_max_n;
+        drafter_state.max_n = saved_drafter_max_n;
+        let step = match step {
+            Ok(s) => s,
+            Err(e) => bail!(format!("pp-mtp spec_step: {e}")),
+        };
+        total_cycles += 1;
+        total_accepted += step.accept_count;
+        for &tok in &step.committed {
+            if generated >= max_tokens {
+                break;
+            }
+            push_token(
+                tok,
+                stdout,
+                &mut generated,
+                &mut streamed_tokens,
+                &mut bytes_fed_to_filter,
+                &mut filter,
+            );
+            committed_from_cycles += 1;
+            if tok == eos_token || im_end_token == Some(tok) || tokenizer.is_terminator(tok) {
+                hit_terminal = true;
+                break;
+            }
+            if !stop.is_empty() && stop.iter().any(|s| tokenizer.decode(&streamed_tokens).ends_with(s)) {
+                hit_terminal = true;
+                break;
+            }
+        }
+        position += step.advance;
+        if let Some(&last) = step.committed.last() {
+            seed_token = last;
+        }
+    }
+
+    if generated > 0 {
+        let gpus = m.pp_gpus.as_mut().unwrap();
+        if let Err(e) = qwen35::forward_scratch_multi(
+            gpus,
+            &weights,
+            &config,
+            seed_token,
+            position,
+            &mut kv_cache,
+            &mut dn_state,
+            &scratch_set,
+        ) {
+            eprintln!("[daemon] pp-mtp final-token KV write failed (ignored): {e}");
+        } else {
+            position += 1;
+        }
+    }
+
+    m.conversation_tokens.extend_from_slice(&emitted);
+    m.seq_pos = position;
+    mtp_state.drafter_state = Some(drafter_state);
+    m.q35_weights = Some(weights);
+    m.kv_cache = Some(kv_cache);
+    m.dn_state = Some(dn_state);
+    m.pp_scratch_set = Some(scratch_set);
+    m.mtp = Some(mtp_state);
+    m.tokenizer = Some(tokenizer);
+
+    let t_end = Instant::now();
+    let total_s = t_end.duration_since(t0).as_secs_f64();
+    let prefill_s = t_prefill.duration_since(t0).as_secs_f64();
+    let decode_s = t_end.duration_since(t_prefill).as_secs_f64();
+    let tok_s = if total_s > 0.0 { generated as f64 / total_s } else { 0.0 };
+    let prefill_tok_s = if prefill_s > 0.0 {
+        new_tokens.len() as f64 / prefill_s
+    } else {
+        0.0
+    };
+    let decode_tok_s = if decode_s > 0.0 {
+        generated as f64 / decode_s
+    } else {
+        0.0
+    };
+    let tau = if total_cycles > 0 {
+        committed_from_cycles as f64 / total_cycles as f64
+    } else {
+        0.0
+    };
+    let accept_rate = if total_cycles > 0 {
+        total_accepted as f64 / total_cycles as f64
+    } else {
+        0.0
+    };
+    let _ = writeln!(
+        stdout,
+        r#"{{"type":"done","id":"{}","tokens":{},"tok_s":{:.1},"prefill_tokens":{},"prefill_ms":{:.1},"prefill_tok_s":{:.1},"decode_tok_s":{:.1},"ttft_ms":{:.1},"spec_path":"pp-mtp","mtp_k":{},"tau":{:.2},"accept_rate":{:.2},"cycles":{},"pp":{}}}"#,
+        id,
+        generated,
+        tok_s,
+        new_tokens.len(),
+        prefill_s * 1000.0,
+        prefill_tok_s,
+        decode_tok_s,
+        prefill_s * 1000.0,
+        m.mtp.as_ref().map(|s| s.max_n).unwrap_or(0),
+        tau,
+        accept_rate,
+        total_cycles,
+        m.pp,
+    );
+    let _ = stdout.flush();
+}
+
+#[allow(clippy::too_many_arguments)]
 fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Option<&mut rdna_compute::Gpu>, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, presence_penalty: f32, frequency_penalty: f32, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>, tools: Option<&[serde_json::Value]>, messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>, think_mode: ThinkMode, stop: &[String]) {
     // hunt3 M-E: seed the process-global CPU sampler RNG with this request's
     // fixed seed so the grammar/CPU-fallback sample stream is deterministic per
@@ -8595,6 +9289,30 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
     // at load when DFlash / CASK / PFlash / VL is requested, so this branch
     // doesn't need to thread any of those args through.
     if m.pp > 1 {
+        let pp_mtp_allowed = m.mtp.as_ref().map(|s| s.compressed).unwrap_or(false)
+            && temp <= 1e-6
+            && (repeat_penalty - 1.0).abs() <= 1e-6
+            && presence_penalty.abs() <= 1e-6
+            && frequency_penalty.abs() <= 1e-6
+            && budget_alert_at_tok == 0
+            && pflash_state.is_none();
+        if pp_mtp_allowed {
+            generate_pp_mtp(
+                m,
+                gpu,
+                stdout,
+                id,
+                prompt,
+                system_prompt,
+                max_tokens,
+                max_think_tokens,
+                assistant_prefix,
+                tools,
+                messages_history,
+                stop,
+            );
+            return;
+        }
         generate_multi(
             m, gpu, pflash_state, pflash_cfg, stdout, id, prompt, system_prompt,
             temp, top_p, max_tokens, repeat_penalty, repeat_window,

--- a/crates/hipfire-runtime/src/lib.rs
+++ b/crates/hipfire-runtime/src/lib.rs
@@ -22,6 +22,7 @@ pub mod hfq;
 pub mod kv_adaptive;
 pub mod llama;
 pub mod model_source;
+pub mod mtp_mirror;
 pub mod safetensors_source;
 pub mod loop_guard;
 pub mod multi_gpu;

--- a/crates/hipfire-runtime/src/mtp_mirror.rs
+++ b/crates/hipfire-runtime/src/mtp_mirror.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! One-time tensor mirroring for hetero / PP MTP.
+
+use hip_bridge::HipResult;
+use rdna_compute::{Gpu, GpuTensor};
+
+/// Allocate a same-shape, same-dtype tensor on `gpu` and copy `src` into it.
+pub fn clone_tensor_same(gpu: &mut Gpu, src: &GpuTensor) -> HipResult<GpuTensor> {
+    let dst = gpu.alloc_tensor(&src.shape, src.dtype)?;
+    gpu.hip
+        .memcpy_dtod_at(&dst.buf, 0, &src.buf, 0, src.byte_size())?;
+    Ok(dst)
+}
+
+/// Allocate a same-shape, same-dtype tensor on `dst_gpu` and peer-copy `src`.
+pub fn clone_tensor_peer(
+    src_gpu: &Gpu,
+    dst_gpu: &mut Gpu,
+    src: &GpuTensor,
+) -> HipResult<GpuTensor> {
+    debug_assert_ne!(
+        src_gpu.device_id, dst_gpu.device_id,
+        "clone_tensor_peer: same device; use clone_tensor_same",
+    );
+    dst_gpu.bind_thread()?;
+    let dst = dst_gpu.alloc_tensor(&src.shape, src.dtype)?;
+    src_gpu.hip.memcpy_peer(
+        &dst.buf,
+        dst_gpu.device_id,
+        &src.buf,
+        src_gpu.device_id,
+        src.byte_size(),
+    )?;
+    Ok(dst)
+}


### PR DESCRIPTION
## Summary

Surgical current-master reconciliation of the useful PP+MTP pieces from #382.

This intentionally does **not** import the old `SpecPath` / `GenerateCtx` dispatcher rewrite or the full old branch history. It adds the narrow pieces needed to load a compressed MTP head on the PP output device and run greedy PP+MTP decode through the daemon.

## What changed

- Add `forward_prefill_batch_multi_with_caps` so PP verify can capture output-band hidden rows and elide last-token logits when requested.
- Add PP-safe compressed MTP stepper with output-device MTP head, mirrored token embeddings, and multi-device DeltaNet snapshot/restore.
- Add daemon load/generate wiring for `pp > 1` + explicit compressed `.mtp` head.
- Add `hipfire_runtime::mtp_mirror` tensor clone helpers.

## Scope intentionally left out

- Old #382 `SpecPath` / `GenerateCtx` dispatcher rewrite.
- Old PP GDN tape-shard fast replay. This branch uses full accepted-prefix replay on partial accepts for correctness first.

## Validation

Local:

```bash
cargo check -p hipfire-runtime --example daemon
git diff --check
```

hiptrx rerun after avoiding a midflight collision with another agent:

- Commit: `6d86816f`
- Hardware: `ROCR_VISIBLE_DEVICES=2,3`, 2x Radeon AI PRO R9700 (`gfx1201`), HIP 7.2
- Trunk: `/home/kaden/.hipfire/models/qwen3-35b-a3b.mq4-awq`
  - md5 `edde51ec1dac0f2bd42cff5ef1cb8944`
  - sha256 `1dc1c7964de415e0040a540a4300b9518e11b00c13d99c23f576f2b9fe1e8bca`
- MTP head: `/home/kaden/.hipfire/models/qwen3.6-35b-a3b.moe-mtp-mq4-cvs16384.mtp`
  - md5 `51076bfb5b489832f2f6c4191b9799b0`
  - sha256 `1e11a06d1946e1e5711d6692894e917a61d5f360d4f3508c8372d49e97c912c1`

Load params:

```json
{
  "max_seq": 4096,
  "pp": 2,
  "kv_mode": "q8",
  "mtp_mode": "on",
  "mtp_head": "/home/kaden/.hipfire/models/qwen3.6-35b-a3b.moe-mtp-mq4-cvs16384.mtp",
  "mtp_k": 5,
  "mtp_kv_mode": "q8"
}
```

Result:

- PP split 20/20, `output_device=1`, `peer_access=true`.
- Warmup: `spec_path:"pp-mtp"`, coherent `warmup<|im_end|>`.
- Smoke prompt: coherent Python `remove_duplicates` body, not garbage.
- Done event: `spec_path:"pp-mtp"`, `prefill_tok_s:999.8`, `decode_tok_s:121.3`, `tok_s:116.5`, `tau:3.52`, `accept_rate:2.52`, `cycles:27`, `pp:2`.

Related: #382