### PR TITLE
feat(registry): add VibeThinker-3B (MQ4 + MQ6)

### DIFF
--- a/cli/registry.json
+++ b/cli/registry.json
@@ -465,6 +465,20 @@
         "presence_penalty": 1.5
       },
       "desc": "Qwen3.5-35B-A3B agentic MoE (nex-agi, SWE-bench Verified 74.4). 88 tok/s. T3-3L graded experts (MQ6/MQ4/MQ3L). Tool-use: qwen3 reasoning / qwen3_coder tool-call format."
+    },
+    "vibethinker:3b": {
+      "repo": "xfivetide/VibeThinker-3B-hipfire",
+      "file": "vibethinker-3b.mq4.hfq",
+      "size_gb": 1.82,
+      "min_vram_gb": 3.5,
+      "desc": "VibeThinker-3B (WeiboAI), Qwen2 MQ4. ~36-90 tok/s on gfx1151."
+    },
+    "vibethinker:3b-mq6": {
+      "repo": "xfivetide/VibeThinker-3B-hipfire",
+      "file": "vibethinker-3b.mq6.hfq",
+      "size_gb": 2.51,
+      "min_vram_gb": 5.0,
+      "desc": "VibeThinker-3B (WeiboAI), Qwen2 MQ6 6-bit. ~25-60 tok/s on gfx1151."
     }
   },
   "aliases": {
@@ -504,6 +518,7 @@
     "qwen3.5:9b:draft": "qwen3.5:9b-draft",
     "qwen3.5:27b:draft": "qwen3.5:27b-draft",
     "qwen3.6:27b:draft": "qwen3.6:27b-draft",
-    "qwen3.5:2b-mq4": "qwen3.5:2b"
+    "qwen3.5:2b-mq4": "qwen3.5:2b",
+    "vibethinker": "vibethinker:3b"
   }
 }

--- a/registry/v1.json
+++ b/registry/v1.json
@@ -707,6 +707,28 @@
       "size_bytes": 19820755200,
       "arch_id": 6,
       "quant": "mq4p"
+    },
+    "vibethinker:3b": {
+      "repo": "xfivetide/VibeThinker-3B-hipfire",
+      "file": "vibethinker-3b.mq4.hfq",
+      "size_gb": 1.82,
+      "min_vram_gb": 3.5,
+      "desc": "VibeThinker-3B (WeiboAI), Qwen2 MQ4. ~36-90 tok/s on gfx1151.",
+      "sha256": "b5e3f901a2ba5cab5f34051a9d711940edee5356f877e88a424e07ed4ddc6c1c",
+      "size_bytes": 1818198016,
+      "arch_id": 7,
+      "quant": "mq4"
+    },
+    "vibethinker:3b-mq6": {
+      "repo": "xfivetide/VibeThinker-3B-hipfire",
+      "file": "vibethinker-3b.mq6.hfq",
+      "size_gb": 2.51,
+      "min_vram_gb": 5.0,
+      "desc": "VibeThinker-3B (WeiboAI), Qwen2 MQ6 6-bit. ~25-60 tok/s on gfx1151.",
+      "sha256": "813a451d3aa90981776fccad3abd5d22fbbe96834e42c6d812fb158b14599048",
+      "size_bytes": 2511831040,
+      "arch_id": 7,
+      "quant": "mq6"
     }
   },
   "aliases": {
@@ -746,6 +768,7 @@
     "qwen3.5:9b:draft": "qwen3.5:9b-draft",
     "qwen3.5:27b:draft": "qwen3.5:27b-draft",
     "qwen3.6:27b:draft": "qwen3.6:27b-draft",
-    "qwen3.5:2b-mq4": "qwen3.5:2b"
+    "qwen3.5:2b-mq4": "qwen3.5:2b",
+    "vibethinker": "vibethinker:3b"
   }
 }

--- a/scripts/registry_gen.py
+++ b/scripts/registry_gen.py
@@ -175,6 +175,8 @@ def arch_id_for(tag: str, entry: dict) -> int | None:
         return 11
     if family == "north-mini-code":
         return 12
+    if family == "vibethinker":
+        return 7   # Qwen2 dense (WeiboAI/VibeThinker-3B base)
     return None
 
 


### PR DESCRIPTION
FWHT-rotated quantizations of [WeiboAI/VibeThinker-3B](https://huggingface.co/WeiboAI/VibeThinker-3B) (Qwen2ForCausalLM, arch_id=7).

**Files:**
- `vibethinker-3b.mq4.hfq` — MQ4G256, 1.82 GB, ~36-90 tok/s on gfx1151
- `vibethinker-3b.mq6.hfq` — MQ6G256, 2.51 GB, ~25-60 tok/s on gfx1151

**Changes:**
- Add `vibethinker:3b` and `vibethinker:3b-mq6` to curated registry
- Map vibethinker family → arch_id 7 in registry_gen.py
- Add `vibethinker` → `vibethinker:3b` alias
- Regenerate registry/v1.json with verified LFS sha256s