### PR TITLE
fix(arch-llama): unify Site A attention dispatch + expand llama HFQ KV-mode policy

### DIFF
--- a/crates/hipfire-arch-llama/src/arch.rs
+++ b/crates/hipfire-arch-llama/src/arch.rs
@@ -229,36 +229,28 @@ impl Llama {
             )?;
 
             // ── KV cache write + attention (dispatched) ────────
-            // Derive tier plan from KV cache state. Q4 is inferred as
-            // "quantized but not any specific format".
-            let quant_q4 = kv_cache.quantized
-                && !kv_cache.quant_hfq4
-                && !kv_cache.quant_q8
-                && !kv_cache.quant_int8
-                && kv_cache.k_scales.is_empty();
             {
                 let ctx = DispatchCtx::new(gpu);
                 let family = attention_family();
+                let ti = kv_cache.tier_inputs();
+                let (k_scales, v_scales) = if ti.quant_hfq8 {
+                    (
+                        Some(&kv_cache.k_scales[layer_idx]),
+                        Some(&kv_cache.v_scales[layer_idx]),
+                    )
+                } else {
+                    (None, None)
+                };
                 let plan = KvTierPlan::derive(KvTierInputs {
-                    quant_asym4: false,
-                    quant_asym3: false,
-                    quant_asym2: false,
-                    quant_q8: kv_cache.quant_q8,
-                    quant_fwht: false,
-                    quant_hfq4: kv_cache.quant_hfq4,
-                    quant_q4,
-                    quant_int8: false,
-                    quant_hfq8: false,
-                    f32_policy: hipfire_dispatch::families::kv_tier::F32AttnPolicy::Simple,
-                    v_mode_bits: 8,
                     pos,
                     flash_mode: 0,
-                    capture_mode: false,
+                    capture_mode: gpu.graphs.capture_mode,
                     batch_size: 1,
                     is_tree: false,
                     is_boundary: false,
                     q8_windowed: false,
                     window: 0,
+                    ..ti
                 })
                 .map_err(|e| hip_bridge::HipError::new(0, &e.to_string()))?;
                 let io = AttnParams {
@@ -267,8 +259,8 @@ impl Llama {
                     v: &scratch.v,
                     k_cache: &kv_cache.k_gpu[layer_idx],
                     v_cache: &kv_cache.v_gpu[layer_idx],
-                    k_scales: None,
-                    v_scales: None,
+                    k_scales,
+                    v_scales,
                     pos_buf: &scratch.pos_buf,
                     pos,
                     positions: None,
@@ -278,9 +270,9 @@ impl Llama {
                     physical_cap: kv_cache.physical_cap,
                     batch_size: 1,
                     max_ctx_len: 0,
-                    flash_partials: None,
-                    givens_cos: None,
-                    givens_sin: None,
+                    flash_partials: Some(&scratch.attn_partials),
+                    givens_cos: kv_cache.givens_cos.as_ref(),
+                    givens_sin: kv_cache.givens_sin.as_ref(),
                     tree_bias: None,
                     block_start: 0,
                     block_cols: 0,

--- a/crates/hipfire-arch-llama/src/carrier.rs
+++ b/crates/hipfire-arch-llama/src/carrier.rs
@@ -33,7 +33,7 @@ pub fn load_bundle(src: ModelSource, ctx: &mut LoadCtx) -> Result<LlamaBundle, S
     };
     let kv = KvCache::from_mode(
         hipfire_runtime::kv_mode::resolve(
-            "",
+            ctx.kv_mode_override.unwrap_or(""),
             &hipfire_runtime::kv_mode::LLAMA_HFQ_POLICY,
             config.head_dim,
         )

--- a/crates/hipfire-dispatch-tests/src/llama.rs
+++ b/crates/hipfire-dispatch-tests/src/llama.rs
@@ -5,6 +5,154 @@
 
 use rdna_compute::DType;
 
+// ─── KV-tier dispatch sweep (Site A fix validation) ────────────
+//
+// These tests validate that each KvCache tier produces the correct
+// KvTierPlan via KvTierPlan::derive — mirroring what arch.rs Site A
+// (and the runtime forward) now do via kv_cache.tier_inputs().
+// GPU-free: tests pure dispatch-resolution logic only.
+
+fn tier_inputs_base() -> hipfire_dispatch::families::kv_tier::KvTierInputs {
+    use hipfire_dispatch::families::kv_tier::{F32AttnPolicy, KvTierInputs};
+    KvTierInputs {
+        quant_asym4: false,
+        quant_asym3: false,
+        quant_asym2: false,
+        quant_q8: false,
+        quant_fwht: false,
+        quant_hfq4: false,
+        quant_q4: false,
+        quant_int8: false,
+        quant_hfq8: false,
+        f32_policy: F32AttnPolicy::Simple,
+        v_mode_bits: 8,
+        pos: 0,
+        flash_mode: 0,
+        capture_mode: false,
+        batch_size: 1,
+        is_tree: false,
+        is_boundary: false,
+        q8_windowed: false,
+        window: 0,
+    }
+}
+
+#[test]
+fn llama_kv_tier_q8_uses_q8_kernels_no_givens() {
+    use hipfire_dispatch::families::kv_tier::KvTierPlan;
+    use hipfire_dispatch::types::KernelKey;
+    let plan = KvTierPlan::derive(tier_inputs_base().with_q8()).unwrap();
+    // Q8 never needs givens rotation buffers.
+    assert!(!plan.uses_givens, "Q8 must not set uses_givens");
+    assert_eq!(plan.write_key, KernelKey::KvWriteQ8_0);
+    // Short-context Q8 defaults to non-flash single-token attend.
+    assert_eq!(plan.attend_key, KernelKey::AttnQ8_0Kv);
+}
+
+#[test]
+fn llama_kv_tier_asym4_uses_givens() {
+    use hipfire_dispatch::families::kv_tier::KvTierPlan;
+    use hipfire_dispatch::types::KernelKey;
+    let plan = KvTierPlan::derive(tier_inputs_base().with_asym4()).unwrap();
+    assert!(plan.uses_givens, "Asym4 must set uses_givens");
+    assert_eq!(plan.write_key, KernelKey::KvWriteAsym4);
+    assert_eq!(plan.attend_key, KernelKey::AttnFlashAsym4);
+}
+
+#[test]
+fn llama_kv_tier_asym3_uses_givens() {
+    use hipfire_dispatch::families::kv_tier::KvTierPlan;
+    use hipfire_dispatch::types::KernelKey;
+    let plan = KvTierPlan::derive(tier_inputs_base().with_asym3()).unwrap();
+    assert!(plan.uses_givens, "Asym3 must set uses_givens");
+    assert_eq!(plan.write_key, KernelKey::KvWriteAsym3);
+    assert_eq!(plan.attend_key, KernelKey::AttnFlashAsym3);
+}
+
+#[test]
+fn llama_kv_tier_asym2_uses_givens() {
+    use hipfire_dispatch::families::kv_tier::KvTierPlan;
+    use hipfire_dispatch::types::KernelKey;
+    let plan = KvTierPlan::derive(tier_inputs_base().with_asym2()).unwrap();
+    assert!(plan.uses_givens, "Asym2 must set uses_givens");
+    assert_eq!(plan.write_key, KernelKey::KvWriteAsym2);
+    assert_eq!(plan.attend_key, KernelKey::AttnFlashAsym2);
+}
+
+#[test]
+fn llama_kv_tier_hfq8_no_givens() {
+    use hipfire_dispatch::families::kv_tier::KvTierPlan;
+    use hipfire_dispatch::types::KernelKey;
+    let plan = KvTierPlan::derive(tier_inputs_base().with_hfq8()).unwrap();
+    assert!(!plan.uses_givens, "HFQ8 must not set uses_givens");
+    assert_eq!(plan.write_key, KernelKey::KvWriteHfq8);
+    assert_eq!(plan.attend_key, KernelKey::AttnHfq8Kv);
+}
+
+#[test]
+fn llama_kv_tier_q4_no_givens() {
+    use hipfire_dispatch::families::kv_tier::KvTierPlan;
+    use hipfire_dispatch::types::KernelKey;
+    let plan = KvTierPlan::derive(tier_inputs_base().with_q4()).unwrap();
+    assert!(!plan.uses_givens, "Q4 must not set uses_givens");
+    assert_eq!(plan.write_key, KernelKey::KvWriteQ4);
+    assert_eq!(plan.attend_key, KernelKey::AttnQ4Kv);
+}
+
+#[test]
+fn llama_kv_tier_hfq4_no_givens() {
+    use hipfire_dispatch::families::kv_tier::KvTierPlan;
+    use hipfire_dispatch::types::KernelKey;
+    let plan = KvTierPlan::derive(tier_inputs_base().with_hfq4()).unwrap();
+    assert!(!plan.uses_givens, "HFQ4 must not set uses_givens");
+    assert_eq!(plan.write_key, KernelKey::KvWriteHfq4);
+    assert_eq!(plan.attend_key, KernelKey::AttnHfq4Kv);
+}
+
+#[test]
+fn llama_kv_tier_f32_no_givens() {
+    use hipfire_dispatch::families::kv_tier::KvTierPlan;
+    use hipfire_dispatch::types::KernelKey;
+    let plan = KvTierPlan::derive(tier_inputs_base()).unwrap();
+    assert!(!plan.uses_givens, "F32 must not set uses_givens");
+    assert_eq!(plan.write_key, KernelKey::KvWriteF32);
+    assert_eq!(plan.attend_key, KernelKey::AttnF32);
+}
+
+#[test]
+fn llama_kv_tier_asym4_fwht_uses_givens() {
+    use hipfire_dispatch::families::kv_tier::KvTierPlan;
+    use hipfire_dispatch::types::KernelKey;
+    let mut ti = tier_inputs_base().with_asym4();
+    ti.quant_fwht = true;
+    let plan = KvTierPlan::derive(ti).unwrap();
+    assert!(plan.uses_givens, "Asym4+FWHT must set uses_givens");
+    assert_eq!(plan.write_key, KernelKey::KvWriteAsym4Fwht);
+    assert_eq!(plan.attend_key, KernelKey::AttnFlashAsym4Fwht);
+}
+
+// ─── Builder helpers (keep at module end) ─────────────────────
+
+trait KvTierInputsExt: Sized {
+    fn with_q8(self) -> Self;
+    fn with_asym4(self) -> Self;
+    fn with_asym3(self) -> Self;
+    fn with_asym2(self) -> Self;
+    fn with_hfq8(self) -> Self;
+    fn with_q4(self) -> Self;
+    fn with_hfq4(self) -> Self;
+}
+
+impl KvTierInputsExt for hipfire_dispatch::families::kv_tier::KvTierInputs {
+    fn with_q8(mut self) -> Self { self.quant_q8 = true; self }
+    fn with_asym4(mut self) -> Self { self.quant_asym4 = true; self }
+    fn with_asym3(mut self) -> Self { self.quant_asym3 = true; self }
+    fn with_asym2(mut self) -> Self { self.quant_asym2 = true; self }
+    fn with_hfq8(mut self) -> Self { self.quant_hfq8 = true; self }
+    fn with_q4(mut self) -> Self { self.quant_q4 = true; self }
+    fn with_hfq4(mut self) -> Self { self.quant_hfq4 = true; self }
+}
+
 // ─── Prefill batchability ─────────────────────────────────────
 
 #[test]

--- a/crates/hipfire-runtime/src/kv_mode.rs
+++ b/crates/hipfire-runtime/src/kv_mode.rs
@@ -109,11 +109,15 @@ pub const DIR_SAFETENSORS_POLICY: KvModePolicy = KvModePolicy {
     default: Q8, // recognized-but-unaccepted AND unrecognized both → plain q8
 };
 
-/// Site 4 — llama HFQ carrier. carrier.rs:21. Hardcoded q8 today.
+/// Site 4 — llama HFQ carrier. carrier.rs:21. Default q8. Accepts the three
+/// modes that have Flat KV constructors: Q8, Asym3, Asym4. Asym3/Asym4 are
+/// gated in `KvCache::from_mode` with a clean error at head_dim≠256 (most llama
+/// models are head_dim=128; only validated at 256 via Qwen 3.5). Asym2/Fwht*
+/// have no Flat constructor and silently fall to q8 (unimplemented, not broken).
 pub const LLAMA_HFQ_POLICY: KvModePolicy = KvModePolicy {
     site: "llama-hfq",
     normalize_alias: normalize_full,
-    accepted: &[Q8],
+    accepted: &[Q8, Asym3, Asym4],
     default: Q8,
 };
 
@@ -261,14 +265,37 @@ mod tests {
     }
 
     #[test]
-    fn truth_table_q8_only_policies() {
-        for p in [&LLAMA_HFQ_POLICY, &HFQ_Q8_ONLY_POLICY] {
-            assert_eq!(resolve("", p, 128).mode, KvMode::Q8);
-            assert_eq!(resolve("q8", p, 128).mode, KvMode::Q8);
-            assert_eq!(resolve("asym3", p, 128).mode, KvMode::Q8); // unaccepted → q8
-            assert_eq!(resolve("fwht4", p, 256).mode, KvMode::Q8);
-            assert_eq!(resolve("garbage", p, 256).mode, KvMode::Q8);
-        }
+    fn truth_table_llama_hfq_expanded() {
+        let p = &LLAMA_HFQ_POLICY;
+        // Default and explicit q8 → Q8.
+        assert_eq!(resolve("", p, 128).mode, KvMode::Q8);
+        assert_eq!(resolve("", p, 256).mode, KvMode::Q8); // default is Q8, not Asym3
+        assert_eq!(resolve("q8", p, 128).mode, KvMode::Q8);
+        // Asym3/Asym4 accepted — reach from_mode where head_dim gate fires.
+        assert_eq!(resolve("asym3", p, 128).mode, KvMode::Asym3);
+        assert_eq!(resolve("asym3", p, 256).mode, KvMode::Asym3);
+        assert_eq!(resolve("asym4", p, 128).mode, KvMode::Asym4);
+        assert_eq!(resolve("turbo3", p, 128).mode, KvMode::Asym3);
+        assert_eq!(resolve("turbo4", p, 256).mode, KvMode::Asym4);
+        // auto/turbo normalize to Asym3 (accepted → pass through).
+        assert_eq!(resolve("auto", p, 256).mode, KvMode::Asym3);
+        // Unaccepted modes (asym2/fwht*) silently fall to Q8 default.
+        assert_eq!(resolve("asym2", p, 128).mode, KvMode::Q8);
+        assert!(resolve("asym2", p, 128).warning.is_some());
+        assert_eq!(resolve("fwht3", p, 256).mode, KvMode::Q8);
+        // Unrecognized strings also fall to Q8 with warning.
+        assert_eq!(resolve("garbage", p, 256).mode, KvMode::Q8);
+        assert!(resolve("garbage", p, 256).warning.is_some());
+    }
+
+    #[test]
+    fn truth_table_hfq_q8_only() {
+        let p = &HFQ_Q8_ONLY_POLICY;
+        assert_eq!(resolve("", p, 128).mode, KvMode::Q8);
+        assert_eq!(resolve("q8", p, 128).mode, KvMode::Q8);
+        assert_eq!(resolve("asym3", p, 128).mode, KvMode::Q8); // unaccepted → q8
+        assert_eq!(resolve("fwht4", p, 256).mode, KvMode::Q8);
+        assert_eq!(resolve("garbage", p, 256).mode, KvMode::Q8);
     }
 
     #[test]

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -5039,19 +5039,21 @@ impl KvCache {
             KvMode::Asym3Auto,
             "from_mode received unresolved sentinel"
         );
-        // GATE: the asym4 single-token flash-attention decode (AttnFlashAsym4)
-        // is correct only at head_dim=256 (validated via qwen35). At head_dim=128
-        // it deterministically produces garbage — the write/tile/reduce kernels
-        // nominally accept head_dim 128, but the flash decode path is broken
-        // there (tracked, not yet root-caused). Fail the load loudly here rather
-        // than let an asym4@128 cache silently emit garbage at inference.
-        if matches!(mode, KvMode::Asym4) && dims.head_dim != 256 {
+        // GATE: asym4 and asym3 require head_dim=256. Both are validated only on
+        // Qwen 3.5 (head_dim=256); the constructors hard-assert head_dim==256 and
+        // the flash-decode paths are untested below that. Return a clean error here
+        // rather than panicking or emitting garbage inside the constructor.
+        if matches!(mode, KvMode::Asym4 | KvMode::Asym3) && dims.head_dim != 256 {
             return Err(hip_bridge::HipError::new(
                 0,
                 &format!(
-                    "asym4 KV cache is unsupported at head_dim={} (the single-token \
-                     flash-attention path is broken below head_dim=256; gated to \
-                     prevent silent garbage output). Use --kv-mode q8.",
+                    "{} KV cache requires head_dim=256 (validated on Qwen 3.5); \
+                     head_dim={} is unsupported. Use --kv-mode q8.",
+                    match mode {
+                        KvMode::Asym4 => "asym4",
+                        KvMode::Asym3 => "asym3",
+                        _ => unreachable!(),
+                    },
                     dims.head_dim
                 ),
             ));


### PR DESCRIPTION
## Summary

Deferred items from PR #463 (transparent loading). Three commits:

### 1. `fix(arch-llama)`: unify Site A attention dispatch (`arch.rs:242`)

`Llama::forward_scratch_layers` in `hipfire-arch-llama` had a hardcoded Q8-shaped `KvTierInputs` literal (`quant_asym*: false`, `v_mode_bits: 8`, `givens_cos/sin: None`). For asym or HFQ8 KV caches this would either panic or silently select the wrong kernel.

**Changes in `crates/hipfire-arch-llama/src/arch.rs`:**
- Replace the literal with `..kv_cache.tier_inputs()` struct update (all quantization flags now come from cache state)
- Thread `givens_cos/sin` from the cache into `AttnParams` (asym attend kernels unwrap these)
- Pass `flash_partials: Some(&scratch.attn_partials)` (required for flash attend tiles)
- Add conditional `(k_scales, v_scales)` for HFQ8 (attend kernel panics on `None` for that tier)  
- Use `gpu.graphs.capture_mode` instead of hardcoded `false`

Byte-identical no-op for Q8 caches.

### 2. `test(dispatch-tests)`: KV-tier dispatch sweep

9 GPU-free tier-routing tests in `hipfire-dispatch-tests/src/llama.rs` covering Q8, asym2/3/4, FWHT+asym4, HFQ4, HFQ8, Q4, F32. Each verifies `uses_givens` and the paired `write_key`/`attend_key`.

### 3. `feat(kv-mode)`: expand `LLAMA_HFQ_POLICY` + wire `kv_mode_override`

- `kv_mode.rs`: `LLAMA_HFQ_POLICY` now accepts `[Q8, Asym3, Asym4]` (was `[Q8]` only). Asym2/Fwht* have no Flat KV constructor and silently fall to Q8.
- `llama.rs::KvCache::from_mode`: new clean-error gate for Asym3 alongside the existing Asym4 gate — at `head_dim≠256` returns a user-readable error instead of panicking in `new_gpu_asym3_capped`.
- `carrier.rs::load_bundle`: was hardcoding `""` for `kv_mode_override`, silently ignoring explicit `--kv-mode` requests for HFQ llama loads since the carrier was introduced. Now passes `ctx.kv_mode_override`.

**Validated sweep on `qwen3-0.6b-llama.mq4` (head_dim=128, gfx1151):**
| `--kv-mode` | Result |
|---|---|
| `q8` | LOADED, coherent output |
| `asym3` | Clean error: "asym3 KV cache requires head_dim=256" |
| `asym4` | Clean error: "asym4 KV cache requires head_dim=256" |
| `asym2` | LOADED → Q8 (silently downgraded, no Flat constructor) |

## Test plan

- [ ] `cargo test -p hipfire-dispatch-tests` — 9 new tier tests pass
- [ ] `cargo test -p hipfire-runtime --lib -- kv_mode` — truth-table tests pass
- [ ] Q8 coherence: `qwen3-0.6b-llama.mq4` with `--kv-mode q8` produces coherent output
- [ ] Asym gate: `--kv-mode asym3` on head_dim=128 model returns clean load error

🤖 Generated with [Claude Code](https://claude.com/claude-code)