### PR TITLE
fix(qwen2): apply chat template in generate_qwen2 for instruct models

### DIFF
--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -11934,7 +11934,28 @@ fn generate_qwen2(
     let weights = &state_ref.weights;
     let state = &mut state_ref.state;
 
-    let prompt_ids = tokenizer.encode(prompt);
+    // Apply the model's chat template (if present) so instruct-tuned qwen2
+    // models receive properly-framed ChatML input. Falls back to raw encoding
+    // when no template is loaded (e.g. base/pre-train weights).
+    let prompt_ids = if let Some(template) = m.chat_template.as_ref() {
+        let frame = hipfire_runtime::prompt_frame::JinjaChatFrame {
+            tokenizer,
+            template,
+            system: _system_prompt,
+            user: prompt,
+            enable_thinking: true,
+            bos_token: None,
+        };
+        match frame.render() {
+            Ok(rendered) => tokenizer.encode(&rendered),
+            Err(e) => {
+                eprintln!("[daemon] qwen2 jinja render failed ({e}) — falling back to raw encode");
+                tokenizer.encode(prompt)
+            }
+        }
+    } else {
+        tokenizer.encode(prompt)
+    };
     if prompt_ids.is_empty() {
         let _ = writeln!(
             stdout,


### PR DESCRIPTION
## Summary

- `generate_qwen2()` (arch_id=7) called `tokenizer.encode(prompt)` on **raw user text**, bypassing all ChatML scaffolding that other arch paths apply
- Instruct-tuned Qwen2 models require `<|im_start|>…<|im_end|>` framing; without it the model sees plain text and falls into a space/noise attractor
- Fix: when `m.chat_template` is populated (loaded from `tokenizer_config.json` by the Dir/safetensors path), apply it via `JinjaChatFrame::render()` before encoding; falls back to raw encode for base weights

## Root cause

`generate()` short-circuits to `generate_qwen2()` at line 6140 **before** the Jinja/ChatFrame scaffolding block (line 6682+). The qwen2 path was wired as a bring-up stub and deferred sampling + prompt formatting — this PR closes the prompt-formatting gap.

## Validation

Tested with **WeiboAI/VibeThinker-3B** (Qwen2ForCausalLM, BF16 safetensors dir, transparent loading):

```
bun run cli/index.ts run /path/to/VibeThinker-3B -t 0.7 -n 512 "What is 2+2? Be brief."
# → "4"   [106 tok, 8.17 tok/s]  (thinking stripped by CLI)

bun run cli/index.ts run /path/to/VibeThinker-3B -t 0.7 -n 1024 "Give me just the Python code for fast-doubling Fibonacci."
# → correct O(log n) implementation  [882 tok, 8.18 tok/s]
```

GPU: gfx1151 (Strix Halo, 131 GB VRAM), ROCm / HIP 7.2

## Test plan

- [ ] `hipfire run <qwen2-instruct-dir>` produces coherent output (not spaces/noise)
- [ ] `hipfire run <qwen2-base-dir>` (no chat_template) still works via raw encode fallback
- [ ] Existing HFQ qwen2 models (paro-qwen25-packed, qwen25-0.5b-instruct.mq4) unaffected — they load via the same arch_id=7 path, `m.chat_template` was already populated and is now used

🤖 Generated with [Claude Code](https://claude.com/claude-code)