### PR TITLE
fix(daemon): rewind live qwen2 bundle state on reset (arch_id=7, #462 class)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -187,6 +187,30 @@ if echo "$CHANGED" | grep -qE "$SERVE_HOTSPOT"; then
         exit 1
     fi
     echo
+
+    # qwen2 (arch_id=7) per-request reset regression (#462 bundle class).
+    # serve-loop-gate above is qwen3.5/DeltaNet-only; this exercises the plain
+    # qwen2 reset path that the Qwen2Carrier bundle migration broke — the reset
+    # handler rewound the dead `m.qwen2_state` field, not the live ModelState::
+    # Qwen2 bundle state, so next_pos bled across requests. Only a real reset
+    # no-op (exit 1) blocks; SKIP (3, no qwen2 model) / infra (2) warn-only.
+    if [ -r ./scripts/qwen2-reset-gate.sh ]; then
+        echo "=== qwen2 per-request reset gate ==="
+        bash ./scripts/qwen2-reset-gate.sh; q2rc=$?
+        if [ "$q2rc" -eq 1 ]; then
+            echo
+            echo "========================================================================"
+            echo "COMMIT BLOCKED: qwen2 per-request reset no-op — next_pos bled across requests."
+            echo "========================================================================"
+            echo
+            echo "The daemon reset handler must rewind the live ModelState::Qwen2 bundle"
+            echo "state via m.qwen2_mut(), not just the dots-ocr-only m.qwen2_state field."
+            echo "  ./scripts/qwen2-reset-gate.sh   # re-run"
+            echo
+            exit 1
+        fi
+        echo
+    fi
 fi
 
 echo

--- a/crates/hipfire-loader/src/lib.rs
+++ b/crates/hipfire-loader/src/lib.rs
@@ -1238,7 +1238,8 @@ fn load_model_ep_ds4(path: &str, max_seq: usize, tp: usize) -> Result<LoadedMode
     let arch_id = hfq.arch_id;
     let n_exp = config.n_routed_experts;
 
-    let gpus = Gpus::init_tp(tp, config.num_hidden_layers).map_err(|e| format!("init_tp: {e:?}"))?;
+    let gpus =
+        Gpus::init_tp(tp, config.num_hidden_layers).map_err(|e| format!("init_tp: {e:?}"))?;
     let n = gpus.devices.len();
     if n != tp {
         return Err(format!(
@@ -1246,8 +1247,13 @@ fn load_model_ep_ds4(path: &str, max_seq: usize, tp: usize) -> Result<LoadedMode
         ));
     }
     eprintln!("[loader] EP load: tp={tp} arch=ds4 experts={n_exp} (rank r owns e%{tp}==r)");
-    let shard = ShardConfig::new(tp, /*tp_kv_replicate=*/ true, n_exp, ExpertAssign::Stride)
-        .map_err(|e| format!("ShardConfig: {e:?}"))?;
+    let shard = ShardConfig::new(
+        tp,
+        /*tp_kv_replicate=*/ true,
+        n_exp,
+        ExpertAssign::Stride,
+    )
+    .map_err(|e| format!("ShardConfig: {e:?}"))?;
     // Transactional partial-load: build per-rank weights/state/partials INTO the
     // staging guard. Every `?` below early-returns while `staging` is alive, so
     // its `Drop` frees the ranks already loaded.
@@ -1338,7 +1344,8 @@ fn load_model_ep_minimax(path: &str, max_seq: usize, tp: usize) -> Result<Loaded
     let arch_id = hfq.arch_id;
     let n_exp = config.num_local_experts;
 
-    let gpus = Gpus::init_tp(tp, config.num_hidden_layers).map_err(|e| format!("init_tp: {e:?}"))?;
+    let gpus =
+        Gpus::init_tp(tp, config.num_hidden_layers).map_err(|e| format!("init_tp: {e:?}"))?;
     let n = gpus.devices.len();
     if n != tp {
         return Err(format!(
@@ -1346,8 +1353,13 @@ fn load_model_ep_minimax(path: &str, max_seq: usize, tp: usize) -> Result<Loaded
         ));
     }
     eprintln!("[loader] EP load: tp={tp} arch=minimax experts={n_exp} (rank r owns e%{tp}==r)");
-    let shard = ShardConfig::new(tp, /*tp_kv_replicate=*/ true, n_exp, ExpertAssign::Stride)
-        .map_err(|e| format!("ShardConfig: {e:?}"))?;
+    let shard = ShardConfig::new(
+        tp,
+        /*tp_kv_replicate=*/ true,
+        n_exp,
+        ExpertAssign::Stride,
+    )
+    .map_err(|e| format!("ShardConfig: {e:?}"))?;
     let fail_rank = ep_fail_rank();
     let _ = fail_rank;
     let mut staging = MinimaxEpStaging::new(gpus);

--- a/crates/hipfire-loader/src/lib.rs
+++ b/crates/hipfire-loader/src/lib.rs
@@ -412,6 +412,18 @@ impl LoadedModel {
         }
     }
 
+    /// Qwen2 bundle if this model is arch_id=7 (plain qwen2 via `Qwen2Carrier`),
+    /// else None. The live `Qwen2State` is at `.state`. NOTE: this is NOT the
+    /// `qwen2_state` direct field — that is None for plain qwen2 and is only
+    /// populated by dots-ocr (arch_id=8). Reset/checkpoint sites must rewind
+    /// BOTH or the reset silently no-ops (see scripts/qwen2-reset-gate.sh).
+    pub fn qwen2_mut(&mut self) -> Option<&mut hipfire_arch_qwen2::Qwen2Bundle> {
+        match &mut self.state {
+            Some(ModelState::Qwen2(b)) => Some(b),
+            _ => None,
+        }
+    }
+
     /// Cohere2-MoE bundle if this model is arch_id=12, else None.
     pub fn cohere2moe(&self) -> Option<&Cohere2MoeBundle> {
         match &self.state {

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -2033,7 +2033,11 @@ fn main() {
                     .unwrap_or(m.rec_presence_penalty.unwrap_or(0.0) as f64)
                     as f32)
                     .max(0.0);
-                let frequency_penalty = (msg.get("frequency_penalty").and_then(|v| v.as_f64()).unwrap_or(0.0) as f32).max(0.0);
+                let frequency_penalty = (msg
+                    .get("frequency_penalty")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.0) as f32)
+                    .max(0.0);
                 // Request-driven top_k / min_p (W7 P2). Fallback ladder:
                 // explicit request field > .hfq/registry-baked rec_top_k /
                 // rec_min_p > None. None reproduces the legacy sampler exactly
@@ -2306,10 +2310,25 @@ fn main() {
                         continue;
                     }
                     generate(
-                        m, &mut gpu, pflash_drafter_gpu.as_mut(), &mut stdout, id, prompt, system,
-                        temp, top_p, top_k, min_p, max_tokens, repeat_penalty, repeat_window,
-                        presence_penalty, frequency_penalty,
-                        budget_alert_at_tok, &budget_alert_text, max_think_tokens,
+                        m,
+                        &mut gpu,
+                        pflash_drafter_gpu.as_mut(),
+                        &mut stdout,
+                        id,
+                        prompt,
+                        system,
+                        temp,
+                        top_p,
+                        top_k,
+                        min_p,
+                        max_tokens,
+                        repeat_penalty,
+                        repeat_window,
+                        presence_penalty,
+                        frequency_penalty,
+                        budget_alert_at_tok,
+                        &budget_alert_text,
+                        max_think_tokens,
                         assistant_prefix,
                         pflash_state.as_mut(),
                         pf_cfg_owned.as_ref(),
@@ -2966,8 +2985,29 @@ fn generate_ep(
         m.deepseek4_eos_tok
     };
     match m.arch_id {
-        10 => ep_serve_minimax(m, stdout, id, &prompt_ids, eos_tok, max_tokens, stop, primed_think, sampling),
-        _ => ep_serve_ds4(m, stdout, id, &prompt_ids, eos_tok, max_tokens, think_mode, tools, stop, sampling),
+        10 => ep_serve_minimax(
+            m,
+            stdout,
+            id,
+            &prompt_ids,
+            eos_tok,
+            max_tokens,
+            stop,
+            primed_think,
+            sampling,
+        ),
+        _ => ep_serve_ds4(
+            m,
+            stdout,
+            id,
+            &prompt_ids,
+            eos_tok,
+            max_tokens,
+            think_mode,
+            tools,
+            stop,
+            sampling,
+        ),
     }
 }
 
@@ -3044,7 +3084,12 @@ fn ep_reset_after_abort(m: &mut LoadedModel) {
 
 /// FIX #3: emit the standard `aborted` + `done(finish_reason=aborted)` event
 /// pair (mirrors the single-GPU AR abort path) then reset EP state.
-fn ep_emit_abort(stdout: &mut std::io::Stdout, id: &str, m: &mut LoadedModel, completion_tokens: usize) {
+fn ep_emit_abort(
+    stdout: &mut std::io::Stdout,
+    id: &str,
+    m: &mut LoadedModel,
+    completion_tokens: usize,
+) {
     let _ = writeln!(
         stdout,
         r#"{{"type":"aborted","id":"{}","reason":"client_cancelled"}}"#,
@@ -3060,9 +3105,20 @@ fn ep_emit_abort(stdout: &mut std::io::Stdout, id: &str, m: &mut LoadedModel, co
 }
 
 /// ds4 EP prefill + greedy decode.
-fn ep_serve_ds4(m: &mut LoadedModel, stdout: &mut std::io::Stdout, id: &str, prompt_ids: &[u32], eos_tok: u32, max_tokens: usize, think_mode: ThinkMode, tools: Option<&[serde_json::Value]>, stop: &[String], sampling: EpSampling) {
-    use std::time::Instant;
+fn ep_serve_ds4(
+    m: &mut LoadedModel,
+    stdout: &mut std::io::Stdout,
+    id: &str,
+    prompt_ids: &[u32],
+    eos_tok: u32,
+    max_tokens: usize,
+    think_mode: ThinkMode,
+    tools: Option<&[serde_json::Value]>,
+    stop: &[String],
+    sampling: EpSampling,
+) {
     use hipfire_arch_deepseek4::dsml::StreamEvent;
+    use std::time::Instant;
 
     let prompt_n = prompt_ids.len();
 
@@ -3223,8 +3279,15 @@ fn ep_serve_ds4(m: &mut LoadedModel, stdout: &mut std::io::Stdout, id: &str, pro
                 aborted_in_prefill = true;
                 break;
             }
-            if let Err(e) = deepseek4::forward::forward_ep(gpus, weights, config, state, partials, t, pos as u32) {
-                let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"forward_ep prefill: {}"}}"#, id, format!("{e}").replace('"', "'"));
+            if let Err(e) = deepseek4::forward::forward_ep(
+                gpus, weights, config, state, partials, t, pos as u32,
+            ) {
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"error","id":"{}","message":"forward_ep prefill: {}"}}"#,
+                    id,
+                    format!("{e}").replace('"', "'")
+                );
                 let _ = stdout.flush();
                 return;
             }
@@ -3261,7 +3324,12 @@ fn ep_serve_ds4(m: &mut LoadedModel, stdout: &mut std::io::Stdout, id: &str, pro
             Some(l) => match gpus.devices[0].download_f32(l) {
                 Ok(v) => v,
                 Err(e) => {
-                    let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"EP first-logits download failed: {}"}}"#, id, format!("{e:?}").replace('"', "'"));
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"error","id":"{}","message":"EP first-logits download failed: {}"}}"#,
+                        id,
+                        format!("{e:?}").replace('"', "'")
+                    );
                     let _ = stdout.flush();
                     return;
                 }
@@ -3305,7 +3373,9 @@ fn ep_serve_ds4(m: &mut LoadedModel, stdout: &mut std::io::Stdout, id: &str, pro
             sampling.top_k,
             sampling.min_p,
         );
-        if next == eos_tok { break; }
+        if next == eos_tok {
+            break;
+        }
         let piece = m.tokenizer.as_ref().unwrap().decode(&[next]);
         for ev in parser.feed(&piece) {
             absorb_event(&ev);
@@ -3358,7 +3428,12 @@ fn ep_serve_ds4(m: &mut LoadedModel, stdout: &mut std::io::Stdout, id: &str, pro
             Some(l) => match gpus.devices[0].download_f32(l) {
                 Ok(v) => v,
                 Err(e) => {
-                    let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"EP decode logits download failed: {}"}}"#, id, format!("{e:?}").replace('"', "'"));
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"error","id":"{}","message":"EP decode logits download failed: {}"}}"#,
+                        id,
+                        format!("{e:?}").replace('"', "'")
+                    );
                     let _ = stdout.flush();
                     return;
                 }
@@ -3435,7 +3510,17 @@ fn ep_serve_ds4(m: &mut LoadedModel, stdout: &mut std::io::Stdout, id: &str, pro
 /// reuse — see generate_minimax for the full rationale). `primed_think`
 /// re-emits the MiniMax `<think>\n` opener display-only for a well-formed turn.
 #[allow(clippy::too_many_arguments)]
-fn ep_serve_minimax(m: &mut LoadedModel, stdout: &mut std::io::Stdout, id: &str, prompt_ids: &[u32], eos_tok: u32, max_tokens: usize, stop: &[String], primed_think: bool, sampling: EpSampling) {
+fn ep_serve_minimax(
+    m: &mut LoadedModel,
+    stdout: &mut std::io::Stdout,
+    id: &str,
+    prompt_ids: &[u32],
+    eos_tok: u32,
+    max_tokens: usize,
+    stop: &[String],
+    primed_think: bool,
+    sampling: EpSampling,
+) {
     use std::time::Instant;
     let prompt_n = prompt_ids.len();
 
@@ -3556,7 +3641,9 @@ fn ep_serve_minimax(m: &mut LoadedModel, stdout: &mut std::io::Stdout, id: &str,
     // prefix is kept). On a mid-prefill abort, ep_emit_abort resets every
     // rank's KV cursor, so leaving conversation_tokens at the prefix keeps the
     // cache consistent with KV state.
-    for &t in &prompt_ids[prefill_from..prefill_from + prefilled_n] { m.conversation_tokens.push(t); }
+    for &t in &prompt_ids[prefill_from..prefill_from + prefilled_n] {
+        m.conversation_tokens.push(t);
+    }
     let prefill_ms = t_prefill.elapsed().as_secs_f64() * 1000.0;
     // FIX #1 / FIX #3 (ep-no-abort): client cancel during prefill → stop
     // cleanly. `aborted_in_prefill` already consumed the signal mid-loop; the
@@ -3588,7 +3675,12 @@ fn ep_serve_minimax(m: &mut LoadedModel, stdout: &mut std::io::Stdout, id: &str,
         match gpus.devices[0].download_f32(&state[0].logits) {
             Ok(v) => v,
             Err(e) => {
-                let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"EP first-logits download failed: {}"}}"#, id, format!("{e:?}").replace('"', "'"));
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"error","id":"{}","message":"EP first-logits download failed: {}"}}"#,
+                    id,
+                    format!("{e:?}").replace('"', "'")
+                );
                 let _ = stdout.flush();
                 return;
             }
@@ -3616,7 +3708,9 @@ fn ep_serve_minimax(m: &mut LoadedModel, stdout: &mut std::io::Stdout, id: &str,
             sampling.top_k,
             sampling.min_p,
         );
-        if next == eos_tok { break; }
+        if next == eos_tok {
+            break;
+        }
         let piece = m.tokenizer.as_ref().unwrap().decode(&[next]);
         generated += 1;
         m.conversation_tokens.push(next);
@@ -3652,15 +3746,26 @@ fn ep_serve_minimax(m: &mut LoadedModel, stdout: &mut std::io::Stdout, id: &str,
         logits = match gpus.devices[0].download_f32(&state[0].logits) {
             Ok(v) => v,
             Err(e) => {
-                let _ = writeln!(stdout, r#"{{"type":"error","id":"{}","message":"EP decode logits download failed: {}"}}"#, id, format!("{e:?}").replace('"', "'"));
+                let _ = writeln!(
+                    stdout,
+                    r#"{{"type":"error","id":"{}","message":"EP decode logits download failed: {}"}}"#,
+                    id,
+                    format!("{e:?}").replace('"', "'")
+                );
                 let _ = stdout.flush();
                 return;
             }
         };
     }
-    ep_emit_done(stdout, id, generated, prompt_n, prefill_ms, t_decode.elapsed().as_secs_f64() * 1000.0);
+    ep_emit_done(
+        stdout,
+        id,
+        generated,
+        prompt_n,
+        prefill_ms,
+        t_decode.elapsed().as_secs_f64() * 1000.0,
+    );
 }
-
 
 /// Outcome of the LCP prompt-cache decision (see [`plan_prompt_cache`]).
 struct PromptCachePlan {
@@ -5082,7 +5187,11 @@ fn generate_multi(
 ) {
     let tokenizer = m.tokenizer.as_ref().unwrap();
     let prompt_est = tokenizer.encode(prompt).len() + 20;
-    if m.seq_pos.saturating_add(prompt_est).saturating_add(max_tokens) > m.max_seq {
+    if m.seq_pos
+        .saturating_add(prompt_est)
+        .saturating_add(max_tokens)
+        > m.max_seq
+    {
         eprintln!(
             "[daemon] context full ({}/{}) — resetting conversation",
             m.seq_pos, m.max_seq
@@ -5939,7 +6048,11 @@ fn generate_multi(
             let need_kv = m
                 .seq_pos
                 .saturating_add(nudge_len)
-                .saturating_add(max_tokens.saturating_sub(generated).saturating_sub(nudge_len))
+                .saturating_add(
+                    max_tokens
+                        .saturating_sub(generated)
+                        .saturating_sub(nudge_len),
+                )
                 .saturating_add(nl.len());
             if nudge_len > 0 && need_kv <= m.physical_cap {
                 for &tok in &nudge_tokens[..nudge_len] {
@@ -6123,7 +6236,34 @@ fn generate_multi(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Option<&mut rdna_compute::Gpu>, stdout: &mut std::io::Stdout, id: &str, prompt: &str, system_prompt: Option<&str>, temp: f32, top_p: f32, top_k: Option<u32>, min_p: Option<f32>, max_tokens: usize, repeat_penalty: f32, repeat_window: usize, presence_penalty: f32, frequency_penalty: f32, budget_alert_at_tok: usize, budget_alert_text: &str, max_think_tokens: usize, assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix, pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>, pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>, tools: Option<&[serde_json::Value]>, messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>, think_mode: ThinkMode, stop: &[String]) {
+fn generate(
+    m: &mut LoadedModel,
+    gpu: &mut rdna_compute::Gpu,
+    drafter_gpu: Option<&mut rdna_compute::Gpu>,
+    stdout: &mut std::io::Stdout,
+    id: &str,
+    prompt: &str,
+    system_prompt: Option<&str>,
+    temp: f32,
+    top_p: f32,
+    top_k: Option<u32>,
+    min_p: Option<f32>,
+    max_tokens: usize,
+    repeat_penalty: f32,
+    repeat_window: usize,
+    presence_penalty: f32,
+    frequency_penalty: f32,
+    budget_alert_at_tok: usize,
+    budget_alert_text: &str,
+    max_think_tokens: usize,
+    assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix,
+    pflash_state: Option<&mut hipfire_arch_qwen35::pflash::PflashState>,
+    pflash_cfg: Option<&hipfire_arch_qwen35::pflash::PflashConfig>,
+    tools: Option<&[serde_json::Value]>,
+    messages_history: Option<&[hipfire_runtime::prompt_frame::Message]>,
+    think_mode: ThinkMode,
+    stop: &[String],
+) {
     // hunt3 M-E: seed the process-global CPU sampler RNG with this request's
     // fixed seed so the grammar/CPU-fallback sample stream is deterministic per
     // request and does not carry RNG state across requests. Matches the u32 the
@@ -6141,8 +6281,26 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         // which loops on ds4's quantized instruct model (card mandates
         // temp=1.0/top_p=1.0). reset_cpu_sampler_rng(0x13579BDF) was already
         // called above, so the host-side draw in ep_serve_* is deterministic.
-        let ep_sampling = EpSampling { temp, top_p, top_k, min_p };
-        generate_ep(m, stdout, id, prompt, system_prompt, max_tokens, max_think_tokens, think_mode, tools, messages_history, stop, ep_sampling);
+        let ep_sampling = EpSampling {
+            temp,
+            top_p,
+            top_k,
+            min_p,
+        };
+        generate_ep(
+            m,
+            stdout,
+            id,
+            prompt,
+            system_prompt,
+            max_tokens,
+            max_think_tokens,
+            think_mode,
+            tools,
+            messages_history,
+            stop,
+            ep_sampling,
+        );
         return;
     }
     // Compress runs on the PFlash drafter handle when one is set (hetero
@@ -6319,10 +6477,26 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
     // doesn't need to thread any of those args through.
     if m.pp > 1 {
         generate_multi(
-            m, gpu, pflash_state, pflash_cfg, stdout, id, prompt, system_prompt,
-            temp, top_p, top_k, min_p, max_tokens, repeat_penalty, repeat_window,
-            presence_penalty, frequency_penalty,
-            budget_alert_at_tok, budget_alert_text, max_think_tokens,
+            m,
+            gpu,
+            pflash_state,
+            pflash_cfg,
+            stdout,
+            id,
+            prompt,
+            system_prompt,
+            temp,
+            top_p,
+            top_k,
+            min_p,
+            max_tokens,
+            repeat_penalty,
+            repeat_window,
+            presence_penalty,
+            frequency_penalty,
+            budget_alert_at_tok,
+            budget_alert_text,
+            max_think_tokens,
             assistant_prefix,
             tools,
             messages_history,
@@ -6431,7 +6605,10 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
         );
     }
     if m.eviction.is_none()
-        && m.seq_pos.saturating_add(prompt_est).saturating_add(max_tokens) > m.max_seq
+        && m.seq_pos
+            .saturating_add(prompt_est)
+            .saturating_add(max_tokens)
+            > m.max_seq
     {
         eprintln!(
             "[daemon] context full ({}/{}) — resetting conversation",
@@ -7248,11 +7425,11 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
     );
     if m.eviction.is_none() {
         if m.seq_pos
-        .saturating_add(new_tokens.len())
-        .saturating_add(max_tokens)
-        .saturating_add(trailer)
-        > m.physical_cap
-    {
+            .saturating_add(new_tokens.len())
+            .saturating_add(max_tokens)
+            .saturating_add(trailer)
+            > m.physical_cap
+        {
             let _ = writeln!(
                 stdout,
                 r#"{{"type":"error","id":"{}","message":"request exceeds loaded KV budget: seq_pos={} + prefill={} + max_tokens={} + trailer={} > physical_cap={} — reload model with a larger max_seq"}}"#,
@@ -8140,9 +8317,14 @@ fn generate(m: &mut LoadedModel, gpu: &mut rdna_compute::Gpu, drafter_gpu: Optio
                 // eviction the physical check is trivially satisfied (budget
                 // always holds post-evict), but we still respect the check for
                 // the non-eviction path.
-                let need_kv = m.seq_pos
+                let need_kv = m
+                    .seq_pos
                     .saturating_add(nudge_len)
-                    .saturating_add(max_tokens.saturating_sub(generated).saturating_sub(nudge_len))
+                    .saturating_add(
+                        max_tokens
+                            .saturating_sub(generated)
+                            .saturating_sub(nudge_len),
+                    )
                     .saturating_add(nl.len());
                 if nudge_len > 0 && (m.eviction.is_some() || need_kv <= m.physical_cap) {
                     for &tok in &nudge_tokens[..nudge_len] {
@@ -10026,7 +10208,10 @@ fn generate_lfm2moe(
         let _ = writeln!(
             stdout,
             r#"{{"type":"error","id":"{}","message":"prompt exceeds context capacity: prompt={} + max_tokens={} > capacity={} — reload model with a larger max_seq"}}"#,
-            id, prompt_ids.len(), max_tokens, cap
+            id,
+            prompt_ids.len(),
+            max_tokens,
+            cap
         );
         let _ = stdout.flush();
         return;
@@ -10315,7 +10500,10 @@ fn generate_minimax(
             let _ = writeln!(
                 stdout,
                 r#"{{"type":"error","id":"{}","message":"prompt exceeds context capacity: prompt={} + max_tokens={} > capacity={} — reload model with a larger max_seq"}}"#,
-                id, prompt_ids.len(), max_tokens, cap
+                id,
+                prompt_ids.len(),
+                max_tokens,
+                cap
             );
             let _ = stdout.flush();
             return;
@@ -11455,7 +11643,10 @@ fn generate_qwen2(
             let _ = writeln!(
                 stdout,
                 r#"{{"type":"error","id":"{}","message":"prompt exceeds context capacity: prompt={} + max_tokens={} > capacity={} — reload model with a larger max_seq"}}"#,
-                id, prompt_ids.len(), max_tokens, cap
+                id,
+                prompt_ids.len(),
+                max_tokens,
+                cap
             );
             let _ = stdout.flush();
             return;
@@ -11675,7 +11866,10 @@ fn generate_vl(
     let prompt_est = tokenizer.encode(prompt).len() + system_est + n_visual_tokens + 20;
 
     if m.eviction.is_none()
-        && m.seq_pos.saturating_add(prompt_est).saturating_add(max_tokens) > m.max_seq
+        && m.seq_pos
+            .saturating_add(prompt_est)
+            .saturating_add(max_tokens)
+            > m.max_seq
     {
         eprintln!(
             "[daemon/vl] context full ({}/{}) — resetting conversation",

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -2155,6 +2155,12 @@ fn main() {
                         if let Some(ref mut s) = m.qwen2_state {
                             s.reset();
                         }
+                        // Live plain-qwen2 state is in the ModelState::Qwen2
+                        // bundle, not the (dots-ocr-only) qwen2_state field —
+                        // rewind it too for defense-in-depth.
+                        if let Some(b) = m.qwen2_mut() {
+                            b.state.reset();
+                        }
                         if let Some(ref mut s) = m.deepseek4_state {
                             s.reset();
                         }
@@ -2338,13 +2344,20 @@ fn main() {
                     if let Some(ModelState::Llama(b)) = m.state.as_mut() {
                         b.kv.compact_offset = 0;
                     }
-                    // arch_id=7: rewind the Qwen2State position cursor so
-                    // the next prefill writes from KV[0]. Without this, a
-                    // reset between turns would leak the prior turn's KV
-                    // entries into attention for the new turn — fluent
-                    // garbage, no panic. See `Qwen2State::reset` doc.
+                    // arch_id=7: rewind the live Qwen2State position cursor so
+                    // the next prefill writes from KV[0]. Without this, a reset
+                    // between turns leaks the prior turn's KV into attention —
+                    // fluent garbage, no panic. The live state lives in the
+                    // ModelState::Qwen2 bundle (built by Qwen2Carrier); the
+                    // `qwen2_state` direct field is None for plain qwen2 and is
+                    // only populated by dots-ocr (arch_id=8). Rewind BOTH so the
+                    // reset is not a silent no-op. See `Qwen2State::reset` and
+                    // scripts/qwen2-reset-gate.sh.
                     if let Some(ref mut s) = m.qwen2_state {
                         s.reset();
+                    }
+                    if let Some(b) = m.qwen2_mut() {
+                        b.state.reset();
                     }
                     // arch_id=9: same rationale for DeepSeek V4. Prior to
                     // 2026-05-24 the V4F state was NEVER reset, so
@@ -2562,9 +2575,14 @@ fn main() {
                 reset_qwen35_recurrent(m, &mut gpu);
                 // Qwen2 (arch_id=7) doesn't have a separate KV buffer — the cache
                 // and the per-step scratch share `Qwen2State`. Reset its position
-                // cursor here so bench_prefill measures cold prefill.
+                // cursor here so bench_prefill measures cold prefill. The live
+                // state is in the ModelState::Qwen2 bundle; `qwen2_state` is only
+                // dots-ocr's — rewind both, else this measures warm prefill.
                 if let Some(ref mut s) = m.qwen2_state {
                     s.reset();
+                }
+                if let Some(b) = m.qwen2_mut() {
+                    b.state.reset();
                 }
                 if let Some(b) = m.cohere2moe_mut() {
                     let _ = b.state.reset(&mut gpu);

--- a/crates/hipfire-tui/src/main.rs
+++ b/crates/hipfire-tui/src/main.rs
@@ -25,7 +25,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() -> Result<()> {
     // Non-interactive argument handling (headless-safe, no TTY required).
-    for arg in std::env::args().skip(1) {
+    if let Some(arg) = std::env::args().nth(1) {
         match arg.as_str() {
             "--version" | "-V" => {
                 println!("hipfire-tui {VERSION}");
@@ -77,7 +77,11 @@ fn run_check() -> Result<()> {
     let app = App::load()?;
     println!("hipfire-tui --check OK");
     println!("  config: default_model = {:?}", app.config.default_model);
-    println!("  registry: {} models, {} aliases", app.registry.models.len(), app.registry.aliases.len());
+    println!(
+        "  registry: {} models, {} aliases",
+        app.registry.models.len(),
+        app.registry.aliases.len()
+    );
     println!("  local models: {}", app.registry.local_files.len());
     if let Some(warn) = &app.registry.warning {
         println!("  registry warning: {warn}");
@@ -115,7 +119,11 @@ fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Re
     // Attempt every step independently so an early failure can't leave mouse
     // capture, the alternate screen, or raw mode enabled. Return the first
     // error after all steps have been tried.
-    let leave = execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture);
+    let leave = execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    );
     let cursor = terminal.show_cursor();
     let raw = disable_raw_mode();
     leave?;
@@ -409,7 +417,11 @@ mod tests {
             &mut app,
             mouse(MouseEventKind::Down(MouseButton::Left), 12, 10),
         );
-        assert_eq!(app.tab, Tab::Home, "a click off the tab row changes nothing");
+        assert_eq!(
+            app.tab,
+            Tab::Home,
+            "a click off the tab row changes nothing"
+        );
     }
 
     #[test]
@@ -430,7 +442,10 @@ mod tests {
         app.settings_easy = true;
         app.settings_selected = 0;
         handle_mouse(&mut app, mouse(MouseEventKind::ScrollDown, 0, 0));
-        assert_eq!(app.settings_selected, 1, "scroll down advances the selection");
+        assert_eq!(
+            app.settings_selected, 1,
+            "scroll down advances the selection"
+        );
         handle_mouse(&mut app, mouse(MouseEventKind::ScrollUp, 0, 0));
         assert_eq!(app.settings_selected, 0, "scroll up retreats it");
     }

--- a/scripts/qwen2-reset-gate.sh
+++ b/scripts/qwen2-reset-gate.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# qwen2-reset-gate.sh — regression guard for the qwen2 (arch_id=7) daemon
+# per-request reset no-op (#462 bundle-migration class).
+#
+# WHY THIS EXISTS: Qwen2Carrier moved the live Qwen2State into
+# ModelState::Qwen2(bundle), but the daemon's reset/checkpoint handlers kept
+# resetting the now-None `m.qwen2_state` direct field (only dots-ocr arch_id=8
+# still populates it). So `{"type":"reset"}` between requests SILENTLY no-op'd:
+# `next_pos` accumulated across requests until the max_seq ceiling auto-reset
+# fired, bleeding prior-turn KV into new turns. Outputs stay on-topic (each
+# request re-sends the full ChatML scaffold, anchoring the model to the latest
+# turn), so attractor detection — serve-multiturn-gate.sh — cannot see it. The
+# precise, deterministic signal is the ceiling auto-reset firing AT ALL.
+#
+# This loads a small qwen2 model at a SMALL max_seq and sends N explicit
+# reset+generate cycles. With a WORKING reset, next_pos rewinds to 0 each turn,
+# so the ceiling (next_pos + prompt + max_tokens > max_seq) can NEVER fire.
+# If the daemon logs "resetting Qwen2State.next_pos", the reset no-op'd → FAIL.
+#
+# Exit: 0 PASS, 1 FAIL (reset no-op), 2 infra error, 3 SKIPPED (no qwen2 model).
+set -u
+
+EXE="./target/release/examples/daemon"
+MODELS_DIR="${HIPFIRE_MODELS_DIR:-${HIPFIRE_DIR:-$HOME/.hipfire}/models}"
+MAX_SEQ=256
+MAX_TOKENS=32
+CYCLES=16
+# A fixed multi-sentence prompt: its re-prefill alone (~40+ tokens/cycle)
+# accumulates next_pos past the ceiling within a few cycles when reset no-ops,
+# independent of how many tokens the model actually generates.
+PROMPT="Explain, in two or three sentences, what a hash map is, how it stores keys and values, and why average-case lookups are fast."
+
+MODEL=""
+for c in qwen25-0.5b-instruct.mq4 qwen25-0.5b-q2.mq4 vibethinker-3b.mq4.hfq; do
+    [ -f "$MODELS_DIR/$c" ] && { MODEL="$MODELS_DIR/$c"; break; }
+done
+[ -z "$MODEL" ] && { echo "qwen2-reset-gate: SKIPPED — no qwen2 model under $MODELS_DIR" >&2; exit 3; }
+[ -x "$EXE" ] || { echo "qwen2-reset-gate: daemon not built at $EXE" >&2; exit 2; }
+
+if [ -r ./scripts/gpu-lock.sh ]; then
+    # shellcheck disable=SC1090
+    . ./scripts/gpu-lock.sh
+    gpu_acquire "qwen2-reset-gate" || { echo "qwen2-reset-gate: could not acquire GPU lock" >&2; exit 2; }
+    trap 'gpu_release 2>/dev/null || true' EXIT
+fi
+
+in_file="$(mktemp)"; out_file="$(mktemp)"
+{
+    printf '{"type":"load","model":"%s","params":{"max_seq":%d}}\n' "$MODEL" "$MAX_SEQ"
+    pj="$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$PROMPT")"
+    for i in $(seq 1 "$CYCLES"); do
+        printf '{"type":"reset"}\n'
+        printf '{"type":"generate","id":"r%d","prompt":%s,"temperature":0.0,"max_tokens":%d}\n' "$i" "$pj" "$MAX_TOKENS"
+    done
+    printf '{"type":"unload"}\n'
+} > "$in_file"
+
+timeout 600 "$EXE" < "$in_file" > "$out_file" 2>&1
+ec=$?
+ceil="$(grep -c 'resetting Qwen2State.next_pos' "$out_file")"
+toks="$(grep -c '"type":"token"' "$out_file")"
+panic="$(grep -cE 'panicked|"type":"error"' "$out_file")"
+rm -f "$in_file"
+
+echo "qwen2-reset-gate: model=$(basename "$MODEL") max_seq=$MAX_SEQ cycles=$CYCLES -> ceiling_resets=$ceil tokens=$toks panics=$panic daemon_exit=$ec"
+echo "  (full daemon log: $out_file)"
+
+if [ "$ec" -ne 0 ] && [ "$ec" -ne 124 ]; then echo "qwen2-reset-gate: FAIL — daemon exit=$ec" >&2; exit 2; fi
+if [ "$panic" -ne 0 ]; then echo "qwen2-reset-gate: FAIL — daemon panic/error event" >&2; exit 1; fi
+if [ "$toks" -eq 0 ]; then echo "qwen2-reset-gate: FAIL — zero tokens generated" >&2; exit 2; fi
+if [ "$ceil" -ne 0 ]; then
+    echo "qwen2-reset-gate: FAIL — per-request reset no-op'd: next_pos accumulated and the max_seq=$MAX_SEQ ceiling auto-reset fired $ceil time(s) across $CYCLES reset+generate cycles. The reset handler is not rewinding the live ModelState::Qwen2 bundle state." >&2
+    exit 1
+fi
+echo "qwen2-reset-gate: PASS — $CYCLES reset+generate cycles at max_seq=$MAX_SEQ, ceiling never fired: reset rewinds next_pos." >&2
+exit 0


### PR DESCRIPTION
## Problem

The qwen2 (`arch_id=7`) daemon **`reset` command silently no-ops**: `next_pos` is
not rewound between requests, so prior-turn KV bleeds into new turns until the
`max_seq` ceiling auto-reset fires. This is the same **#462 bundle-migration
class** that `serve-loop-gate`/`serve-multiturn-gate` were created for — but those
gates only load qwen3.5/DeltaNet, so plain qwen2 slipped through.

Found while generating VibeThinker-3B drafter SFT rollouts (each request sends
`{"type":"reset"}` then `generate`): the daemon logged
`context full (12387/16384) — resetting Qwen2State.next_pos` repeatedly, which is
structurally impossible if the per-request reset worked — a single 4096-token
request can never reach the 16384 ceiling from `next_pos=0`.

## Root cause

`Qwen2Carrier` puts the live `Qwen2State` into `ModelState::Qwen2(bundle)`, and
`generate_qwen2` reads it from there. But the daemon's reset / VL-checkpoint /
bench-prefill handlers rewind the **legacy `m.qwen2_state` direct field**, which is
`None` for plain qwen2 (the `skeleton(...)` default) and is only populated by
**dots-ocr** (`arch_id=8`). So `if let Some(s) = m.qwen2_state { s.reset() }` never
runs for plain qwen2.

The bleed is invisible to attractor detection: each request re-sends the full
ChatML scaffold, so the model stays anchored to the latest turn and outputs remain
on-topic — only the `next_pos` accumulation (and eventual ceiling reset) reveals it.

## Fix

- Add `LoadedModel::qwen2_mut()` (mirrors `minimax_mut()` / `lfm2moe_mut()`).
- Rewind `b.state` at all three reset sites (reset command, VL checkpoint,
  bench-prefill), **preserving** the existing `m.qwen2_state` branch so dots-ocr
  keeps working.

## Regression guard

`scripts/qwen2-reset-gate.sh`: loads a small qwen2 model at a small `max_seq`, sends
N explicit `reset`+`generate` cycles, and fails if the daemon logs a ceiling
auto-reset (impossible under a working per-request reset). Wired into the
`.githooks/pre-commit` serve-gate block alongside the qwen3.5-only
`serve-loop-gate.sh`, closing the documented qwen2 coverage gap.

## Validation

| check | pre-fix | post-fix |
|-------|---------|----------|
| `qwen2-reset-gate.sh` (16 reset cycles, qwen2.5-0.5B, `max_seq=256`) | **7 ceiling resets → FAIL** | **0 → PASS** |
| `serve-loop-gate.sh` (qwen3.5-0.8B, 10 multi-req) | — | **PASS, 10/10 ok** (no regression) |

The added blocks are inert for non-qwen2 arches (`qwen2_mut()` → `None`), so
qwen3.5 / llama / etc. are byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
