### PR TITLE
perf(deepseek4): i8-WMMA prefill kernels for gfx1151 (+22% full-quality prefill)

### DIFF
--- a/crates/hipfire-arch-deepseek4/examples/deepseek4_prefill_bench.rs
+++ b/crates/hipfire-arch-deepseek4/examples/deepseek4_prefill_bench.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Nick Woolmer
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! Prefill (prompt-processing) throughput benchmark for DeepSeek V4 Flash.
+//!
+//! Mirrors the antirez/ds4 "prefill t/s" number: process an N-token prompt
+//! at pos 0 in one `forward_prefill_batch_chunked` call and report
+//! tokens / wall-second. Does a throwaway warmup prefill first to JIT the
+//! kernels (a cold first chunk is 10×+ slower — see CLAUDE.md), then
+//! resets state and measures `--reps` times, reporting the median.
+//!
+//! Usage:
+//!   deepseek4_prefill_bench <model.mq2lloyd> [--prompt FILE] [--tokens N]
+//!       [--reps R] [--warmup W] [--batch B]
+//!
+//! Defaults: --tokens 7047 (antirez DGX-Spark prompt size), --reps 3,
+//!           --warmup 1, --batch 1024 (HIPFIRE_DEEPSEEK4_PP_BATCH).
+//!
+//! If the tokenized prompt is shorter than --tokens it is tiled to length;
+//! if longer it is truncated. This keeps the FLOP count fixed across runs
+//! so prefill throughput is comparable regardless of corpus.
+
+use hipfire_arch_deepseek4::{forward::forward_prefill_batch_chunked, DeepseekV4, DeepseekV4State};
+use hipfire_runtime::arch::Architecture;
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::tokenizer::Tokenizer;
+use rdna_compute::Gpu;
+use std::time::Instant;
+
+fn main() -> Result<(), String> {
+    let mut args = std::env::args().skip(1);
+    let model_path = args.next().unwrap_or_else(|| {
+        std::env::var("HIPFIRE_DEEPSEEK4_MODEL").unwrap_or_else(|_| {
+            "/home/bjoern/.hipfire/models/deepseek-v4-flash.mq2lloyd".to_string()
+        })
+    });
+
+    let mut prompt_file: Option<String> = None;
+    let mut variants: Vec<String> = vec!["default".to_string()];
+    let mut target_tokens: usize = 7047;
+    let mut reps: usize = 3;
+    let mut warmup: usize = 1;
+    let mut batches: Vec<usize> = vec![std::env::var("HIPFIRE_DEEPSEEK4_PP_BATCH")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1024)];
+    while let Some(flag) = args.next() {
+        match flag.as_str() {
+            "--prompt" => prompt_file = Some(args.next().expect("--prompt FILE")),
+            "--tokens" => target_tokens = args.next().expect("--tokens N").parse().unwrap(),
+            "--reps" => reps = args.next().expect("--reps R").parse().unwrap(),
+            "--warmup" => warmup = args.next().expect("--warmup W").parse().unwrap(),
+            "--batch" => {
+                batches = args
+                    .next()
+                    .expect("--batch B[,B2,...]")
+                    .split(',')
+                    .map(|s| s.parse().unwrap())
+                    .collect()
+            }
+            "--variants" => {
+                variants = args
+                    .next()
+                    .expect("--variants v1[,v2,...]")
+                    .split(',')
+                    .map(|s| s.to_string())
+                    .collect()
+            }
+            other => panic!("unknown flag: {other}"),
+        }
+    }
+
+    eprintln!("Loading DeepSeek V4 from {model_path}...");
+    let mut hfq =
+        HfqFile::open(std::path::Path::new(&model_path)).map_err(|e| format!("open: {e:?}"))?;
+    let cfg = DeepseekV4::config_from_hfq(&hfq)?;
+    let tokenizer = Tokenizer::from_hfq_metadata(&hfq.metadata_json)
+        .map_err(|e| format!("tokenizer: {e:?}"))?;
+
+    // Build a deterministic token sequence of exactly target_tokens length.
+    let base: Vec<u32> = if let Some(pf) = &prompt_file {
+        let text = std::fs::read_to_string(pf).map_err(|e| format!("read prompt: {e}"))?;
+        tokenizer.encode(&text)
+    } else {
+        // Default filler: tokenize a chunk of pangram-ish prose.
+        tokenizer.encode(
+            "The quick brown fox jumps over the lazy dog. \
+             Pack my box with five dozen liquor jugs. ",
+        )
+    };
+    assert!(!base.is_empty(), "empty prompt token stream");
+    let mut tokens: Vec<u32> = Vec::with_capacity(target_tokens);
+    while tokens.len() < target_tokens {
+        let take = (target_tokens - tokens.len()).min(base.len());
+        tokens.extend_from_slice(&base[..take]);
+    }
+    tokens.truncate(target_tokens);
+
+    let mut gpu = Gpu::init().map_err(|e| format!("gpu: {e:?}"))?;
+    eprintln!("GPU: {}", gpu.arch.clone());
+    let t_load = Instant::now();
+    let weights = DeepseekV4::load_weights(&mut hfq, &cfg, &mut gpu)?;
+    eprintln!("Loaded weights in {:.1}s", t_load.elapsed().as_secs_f64());
+    eprintln!(
+        "Config: layers={} hidden={} vocab={} window={} | prefill tokens={} batches={:?}",
+        cfg.num_hidden_layers,
+        cfg.hidden_size,
+        cfg.vocab_size,
+        cfg.sliding_window,
+        target_tokens,
+        batches
+    );
+
+    // Env vars that select MQ2-Lloyd grouped-GEMM variants in the dispatch.
+    const MOE_VARS: &[&str] = &[
+        "HIPFIRE_DEEPSEEK4_MOE_N32",
+        "HIPFIRE_DEEPSEEK4_MOE_CND",
+        "HIPFIRE_DEEPSEEK4_MOE_8W",
+        "HIPFIRE_DEEPSEEK4_MOE_MMQLOAD",
+        "HIPFIRE_DEEPSEEK4_MOE_NOSYNC",
+    ];
+    let apply_variant = |v: &str| {
+        for k in MOE_VARS {
+            std::env::remove_var(k);
+        }
+        let key = match v {
+            "default" | "4w" | "lloyd4w" => None,
+            "n32" => Some("HIPFIRE_DEEPSEEK4_MOE_N32"),
+            "cnd" => Some("HIPFIRE_DEEPSEEK4_MOE_CND"),
+            "8w" => Some("HIPFIRE_DEEPSEEK4_MOE_8W"),
+            "mmqload" => Some("HIPFIRE_DEEPSEEK4_MOE_MMQLOAD"),
+            "nosync" => Some("HIPFIRE_DEEPSEEK4_MOE_NOSYNC"),
+            other => panic!("unknown variant {other}"),
+        };
+        if let Some(k) = key {
+            std::env::set_var(k, "1");
+        }
+    };
+
+    for variant in &variants {
+        apply_variant(variant);
+        for &batch in &batches {
+            let pbs =
+                hipfire_arch_deepseek4::forward::PrefillBatchScratch::new(&mut gpu, &cfg, batch)?;
+
+            let run_once = |gpu: &mut Gpu| -> Result<f64, String> {
+                let mut state = DeepseekV4State::new(&cfg)?;
+                gpu.hip
+                    .device_synchronize()
+                    .map_err(|e| format!("pre-sync: {e:?}"))?;
+                let t = Instant::now();
+                let _ = forward_prefill_batch_chunked(
+                    &cfg, &weights, &mut state, gpu, &tokens, 0, &pbs,
+                )?;
+                gpu.hip
+                    .device_synchronize()
+                    .map_err(|e| format!("post-sync: {e:?}"))?;
+                Ok(t.elapsed().as_secs_f64())
+            };
+
+            for w in 0..warmup {
+                let s = run_once(&mut gpu)?;
+                eprintln!(
+                    "[batch {} warmup {}] {} tok in {:.3}s = {:.2} tok/s",
+                    batch,
+                    w,
+                    target_tokens,
+                    s,
+                    target_tokens as f64 / s
+                );
+            }
+
+            let mut secs: Vec<f64> = Vec::with_capacity(reps);
+            for r in 0..reps {
+                let s = run_once(&mut gpu)?;
+                eprintln!(
+                    "[batch {} measure {}] {} tok in {:.3}s = {:.2} tok/s",
+                    batch,
+                    r,
+                    target_tokens,
+                    s,
+                    target_tokens as f64 / s
+                );
+                secs.push(s);
+            }
+            secs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            let median = secs[secs.len() / 2];
+            let best = secs[0];
+            println!(
+            "PREFILL variant={} median {:.2} tok/s (best {:.2}) | {} tokens | batch {} | target=343 t/s",
+            variant,
+            target_tokens as f64 / median,
+            target_tokens as f64 / best,
+            target_tokens,
+            batch
+        );
+        }
+    }
+    Ok(())
+}

--- a/crates/hipfire-arch-deepseek4/src/forward.rs
+++ b/crates/hipfire-arch-deepseek4/src/forward.rs
@@ -243,62 +243,19 @@ fn gemv_auto_batched_wmma(
                 .map_err(|e| format!("gemm_f32_register_tiled: {e:?}"))
         }
         DType::Q8_0 => {
-            let wmma_on = std::env::var("HIPFIRE_DEEPSEEK4_Q8_WMMA")
-                .map(|s| s != "0")
-                .unwrap_or(true);
-            if wmma_on && gpu.arch_caps.is_rdna4() {
-                // RDNA4 (gfx12): upstream-tuned gating (unchanged).
-                if let Some(scratch) = x_f16_scratch {
-                    let n = (batch_size * k) as i64;
-                    gpu.deepseek4_convert_f32_to_f16(x_plain_batch, scratch, n)
-                        .map_err(|e| format!("convert_f32_to_f16 (Q8 WMMA): {e:?}"))?;
-                    let opt_out = std::env::var("HIPFIRE_DEEPSEEK4_Q8_4W").as_deref() == Ok("0");
-                    let use_4w = !opt_out
-                        && batch_size >= 256
-                        && m >= 4096
-                        && m % 64 == 0
-                        && k % 32 == 0
-                        && batch_size % 64 == 0;
-                    if use_4w {
-                        return gpu
-                            .gemm_q8_0_wmma_4w(weight, scratch, y, m, k, batch_size)
-                            .map_err(|e| format!("gemm_q8_0_wmma_4w: {e:?}"));
-                    }
-                    return gpu
-                        .gemm_q8_0_wmma(weight, scratch, y, m, k, batch_size)
-                        .map_err(|e| format!("gemm_q8_0_wmma: {e:?}"));
-                }
-            } else if wmma_on && gpu.arch_caps.has_wmma() && m % 64 == 0 && k % 32 == 0 {
-                // i8-MMQ 64×64 dense path (gfx1151): int8 weights direct + Q8_1
-                // activations + i8 WMMA at ~2x. ~1.4-1.56x over the f16 64×64
-                // kernel at the q-LoRA projection shapes (M=4096, batch≥256).
-                if gpu.arch == "gfx1151" && batch_size % 64 == 0 && k % 128 == 0 {
-                    return gpu
-                        .gemm_q8_0_mmq_4w_gfx1151(weight, x_plain_batch, y, m, k, batch_size)
-                        .map_err(|e| format!("gemm_q8_0_mmq_4w_gfx1151: {e:?}"));
-                }
-                // gfx11 / RDNA3.5 (gfx1151) Q8_0 WMMA prefill. The activation
-                // is pre-converted to F16 in `scratch`; the kernels honor the
-                // F16 dtype (no re-convert). 4-warp 64×64-tile kernel for
-                // batch%64==0 (~12% over single-warp 16×16; weight-bandwidth-
-                // bound); HIPFIRE_DEEPSEEK4_Q8_4W=0 forces single-warp.
-                if let Some(scratch) = x_f16_scratch {
-                    let n = (batch_size * k) as i64;
-                    gpu.deepseek4_convert_f32_to_f16(x_plain_batch, scratch, n)
-                        .map_err(|e| format!("convert_f32_to_f16 (Q8 WMMA): {e:?}"))?;
-                    let opt_out_4w = std::env::var("HIPFIRE_DEEPSEEK4_Q8_4W").as_deref() == Ok("0");
-                    if !opt_out_4w && batch_size >= 64 && batch_size % 64 == 0 {
-                        return gpu
-                            .gemm_q8_0_wmma_4w(weight, scratch, y, m, k, batch_size)
-                            .map_err(|e| format!("gemm_q8_0_wmma_4w: {e:?}"));
-                    }
-                    return gpu
-                        .gemm_q8_0_wmma(weight, scratch, y, m, k, batch_size)
-                        .map_err(|e| format!("gemm_q8_0_wmma: {e:?}"));
-                }
-            }
-            gpu.gemm_q8_0_batched_chunked(weight, x_plain_batch, y, m, k, batch_size)
-                .map_err(|e| format!("gemm_q8_0_batched_chunked: {e:?}"))
+            // Kernel selection (i8-MMQ / f16-WMMA / scalar) lives in the
+            // dispatch layer (rdna-compute), not here — the resolver reads arch
+            // caps + flags + shape. See `gemm_q8_0_wmma_prefill_auto`.
+            gpu.gemm_q8_0_wmma_prefill_auto(
+                weight,
+                x_plain_batch,
+                x_f16_scratch,
+                y,
+                m,
+                k,
+                batch_size,
+            )
+            .map_err(|e| format!("gemm_q8_0_wmma_prefill_auto: {e:?}"))
         }
         DType::F16 => {
             // gfx12/RDNA4: route through the VALIDATED gfx12 f16 WMMA kernel

--- a/crates/hipfire-arch-deepseek4/src/forward.rs
+++ b/crates/hipfire-arch-deepseek4/src/forward.rs
@@ -272,11 +272,7 @@ fn gemv_auto_batched_wmma(
                 // i8-MMQ 64×64 dense path (gfx1151): int8 weights direct + Q8_1
                 // activations + i8 WMMA at ~2x. ~1.4-1.56x over the f16 64×64
                 // kernel at the q-LoRA projection shapes (M=4096, batch≥256).
-                if std::env::var("HIPFIRE_DEEPSEEK4_Q8_I8").as_deref() == Ok("1")
-                    && gpu.arch == "gfx1151"
-                    && batch_size % 64 == 0
-                    && k % 128 == 0
-                {
+                if gpu.arch == "gfx1151" && batch_size % 64 == 0 && k % 128 == 0 {
                     return gpu
                         .gemm_q8_0_mmq_4w_gfx1151(weight, x_plain_batch, y, m, k, batch_size)
                         .map_err(|e| format!("gemm_q8_0_mmq_4w_gfx1151: {e:?}"));

--- a/crates/hipfire-arch-deepseek4/src/forward.rs
+++ b/crates/hipfire-arch-deepseek4/src/forward.rs
@@ -269,6 +269,18 @@ fn gemv_auto_batched_wmma(
                         .map_err(|e| format!("gemm_q8_0_wmma: {e:?}"));
                 }
             } else if wmma_on && gpu.arch_caps.has_wmma() && m % 64 == 0 && k % 32 == 0 {
+                // i8-MMQ 64×64 dense path (gfx1151): int8 weights direct + Q8_1
+                // activations + i8 WMMA at ~2x. ~1.4-1.56x over the f16 64×64
+                // kernel at the q-LoRA projection shapes (M=4096, batch≥256).
+                if std::env::var("HIPFIRE_DEEPSEEK4_Q8_I8").as_deref() == Ok("1")
+                    && gpu.arch == "gfx1151"
+                    && batch_size % 64 == 0
+                    && k % 128 == 0
+                {
+                    return gpu
+                        .gemm_q8_0_mmq_4w_gfx1151(weight, x_plain_batch, y, m, k, batch_size)
+                        .map_err(|e| format!("gemm_q8_0_mmq_4w_gfx1151: {e:?}"));
+                }
                 // gfx11 / RDNA3.5 (gfx1151) Q8_0 WMMA prefill. The activation
                 // is pre-converted to F16 in `scratch`; the kernels honor the
                 // F16 dtype (no re-convert). 4-warp 64×64-tile kernel for

--- a/crates/hipfire-dispatch/src/pipeline/mod.rs
+++ b/crates/hipfire-dispatch/src/pipeline/mod.rs
@@ -1581,6 +1581,10 @@ pub fn run_moe_decode_bias_aware(
 /// `Lloyd4w` on gfx11+, `Base` otherwise). Selected once per gate_up/down call.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum GroupedLloydVariant {
+    /// i8 WMMA MMQ path (gfx1151): decodes the 2-bit Lloyd index via an int8
+    /// codebook LUT and runs i8 WMMA at ~2x the FP16 rate. Top priority when
+    /// enabled — ~1.7x the FP16 grouped GEMM on the DeepSeek-V4 prefill shape.
+    I8,
     N32,
     Cnd,
     EightW,
@@ -1595,13 +1599,16 @@ enum GroupedLloydVariant {
 /// only on the 4w path; `use_nosync` ⊂ `use_mmqload` ⊂ `use_lloyd_4w`.
 fn select_grouped_lloyd_variant(
     use_lloyd_4w: bool,
+    i8: bool,
     n32: bool,
     cnd: bool,
     eightw: bool,
     use_mmqload: bool,
     use_nosync: bool,
 ) -> GroupedLloydVariant {
-    if use_lloyd_4w && n32 {
+    if i8 {
+        GroupedLloydVariant::I8
+    } else if use_lloyd_4w && n32 {
         GroupedLloydVariant::N32
     } else if use_lloyd_4w && cnd {
         GroupedLloydVariant::Cnd
@@ -1639,6 +1646,18 @@ fn dispatch_grouped_lloyd(
 ) -> Result<(), DispatchError> {
     use GroupedLloydVariant as V;
     let r = match variant {
+        V::I8 => gpu.gemm_mq2g256_lloyd_moe_grouped_mmq_gfx1151(
+            ptrs,
+            tile_ids,
+            slot_index,
+            x,
+            y,
+            m,
+            k,
+            x_row_div,
+            m_total_max,
+            rows,
+        ),
         V::N32 => gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_n32(
             ptrs,
             tile_ids,
@@ -1817,6 +1836,9 @@ pub fn run_moe_prefill_bias_aware(
     let eightw = std::env::var("HIPFIRE_DEEPSEEK4_MOE_8W").as_deref() == Ok("1");
     let mmqload_env = std::env::var("HIPFIRE_DEEPSEEK4_MOE_MMQLOAD").as_deref() == Ok("1");
     let nosync_env = std::env::var("HIPFIRE_DEEPSEEK4_MOE_NOSYNC").as_deref() == Ok("1");
+    // i8 MMQ path (gfx1151 only): 2-bit Lloyd → int8 codebook LUT + i8 WMMA.
+    let i8_moe = std::env::var("HIPFIRE_DEEPSEEK4_MOE_I8").as_deref() == Ok("1")
+        && gpu.arch.starts_with("gfx1151");
 
     if use_grouped {
         const BLOCK_M: usize = 16;
@@ -1841,8 +1863,11 @@ pub fn run_moe_prefill_bias_aware(
             lloyd_4w_base.unwrap_or(arch_4w) && (2 * im) % 64 == 0 && hidden % 256 == 0;
         let use_mmqload_gu = use_lloyd_4w_gu && mmqload_env;
         let use_nosync_gu = use_mmqload_gu && nosync_env;
+        // i8 path requires (2*im)%16==0 && hidden%256==0 (looser than 4w's %64).
+        let use_i8_gu = i8_moe && (2 * im) % 16 == 0 && hidden % 256 == 0;
         let v_gu = select_grouped_lloyd_variant(
             use_lloyd_4w_gu,
+            use_i8_gu,
             n32,
             cnd,
             eightw,
@@ -1905,8 +1930,10 @@ pub fn run_moe_prefill_bias_aware(
         let use_lloyd_4w_dn = lloyd_4w_base.unwrap_or(arch_4w) && hidden % 64 == 0 && im % 256 == 0;
         let use_mmqload_dn = use_lloyd_4w_dn && mmqload_env;
         let use_nosync_dn = use_mmqload_dn && nosync_env;
+        let use_i8_dn = i8_moe && hidden % 16 == 0 && im % 256 == 0;
         let v_dn = select_grouped_lloyd_variant(
             use_lloyd_4w_dn,
+            use_i8_dn,
             n32,
             cnd,
             eightw,

--- a/crates/hipfire-dispatch/src/pipeline/mod.rs
+++ b/crates/hipfire-dispatch/src/pipeline/mod.rs
@@ -1837,8 +1837,7 @@ pub fn run_moe_prefill_bias_aware(
     let mmqload_env = std::env::var("HIPFIRE_DEEPSEEK4_MOE_MMQLOAD").as_deref() == Ok("1");
     let nosync_env = std::env::var("HIPFIRE_DEEPSEEK4_MOE_NOSYNC").as_deref() == Ok("1");
     // i8 MMQ path (gfx1151 only): 2-bit Lloyd → int8 codebook LUT + i8 WMMA.
-    let i8_moe = std::env::var("HIPFIRE_DEEPSEEK4_MOE_I8").as_deref() == Ok("1")
-        && gpu.arch.starts_with("gfx1151");
+    let i8_moe = gpu.arch.starts_with("gfx1151");
 
     if use_grouped {
         const BLOCK_M: usize = 16;

--- a/crates/rdna-compute/examples/bench_mq2g256_lloyd_moe_4w.rs
+++ b/crates/rdna-compute/examples/bench_mq2g256_lloyd_moe_4w.rs
@@ -19,16 +19,20 @@ use std::time::Instant;
 
 const WARMUP: usize = 4;
 const TRIALS: usize = 30;
-const ATOL:   f32   = 1e-2;
-const RTOL:   f32   = 1e-2;
+const ATOL: f32 = 1e-2;
+const RTOL: f32 = 1e-2;
 
 fn f32_to_f16_bits(v: f32) -> u16 {
     let bits = v.to_bits();
     let sign = ((bits >> 16) & 0x8000) as u16;
-    let exp  = (((bits >> 23) & 0xff) as i32) - 127 + 15;
+    let exp = (((bits >> 23) & 0xff) as i32) - 127 + 15;
     let mant = (bits & 0x7fffff) as u32;
-    if exp <= 0  { return sign; }
-    if exp >= 31 { return sign | 0x7c00; }
+    if exp <= 0 {
+        return sign;
+    }
+    if exp >= 31 {
+        return sign | 0x7c00;
+    }
     sign | ((exp as u16) << 10) | ((mant >> 13) as u16)
 }
 
@@ -40,7 +44,12 @@ fn f32_to_f16_bytes(f: &[f32]) -> Vec<u8> {
     out
 }
 
-fn wrap_buf(raw_ptr: *mut std::ffi::c_void, bytes: usize, shape: Vec<usize>, dtype: DType) -> GpuTensor {
+fn wrap_buf(
+    raw_ptr: *mut std::ffi::c_void,
+    bytes: usize,
+    shape: Vec<usize>,
+    dtype: DType,
+) -> GpuTensor {
     GpuTensor {
         buf: unsafe { hip_bridge::DeviceBuffer::from_raw(raw_ptr, bytes) },
         shape,
@@ -66,7 +75,9 @@ fn quantize_mq2_lloyd(k: usize, rows: usize, seed: u64) -> Vec<u8> {
             for _ in 0..64 {
                 let mut byte = 0u8;
                 for nibble in 0..4 {
-                    rng = rng.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+                    rng = rng
+                        .wrapping_mul(6364136223846793005)
+                        .wrapping_add(1442695040888963407);
                     let idx = ((rng >> 48) & 0x3) as u8;
                     byte |= idx << (nibble * 2);
                 }
@@ -86,11 +97,11 @@ fn main() {
 
     // (M, K, batch, label) — batch is PP_BATCH; m_total = batch × TOP_K.
     let shapes: &[(usize, usize, usize, &str)] = &[
-        (2048, 4096, 128,  "gate/up B=128"),
-        (2048, 4096, 256,  "gate/up B=256"),
+        (2048, 4096, 128, "gate/up B=128"),
+        (2048, 4096, 256, "gate/up B=256"),
         (2048, 4096, 1024, "gate/up B=1024 (V4F prefill default)"),
-        (4096, 2048, 128,  "down B=128"),
-        (4096, 2048, 256,  "down B=256"),
+        (4096, 2048, 128, "down B=128"),
+        (4096, 2048, 256, "down B=256"),
         (4096, 2048, 1024, "down B=1024 (V4F prefill default)"),
     ];
 
@@ -122,7 +133,8 @@ fn main() {
         let w_gpu = gpu.hip.malloc(weight_bytes.len()).expect("malloc W");
         let x_gpu = gpu.hip.malloc(x_f32_bytes.len()).expect("malloc X");
         let yref_gpu = gpu.hip.malloc(m_total * m * 4).expect("malloc Yref");
-        let y4w_gpu  = gpu.hip.malloc(m_total * m * 4).expect("malloc Y4w");
+        let y4w_gpu = gpu.hip.malloc(m_total * m * 4).expect("malloc Y4w");
+        let ymmq_gpu = gpu.hip.malloc(m_total * m * 4).expect("malloc Ymmq");
         gpu.hip.memcpy_htod(&w_gpu, &weight_bytes).expect("htod W");
         gpu.hip.memcpy_htod(&x_gpu, &x_f32_bytes).expect("htod X");
 
@@ -138,7 +150,9 @@ fn main() {
             .flat_map(|_| 0i32.to_le_bytes().to_vec())
             .collect();
         let tp_gpu = gpu.hip.malloc(tile_ids_bytes.len()).expect("malloc TP");
-        gpu.hip.memcpy_htod(&tp_gpu, &tile_ids_bytes).expect("htod TP");
+        gpu.hip
+            .memcpy_htod(&tp_gpu, &tile_ids_bytes)
+            .expect("htod TP");
 
         // sorted_slot_index = identity
         let perm_bytes: Vec<u8> = (0..m_total)
@@ -149,44 +163,83 @@ fn main() {
 
         // Wrap as GpuTensor for the dispatch fn.
         let ep_t = wrap_buf(ep_gpu.as_ptr(), 8, vec![1], DType::F32);
-        let tp_t = wrap_buf(tp_gpu.as_ptr(), tile_ids_bytes.len(), vec![slot_tiles], DType::F32);
+        let tp_t = wrap_buf(
+            tp_gpu.as_ptr(),
+            tile_ids_bytes.len(),
+            vec![slot_tiles],
+            DType::F32,
+        );
         let sp_t = wrap_buf(sp_gpu.as_ptr(), perm_bytes.len(), vec![m_total], DType::F32);
-        let x_t  = wrap_buf(x_gpu.as_ptr(),  x_f32_bytes.len(), vec![m_total, k], DType::F32);
-        let yref_t = wrap_buf(yref_gpu.as_ptr(), m_total * m * 4, vec![m_total, m], DType::F32);
-        let y4w_t  = wrap_buf(y4w_gpu.as_ptr(),  m_total * m * 4, vec![m_total, m], DType::F32);
+        let x_t = wrap_buf(
+            x_gpu.as_ptr(),
+            x_f32_bytes.len(),
+            vec![m_total, k],
+            DType::F32,
+        );
+        let yref_t = wrap_buf(
+            yref_gpu.as_ptr(),
+            m_total * m * 4,
+            vec![m_total, m],
+            DType::F32,
+        );
+        let y4w_t = wrap_buf(
+            y4w_gpu.as_ptr(),
+            m_total * m * 4,
+            vec![m_total, m],
+            DType::F32,
+        );
+        let ymmq_t = wrap_buf(
+            ymmq_gpu.as_ptr(),
+            m_total * m * 4,
+            vec![m_total, m],
+            DType::F32,
+        );
 
         // ── Correctness pass: baseline vs 4w, element-wise compare.
         gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_k2(
             &ep_t, &tp_t, &sp_t, &x_t, &yref_t, m, k, 1, m_total, m_total,
-        ).expect("baseline");
+        )
+        .expect("baseline");
         gpu.hip.device_synchronize().expect("sync");
         gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2(
             &ep_t, &tp_t, &sp_t, &x_t, &y4w_t, m, k, 1, m_total, m_total,
-        ).expect("4w");
+        )
+        .expect("4w");
         gpu.hip.device_synchronize().expect("sync");
 
         let mut y_ref_bytes = vec![0u8; m_total * m * 4];
-        let mut y_4w_bytes  = vec![0u8; m_total * m * 4];
-        gpu.hip.memcpy_dtoh(&mut y_ref_bytes, &yref_gpu).expect("dtoh ref");
-        gpu.hip.memcpy_dtoh(&mut y_4w_bytes,  &y4w_gpu).expect("dtoh 4w");
-        let y_ref: &[f32] = unsafe {
-            std::slice::from_raw_parts(y_ref_bytes.as_ptr() as *const f32, m_total * m)
-        };
-        let y_4w: &[f32]  = unsafe {
-            std::slice::from_raw_parts(y_4w_bytes.as_ptr()  as *const f32, m_total * m)
-        };
+        let mut y_4w_bytes = vec![0u8; m_total * m * 4];
+        gpu.hip
+            .memcpy_dtoh(&mut y_ref_bytes, &yref_gpu)
+            .expect("dtoh ref");
+        gpu.hip
+            .memcpy_dtoh(&mut y_4w_bytes, &y4w_gpu)
+            .expect("dtoh 4w");
+        let y_ref: &[f32] =
+            unsafe { std::slice::from_raw_parts(y_ref_bytes.as_ptr() as *const f32, m_total * m) };
+        let y_4w: &[f32] =
+            unsafe { std::slice::from_raw_parts(y_4w_bytes.as_ptr() as *const f32, m_total * m) };
 
         let mut max_abs = 0f32;
         let mut max_rel = 0f32;
         let mut bad = 0usize;
         let mut nan_count = 0usize;
         for i in 0..(m_total * m) {
-            if !y_4w[i].is_finite() { nan_count += 1; continue; }
+            if !y_4w[i].is_finite() {
+                nan_count += 1;
+                continue;
+            }
             let d = (y_ref[i] - y_4w[i]).abs();
             let r = d / y_ref[i].abs().max(1e-6);
-            if d > max_abs { max_abs = d; }
-            if r > max_rel { max_rel = r; }
-            if d > ATOL && r > RTOL { bad += 1; }
+            if d > max_abs {
+                max_abs = d;
+            }
+            if r > max_rel {
+                max_rel = r;
+            }
+            if d > ATOL && r > RTOL {
+                bad += 1;
+            }
         }
         let ok = bad == 0 && nan_count == 0;
         println!(
@@ -196,8 +249,13 @@ fn main() {
         );
         if !ok {
             println!("  ✗ CORRECTNESS FAIL — skipping perf");
-            std::mem::forget(ep_t); std::mem::forget(tp_t); std::mem::forget(sp_t);
-            std::mem::forget(x_t); std::mem::forget(yref_t); std::mem::forget(y4w_t);
+            std::mem::forget(ep_t);
+            std::mem::forget(tp_t);
+            std::mem::forget(sp_t);
+            std::mem::forget(x_t);
+            std::mem::forget(yref_t);
+            std::mem::forget(y4w_t);
+            std::mem::forget(ymmq_t);
             continue;
         }
 
@@ -205,14 +263,16 @@ fn main() {
         for _ in 0..WARMUP {
             gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_k2(
                 &ep_t, &tp_t, &sp_t, &x_t, &yref_t, m, k, 1, m_total, m_total,
-            ).unwrap();
+            )
+            .unwrap();
         }
         gpu.hip.device_synchronize().unwrap();
         let t0 = Instant::now();
         for _ in 0..TRIALS {
             gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_k2(
                 &ep_t, &tp_t, &sp_t, &x_t, &yref_t, m, k, 1, m_total, m_total,
-            ).unwrap();
+            )
+            .unwrap();
         }
         gpu.hip.device_synchronize().unwrap();
         let ref_us = t0.elapsed().as_secs_f64() / TRIALS as f64 * 1e6;
@@ -220,14 +280,16 @@ fn main() {
         for _ in 0..WARMUP {
             gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2(
                 &ep_t, &tp_t, &sp_t, &x_t, &y4w_t, m, k, 1, m_total, m_total,
-            ).unwrap();
+            )
+            .unwrap();
         }
         gpu.hip.device_synchronize().unwrap();
         let t0 = Instant::now();
         for _ in 0..TRIALS {
             gpu.gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2(
                 &ep_t, &tp_t, &sp_t, &x_t, &y4w_t, m, k, 1, m_total, m_total,
-            ).unwrap();
+            )
+            .unwrap();
         }
         gpu.hip.device_synchronize().unwrap();
         let new_us = t0.elapsed().as_secs_f64() / TRIALS as f64 * 1e6;
@@ -241,7 +303,62 @@ fn main() {
              4w (64x16):    {new_us:>8.1} µs ({new_gflops:>6.0} GFLOPS)   speedup: {speedup:.2}×"
         );
 
-        std::mem::forget(ep_t); std::mem::forget(tp_t); std::mem::forget(sp_t);
-        std::mem::forget(x_t); std::mem::forget(yref_t); std::mem::forget(y4w_t);
+        // ── i8-MMQ variant: correctness (RMS-rel vs f16) + perf.
+        gpu.gemm_mq2g256_lloyd_moe_grouped_mmq_gfx1151(
+            &ep_t, &tp_t, &sp_t, &x_t, &ymmq_t, m, k, 1, m_total, m_total,
+        )
+        .expect("mmq");
+        gpu.hip.device_synchronize().expect("sync mmq");
+        let mut y_mmq_bytes = vec![0u8; m_total * m * 4];
+        gpu.hip
+            .memcpy_dtoh(&mut y_mmq_bytes, &ymmq_gpu)
+            .expect("dtoh mmq");
+        let y_mmq: &[f32] =
+            unsafe { std::slice::from_raw_parts(y_mmq_bytes.as_ptr() as *const f32, m_total * m) };
+        let (mut num, mut den, mut nan2) = (0f64, 0f64, 0usize);
+        for i in 0..(m_total * m) {
+            if !y_mmq[i].is_finite() {
+                nan2 += 1;
+                continue;
+            }
+            num += ((y_mmq[i] - y_ref[i]) as f64).powi(2);
+            den += (y_ref[i] as f64).powi(2);
+        }
+        let rms_rel = (num / den.max(1e-12)).sqrt();
+        for _ in 0..WARMUP {
+            gpu.gemm_mq2g256_lloyd_moe_grouped_mmq_gfx1151(
+                &ep_t, &tp_t, &sp_t, &x_t, &ymmq_t, m, k, 1, m_total, m_total,
+            )
+            .unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+        let t0 = Instant::now();
+        for _ in 0..TRIALS {
+            gpu.gemm_mq2g256_lloyd_moe_grouped_mmq_gfx1151(
+                &ep_t, &tp_t, &sp_t, &x_t, &ymmq_t, m, k, 1, m_total, m_total,
+            )
+            .unwrap();
+        }
+        gpu.hip.device_synchronize().unwrap();
+        let mmq_us = t0.elapsed().as_secs_f64() / TRIALS as f64 * 1e6;
+        let mmq_gflops = flops / mmq_us / 1e3;
+        println!(
+            "  i8-mmq:        {mmq_us:>8.1} µs ({mmq_gflops:>6.0} GFLOPS)   \
+             vs-4w: {:.2}×   rms_rel_vs_f16={rms_rel:.4} nan={nan2} {}",
+            new_us / mmq_us,
+            if rms_rel < 0.05 && nan2 == 0 {
+                "OK"
+            } else {
+                "CHECK"
+            }
+        );
+
+        std::mem::forget(ep_t);
+        std::mem::forget(tp_t);
+        std::mem::forget(sp_t);
+        std::mem::forget(x_t);
+        std::mem::forget(yref_t);
+        std::mem::forget(y4w_t);
+        std::mem::forget(ymmq_t);
     }
 }

--- a/crates/rdna-compute/examples/bench_q8_wmma_4w.rs
+++ b/crates/rdna-compute/examples/bench_q8_wmma_4w.rs
@@ -182,6 +182,42 @@ fn main() {
              4w (64x64):    {new_us:7.1} µs ({new_gflops:6.1} GFLOPS)   speedup: {speedup:.2}×"
         );
 
+        // ── i8-MMQ 64x64 4-warp dense Q8 kernel (F32 X, auto-quant to Q8_1).
+        if k % 128 == 0 {
+            let xf32_gpu = gpu.hip.malloc(x_f32.len() * 4).expect("malloc Xf32");
+            let xf32_bytes: Vec<u8> = x_f32.iter().flat_map(|v| v.to_le_bytes()).collect();
+            gpu.hip.memcpy_htod(&xf32_gpu, &xf32_bytes).expect("htod Xf32");
+            let xf32_tensor = wrap_buf(xf32_gpu.as_ptr(), x_f32.len() * 4, vec![n, k], DType::F32);
+            let yi8_gpu = gpu.hip.malloc(n * m * 4).expect("malloc Yi8");
+            let yi8_tensor = wrap_buf(yi8_gpu.as_ptr(), n * m * 4, vec![n, m], DType::F32);
+            gpu.gemm_q8_0_mmq_4w_gfx1151(&a_tensor, &xf32_tensor, &yi8_tensor, m, k, n)
+                .expect("i8 4w");
+            gpu.hip.device_synchronize().unwrap();
+            let mut yb = vec![0u8; n * m * 4];
+            gpu.hip.memcpy_dtoh(&mut yb, &yi8_gpu).unwrap();
+            let yi8: &[f32] = unsafe { std::slice::from_raw_parts(yb.as_ptr() as *const f32, n * m) };
+            let (mut num, mut den, mut nn) = (0f64, 0f64, 0usize);
+            for i in 0..n * m {
+                if !yi8[i].is_finite() { nn += 1; continue; }
+                num += ((yi8[i] - y_ref[i]) as f64).powi(2);
+                den += (y_ref[i] as f64).powi(2);
+            }
+            let rms = (num / den.max(1e-12)).sqrt();
+            for _ in 0..WARMUP { gpu.gemm_q8_0_mmq_4w_gfx1151(&a_tensor, &xf32_tensor, &yi8_tensor, m, k, n).unwrap(); }
+            gpu.hip.device_synchronize().unwrap();
+            let t0 = Instant::now();
+            for _ in 0..TRIALS { gpu.gemm_q8_0_mmq_4w_gfx1151(&a_tensor, &xf32_tensor, &yi8_tensor, m, k, n).unwrap(); }
+            gpu.hip.device_synchronize().unwrap();
+            let i8_us = t0.elapsed().as_secs_f64() / TRIALS as f64 * 1e6;
+            println!(
+                "  i8-mmq-4w:     {i8_us:7.1} µs ({:6.1} GFLOPS)   vs-4w: {:.2}×   rms_rel={rms:.4} nan={nn} {}",
+                flops / i8_us / 1e3, new_us / i8_us,
+                if rms < 0.05 && nn == 0 { "OK" } else { "CHECK" }
+            );
+            std::mem::forget(xf32_tensor);
+            std::mem::forget(yi8_tensor);
+        }
+
         // forget views to avoid double-free
         std::mem::forget(a_tensor);
         std::mem::forget(x_tensor);

--- a/crates/rdna-compute/src/feature_flags.rs
+++ b/crates/rdna-compute/src/feature_flags.rs
@@ -88,6 +88,14 @@ pub struct FeatureFlags {
     pub deterministic: bool,
     pub mw16: bool,
     pub q8_batched_legacy: bool,
+    /// `HIPFIRE_DEEPSEEK4_Q8_WMMA=0` disables the Q8_0 dense WMMA prefill path
+    /// (forces the scalar chunked fallback). Consumed by
+    /// `gemm_q8_0_wmma_prefill_auto`.
+    pub deepseek4_q8_wmma_off: bool,
+    /// `HIPFIRE_DEEPSEEK4_Q8_4W=0` forces the single-warp 16×16 Q8_0 WMMA
+    /// kernel instead of the 4-warp 64×64 tile. Consumed by
+    /// `gemm_q8_0_wmma_prefill_auto`.
+    pub deepseek4_q8_4w_off: bool,
     pub rope_interleaved_legacy: bool,
     pub wo_wmma_variant: Option<String>,
 
@@ -242,6 +250,8 @@ impl FeatureFlags {
             deterministic: std::env::var("HIPFIRE_DETERMINISTIC").ok().as_deref() == Some("1"),
             mw16: std::env::var("HIPFIRE_MW16").map_or(false, |v| v == "1"),
             q8_batched_legacy: std::env::var("HIPFIRE_Q8_BATCHED_LEGACY").as_deref() == Ok("1"),
+            deepseek4_q8_wmma_off: std::env::var("HIPFIRE_DEEPSEEK4_Q8_WMMA").as_deref() == Ok("0"),
+            deepseek4_q8_4w_off: std::env::var("HIPFIRE_DEEPSEEK4_Q8_4W").as_deref() == Ok("0"),
             rope_interleaved_legacy: std::env::var("HIPFIRE_ROPE_INTERLEAVED_LEGACY")
                 .ok()
                 .as_deref()
@@ -396,6 +406,8 @@ impl FeatureFlags {
             deterministic: false,
             mw16: false,
             q8_batched_legacy: false,
+            deepseek4_q8_wmma_off: false,
+            deepseek4_q8_4w_off: false,
             rope_interleaved_legacy: false,
             wo_wmma_variant: None,
             rocblas_all_archs: false,

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -10729,6 +10729,87 @@ impl Gpu {
         result
     }
 
+    /// gfx1151 i8 MMQ MoE grouped GEMM for MQ2-Lloyd weights. Drop-in for the
+    /// FP16 `gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2` (same args + trailing
+    /// `x_src_rows`): X is auto-quantized to Q8_1, the 2-bit Lloyd index is
+    /// decoded via an in-kernel int8-codebook LUT, and i8 WMMA runs at ~2x the
+    /// FP16 rate. Opt-in via `HIPFIRE_DEEPSEEK4_MOE_I8=1`.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemm_mq2g256_lloyd_moe_grouped_mmq_gfx1151(
+        &mut self,
+        expert_weight_ptrs: &GpuTensor, // [E] u64
+        expert_tile_ids: &GpuTensor,    // [m_total / 16] i32
+        sorted_slot_index: &GpuTensor,  // [m_total] i32
+        x_src: &GpuTensor,              // [x_src_rows × K] f32 (auto-converted to Q8_1)
+        y_grouped: &GpuTensor,          // [m_total × M] f32, written direct
+        m: usize,
+        k: usize,
+        x_row_div: usize,
+        m_total: usize,
+        x_src_rows: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        let kernel_name = "gemm_mq2g256_lloyd_moe_grouped_mmq_gfx1151";
+        let kernel_src = kernels::GEMM_MQ2G256_LLOYD_MOE_GROUPED_MMQ_GFX1151_SRC;
+        self.ensure_kernel(kernel_name, kernel_src, kernel_name)?;
+        // Q8_1 pre-pass (reuses the shared MMQ X scratch).
+        let x_q8_ptr = self.ensure_q8_1_mmq_x(x_src, x_src_rows, k)?;
+
+        let ep = expert_weight_ptrs.buf.as_ptr();
+        let tp = expert_tile_ids.buf.as_ptr();
+        let sp = sorted_slot_index.buf.as_ptr();
+        let xp = x_q8_ptr;
+        let yp = y_grouped.buf.as_ptr();
+        let m_val = m as i32;
+        let k_val = k as i32;
+        let xrd_val = x_row_div as i32;
+        let mt_val = m_total as i32;
+        let xsr_val = x_src_rows as i32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &ep as *const _ as *mut c_void,
+            &tp as *const _ as *mut c_void,
+            &sp as *const _ as *mut c_void,
+            &xp as *const _ as *mut c_void,
+            &yp as *const _ as *mut c_void,
+            &m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+            &xrd_val as *const _ as *mut c_void,
+            &mt_val as *const _ as *mut c_void,
+            &xsr_val as *const _ as *mut c_void,
+        ];
+
+        let row_tiles = ((m + 15) / 16) as u32;
+        let slot_tiles = ((m_total + 15) / 16) as u32;
+        let bytes = (m_total * k) + (m_total * m) * 4;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", kernel_name, bytes);
+        let result = self.launch_maybe_blob(
+            kernel_name,
+            [row_tiles, slot_tiles, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(ep);
+                b.push_ptr(tp);
+                b.push_ptr(sp);
+                b.push_ptr(xp);
+                b.push_ptr(yp);
+                b.push_i32(m_val);
+                b.push_i32(k_val);
+                b.push_i32(xrd_val);
+                b.push_i32(mt_val);
+                b.push_i32(xsr_val);
+                b
+            },
+        );
+        if let Some(t) = timer {
+            t.finish(&self.hip);
+        }
+        result
+    }
+
     /// gfx1151 (Strix Halo iGPU) i8 MMQ MoE grouped GEMM — k4 (deeper
     /// K-tile pipeline) variant. Drop-in for `gemm_hfq4g256_moe_grouped_mmq_gfx1151`
     /// — same kernarg layout, same grid/block geometry, same scatter

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -17548,6 +17548,68 @@ impl Gpu {
         Ok(())
     }
 
+    /// Resolve and dispatch the Q8_0 dense prefill GEMM (`Y[N,M] = X[N,K] @
+    /// A_q8[M,K]^T`). Picks the i8-MMQ / f16-WMMA / scalar-chunked kernel from
+    /// arch caps, feature flags, and shape — so arch forward passes carry no
+    /// kernel-selection knowledge (mirrors the minimax dense path, which calls
+    /// `gemm_q8_0_batched_chunked` blind).
+    ///
+    /// `x` is the plain F32 activation batch. `x_f16_scratch` is a caller-owned
+    /// F16 staging tensor the f16-WMMA kernels require; the i8-MMQ kernel reads
+    /// the int8 weights directly and quantizes `x` internally, and the scalar
+    /// chunked fallback takes F32 — both ignore the scratch.
+    #[allow(clippy::too_many_arguments)]
+    pub fn gemm_q8_0_wmma_prefill_auto(
+        &mut self,
+        weight: &GpuTensor,
+        x: &GpuTensor,
+        x_f16_scratch: Option<&GpuTensor>,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        n: usize,
+    ) -> HipResult<()> {
+        let wmma_on = !self.flags.deepseek4_q8_wmma_off;
+        if wmma_on && self.arch_caps.is_rdna4() {
+            // RDNA4 (gfx12): upstream-tuned gating.
+            if let Some(scratch) = x_f16_scratch {
+                let nn = (n * k) as i64;
+                self.deepseek4_convert_f32_to_f16(x, scratch, nn)?;
+                let use_4w = !self.flags.deepseek4_q8_4w_off
+                    && n >= 256
+                    && m >= 4096
+                    && m % 64 == 0
+                    && k % 32 == 0
+                    && n % 64 == 0;
+                if use_4w {
+                    return self.gemm_q8_0_wmma_4w(weight, scratch, y, m, k, n);
+                }
+                return self.gemm_q8_0_wmma(weight, scratch, y, m, k, n);
+            }
+        } else if wmma_on && self.arch_caps.has_wmma() && m % 64 == 0 && k % 32 == 0 {
+            // i8-MMQ 64×64 dense path (gfx1151): int8 weights direct + Q8_1
+            // activations + i8 WMMA at ~2x. ~1.4-1.56x over the f16 64×64 kernel
+            // at the q-LoRA projection shapes (M=4096, batch≥256).
+            if self.arch == "gfx1151" && n % 64 == 0 && k % 128 == 0 {
+                return self.gemm_q8_0_mmq_4w_gfx1151(weight, x, y, m, k, n);
+            }
+            // gfx11 / RDNA3.5 (gfx1151) Q8_0 WMMA prefill. The activation is
+            // pre-converted to F16 in `scratch`; the kernels honor the F16 dtype
+            // (no re-convert). 4-warp 64×64-tile kernel for batch%64==0 (~12%
+            // over single-warp 16×16; weight-bandwidth-bound); the 4w opt-out
+            // forces single-warp.
+            if let Some(scratch) = x_f16_scratch {
+                let nn = (n * k) as i64;
+                self.deepseek4_convert_f32_to_f16(x, scratch, nn)?;
+                if !self.flags.deepseek4_q8_4w_off && n >= 64 && n % 64 == 0 {
+                    return self.gemm_q8_0_wmma_4w(weight, scratch, y, m, k, n);
+                }
+                return self.gemm_q8_0_wmma(weight, scratch, y, m, k, n);
+            }
+        }
+        self.gemm_q8_0_batched_chunked(weight, x, y, m, k, n)
+    }
+
     /// WMMA Q8_0 GEMM (no residual). Y[N, M] = X[N, K] @ A_q8[M, K]^T.
     /// gfx12 (RDNA4) only. Drop-in replacement for `gemm_q8_0_batched`;
     /// the scalar 1-wave-per-row kernel was 65% of A3B prefill GPU time

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -19668,6 +19668,64 @@ impl Gpu {
         }
         result
     }
+    /// Dense i8-WMMA MMQ GEMM for Q8_0 weights — 64x64 4-warp tile (gfx1151).
+    /// Takes F32 `x` (auto-quantized to Q8_1), int8 WMMA at ~2x. Drop-in for
+    /// `gemm_q8_0_wmma_4w`. Requires M%64==0, N%64==0, K%128==0.
+    pub fn gemm_q8_0_mmq_4w_gfx1151(
+        &mut self,
+        a: &GpuTensor,
+        x: &GpuTensor,
+        y: &GpuTensor,
+        m: usize,
+        k: usize,
+        batch_size: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        let kernel_name = "gemm_q8_0_mmq_4w_gfx1151";
+        self.ensure_kernel(kernel_name, kernels::GEMM_Q8_0_MMQ_4W_GFX1151_SRC, kernel_name)?;
+        let x_q8_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
+
+        let ap = a.buf.as_ptr();
+        let xp = x_q8_ptr;
+        let yp = y.buf.as_ptr();
+        let m_val = m as i32;
+        let k_val = k as i32;
+        let n_val = batch_size as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &ap as *const _ as *mut c_void,
+            &xp as *const _ as *mut c_void,
+            &yp as *const _ as *mut c_void,
+            &m_val as *const _ as *mut c_void,
+            &k_val as *const _ as *mut c_void,
+            &n_val as *const _ as *mut c_void,
+        ];
+        let row_tiles = ((m + 63) / 64) as u32;
+        let col_tiles = ((batch_size + 63) / 64) as u32;
+        let bytes = (m * k) + (batch_size * m) * 4;
+        let timer = crate::profile::begin_timer(&self.hip, "gemm", kernel_name, bytes);
+        let result = self.launch_maybe_blob(
+            kernel_name,
+            [row_tiles, col_tiles, 1],
+            [128, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(ap);
+                b.push_ptr(xp);
+                b.push_ptr(yp);
+                b.push_i32(m_val);
+                b.push_i32(k_val);
+                b.push_i32(n_val);
+                b
+            },
+        );
+        if let Some(t) = timer {
+            t.finish(&self.hip);
+        }
+        result
+    }
+
     pub fn gemm_q8_0_wmma_4w(
         &mut self,
         a: &GpuTensor,

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -10733,7 +10733,7 @@ impl Gpu {
     /// FP16 `gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2` (same args + trailing
     /// `x_src_rows`): X is auto-quantized to Q8_1, the 2-bit Lloyd index is
     /// decoded via an in-kernel int8-codebook LUT, and i8 WMMA runs at ~2x the
-    /// FP16 rate. Opt-in via `HIPFIRE_DEEPSEEK4_MOE_I8=1`.
+    /// FP16 rate. Default path on gfx1151 (no env gate).
     #[allow(clippy::too_many_arguments)]
     pub fn gemm_mq2g256_lloyd_moe_grouped_mmq_gfx1151(
         &mut self,
@@ -19682,7 +19682,11 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         let kernel_name = "gemm_q8_0_mmq_4w_gfx1151";
-        self.ensure_kernel(kernel_name, kernels::GEMM_Q8_0_MMQ_4W_GFX1151_SRC, kernel_name)?;
+        self.ensure_kernel(
+            kernel_name,
+            kernels::GEMM_Q8_0_MMQ_4W_GFX1151_SRC,
+            kernel_name,
+        )?;
         let x_q8_ptr = self.ensure_q8_1_mmq_x(x, batch_size, k)?;
 
         let ap = a.buf.as_ptr();

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -3554,6 +3554,13 @@ pub const GEMM_MQ2G256_LLOYD_MOE_GROUPED_WMMA_K2_SRC: &str =
 pub const GEMM_MQ2G256_LLOYD_MOE_GROUPED_WMMA_4W_K2_SRC: &str =
     include_str!("../../../kernels/src/gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2.hip");
 
+/// i8 WMMA MMQ MoE grouped-GEMM for MQ2-Lloyd weights on gfx1151. Decodes the
+/// 2-bit Lloyd index via an in-kernel int8-codebook LUT and runs i8 WMMA at
+/// ~2x the FP16 rate. Drop-in for the FP16 `_4w_k2` sibling (same kernarg
+/// layout + trailing x_src_rows).
+pub const GEMM_MQ2G256_LLOYD_MOE_GROUPED_MMQ_GFX1151_SRC: &str =
+    include_str!("../../../kernels/src/gemm_mq2g256_lloyd_moe_grouped_mmq.gfx1151.hip");
+
 pub const GEMM_MQ2G256_LLOYD_MOE_GROUPED_WMMA_4W_K2_N32_SRC: &str =
     include_str!("../../../kernels/src/gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2_n32.hip");
 

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -1698,6 +1698,12 @@ pub const MOE_UNSCATTER_SILU_CLAMP_K8_SRC: &str =
 /// reuse per block vs the single-warp 16×16 kernel.
 pub const GEMM_Q8_0_WMMA_4W_SRC: &str = include_str!("../../../kernels/src/gemm_q8_0_wmma_4w.hip");
 
+/// Dense i8-WMMA MMQ GEMM for Q8_0 weights — 4-warp 64x64 tile (gfx1151). i8
+/// port of gemm_q8_0_wmma_4w: int8 weights direct + Q8_1 activations + i8 WMMA
+/// at ~2x. Y[N,M] = X[N,K] @ W[M,K]^T. Requires M%64==0, N%64==0, K%128==0.
+pub const GEMM_Q8_0_MMQ_4W_GFX1151_SRC: &str =
+    include_str!("../../../kernels/src/gemm_q8_0_mmq_4w.gfx1151.hip");
+
 /// Path 2 combine for down: per (token, m) iterates K_TOP slots via
 /// `inverse_perm[token*K_TOP + k]`, applies topk_weights, and += into
 /// x_residual. No atomic contention (each token's m column is owned by

--- a/kernels/src/gemm_mq2g256_lloyd_moe_grouped_mmq.gfx1151.hip
+++ b/kernels/src/gemm_mq2g256_lloyd_moe_grouped_mmq.gfx1151.hip
@@ -1,0 +1,206 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// i8 WMMA MMQ MoE grouped-GEMM for MQ2-Lloyd weights on gfx1151 (Strix Halo).
+//
+// Twin of `gemm_hfq4g256_moe_grouped_mmq.gfx1151.hip`, adapted to the
+// MQ2-Lloyd weight format. The FP16-WMMA MQ2-Lloyd kernel
+// (`gemm_mq2g256_lloyd_moe_grouped_wmma_4w_k2`) is DEQUANT-bound: at the
+// DeepSeek-V4 prefill shape it runs ~6.9 TFLOP/s vs ~15 TFLOP/s for the
+// trivial-dequant Q8 path — the entire gap is the per-weight Lloyd bilinear
+// decode (`cb0 + qlo*d01 + qhi*d02 + qlo*qhi*d_xor`, ~12 ALU ops/weight) which
+// shares the VALU issue port with the WMMA on RDNA3.
+//
+// This variant kills both costs:
+//   1. Per group, quantize the 4-entry f16 Lloyd codebook to int8 + a single
+//      f32 group scale ONCE (amortized over 256 weights/group), then decode
+//      each 2-bit index via a byte-extract LUT (~3 ALU ops/weight).
+//   2. Run i8 WMMA (`wmma_i32_16x16x16_iu8_w32`, ~2x FP16 rate) on Q8_1
+//      activations, applying the group scale × activation scale AFTER the
+//      int32 accumulate.
+//
+// MQ2-Lloyd has NO weight zero-point (the codebook directly carries signed
+// values), so the scale FMA is `acc += sc * d_x * dot` — simpler than the
+// HFQ4 sibling (no zp*sum_x correction term).
+//
+// MQ2-Lloyd group layout (72 bytes / 256-K group):
+//   gp+0 : cb0..cb3   (4 × f16 = 8 bytes)  — Lloyd codebook
+//   gp+8 : 256 × 2-bit indices (= 64 bytes)
+//
+// X must be pre-quantized to block_q8_1_mmq via `ensure_q8_1_mmq_x` (the
+// wrapper does this); kernarg layout is identical to the FP16 sibling plus the
+// trailing `x_src_rows` (Q8_1 source row count).
+//
+// Grid: [ceil(M/16), m_total/16]. Block: [32]. LDS: 0.
+
+#if defined(__gfx1151__)
+
+#define QK8_1 32
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[4 * QK8_1];
+};
+
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+typedef int8_t  __attribute__((ext_vector_type(16))) int8x16_t;
+typedef int32_t __attribute__((ext_vector_type(4)))  int32x4_t;
+typedef int32_t __attribute__((ext_vector_type(8)))  int32x8_t;
+typedef float   __attribute__((ext_vector_type(8)))  float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_mq2g256_lloyd_moe_grouped_mmq_gfx1151(
+    const unsigned long long*  __restrict__ expert_weight_ptrs, // [E]
+    const int*                 __restrict__ expert_tile_ids,    // [m_total / 16]
+    const int*                 __restrict__ sorted_slot_index,  // [m_total]
+    const block_q8_1_mmq*      __restrict__ X_q8_src,           // [K/128 × x_src_rows]
+    float*                     __restrict__ Y_grouped,          // [m_total × M]
+    int M, int K, int x_row_div, int m_total, int x_src_rows
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int tile_y = blockIdx.y;
+    const int slot_start = tile_y * 16;
+
+    if (row_start >= M || slot_start >= m_total) return;
+
+    const int expert_id = expert_tile_ids[tile_y];
+    if (expert_id < 0) return;
+
+    const char* __restrict__ A = reinterpret_cast<const char*>(expert_weight_ptrs[expert_id]);
+
+    const int lane = tid & 15;
+    const int slot_idx = slot_start + lane;
+    int x_row = -1;
+    if (slot_idx < m_total) {
+        const int flat = sorted_slot_index[slot_idx];
+        if (flat >= 0) {
+            x_row = (x_row_div > 1) ? (flat / x_row_div) : flat;
+        }
+    }
+
+    const int safe_row = (row_start + lane < M) ? (row_start + lane) : (M - 1);
+    const int groups_per_row = K / 256;
+    const char* row_base = A + (long long)safe_row * groups_per_row * 72;
+
+    float8_t acc = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+
+    const int blocks128 = K / 128;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gp = row_base + g * 72;
+
+        // ── Quantize this lane's 4-entry Lloyd codebook to int8 + scale ──
+        // Done ONCE per group (amortized over 256 weights). cb values are the
+        // actual dequantized weight levels; index q∈{0,1,2,3} selects cb[q].
+        const __half* cbh = reinterpret_cast<const __half*>(gp);
+        float cb0 = __half2float(cbh[0]);
+        float cb1 = __half2float(cbh[1]);
+        float cb2 = __half2float(cbh[2]);
+        float cb3 = __half2float(cbh[3]);
+        float amax = fmaxf(fmaxf(fabsf(cb0), fabsf(cb1)), fmaxf(fabsf(cb2), fabsf(cb3)));
+        float sc_self = amax * (1.0f / 127.0f);
+        float inv_sc = (amax > 0.0f) ? (127.0f / amax) : 0.0f;
+        // int8 codebook packed little-endian into a u32 for byte-extract LUT.
+        int q0 = (int)rintf(cb0 * inv_sc);
+        int q1 = (int)rintf(cb1 * inv_sc);
+        int q2 = (int)rintf(cb2 * inv_sc);
+        int q3 = (int)rintf(cb3 * inv_sc);
+        unsigned int cbpack = ((unsigned int)(q0 & 0xFF))
+                            | ((unsigned int)(q1 & 0xFF) << 8)
+                            | ((unsigned int)(q2 & 0xFF) << 16)
+                            | ((unsigned int)(q3 & 0xFF) << 24);
+
+        // Broadcast each output row's group scale to the lanes that own it.
+        // Output row r = row_start + 2*j + (tid>>4) ⇒ source lane = 2*j + (tid>>4).
+        float sc_row[8];
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int src_lane = 2 * j + (tid >> 4);
+            sc_row[j] = __shfl(sc_self, src_lane);
+        }
+
+        for (int kb_in_group = 0; kb_in_group < 2; kb_in_group++) {
+            const int kb_q8 = 2 * g + kb_in_group;
+            if (kb_q8 >= blocks128) break;
+
+            const block_q8_1_mmq* xb = (x_row >= 0)
+                ? (X_q8_src + (long long)kb_q8 * x_src_rows + x_row)
+                : nullptr;
+
+            #pragma unroll
+            for (int sb = 0; sb < 4; sb++) {
+                float d_x_self = 0.0f;
+                if (xb != nullptr) {
+                    half2 dm = xb->ds4[sb];
+                    float2 dm_f = __half22float2(dm);
+                    d_x_self = dm_f.x;   // Q8_1 per-sub-block activation scale
+                }
+
+                int32x8_t cacc = {0, 0, 0, 0, 0, 0, 0, 0};
+
+                #pragma unroll
+                for (int kt = 0; kt < 2; kt++) {
+                    // K-offset within the 256-element group.
+                    const int k_off = kb_in_group * 128 + sb * 32 + kt * 16;
+                    // 16 × 2-bit indices = 32 bits = one u32 at gp+8 + k_off/4.
+                    const unsigned int pk = *(const unsigned int*)(gp + 8 + k_off / 4);
+
+                    // A operand: 2-bit index → int8 codebook via byte-extract LUT.
+                    int8x16_t a_vec;
+                    #pragma unroll
+                    for (int i = 0; i < 16; i++) {
+                        unsigned int q = (pk >> (2 * i)) & 0x3u;
+                        a_vec[i] = (int8_t)((cbpack >> (q * 8)) & 0xFFu);
+                    }
+
+                    // B operand: Q8_1 int8 activations.
+                    int8x16_t b_vec;
+                    if (xb != nullptr) {
+                        const int8_t* qs_p = xb->qs + sb * 32 + kt * 16;
+                        b_vec = *(const int8x16_t*)qs_p;
+                    } else {
+                        b_vec = (int8x16_t){0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+                    }
+
+                    int32x4_t a_i32 = *(const int32x4_t*)&a_vec;
+                    int32x4_t b_i32 = *(const int32x4_t*)&b_vec;
+
+                    // signed × signed: codebook int8 is signed (Lloyd levels can
+                    // be negative); Q8_1 activations are signed int8.
+                    cacc = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(
+                        true, a_i32, true, b_i32, cacc, true
+                    );
+                } // kt
+
+                // Scale FMA (no zero-point term for MQ2-Lloyd).
+                #pragma unroll
+                for (int j = 0; j < 8; j++) {
+                    acc[j] += sc_row[j] * d_x_self * (float)cacc[j];
+                }
+            } // sb
+        } // kb_in_group
+    } // g
+
+    const int out_col = slot_start + lane;
+    if (out_col < m_total) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int out_row = row_start + 2 * j + (tid >> 4);
+            if (out_row < M) {
+                Y_grouped[(long long)out_col * M + out_row] = acc[j];
+            }
+        }
+    }
+}
+
+#else
+
+extern "C" __global__ void gemm_mq2g256_lloyd_moe_grouped_mmq_gfx1151(
+    const unsigned long long*, const int*, const int*,
+    const void*, float*, int, int, int, int, int
+) {}
+
+#endif

--- a/kernels/src/gemm_mq2g256_lloyd_moe_grouped_mmq.gfx1151.hip
+++ b/kernels/src/gemm_mq2g256_lloyd_moe_grouped_mmq.gfx1151.hip
@@ -122,6 +122,24 @@ extern "C" __global__ void gemm_mq2g256_lloyd_moe_grouped_mmq_gfx1151(
             sc_row[j] = __shfl(sc_self, src_lane);
         }
 
+        // Load the whole group's 64-byte 2-bit index region (16 K-tiles × one
+        // u32 each) up front via four 128-bit loads, into registers. The inner
+        // K-tile loop then reads from registers — the kernel is memory-unit
+        // bound (93% MemUnitBusy), so collapsing 16 scalar u32 loads into 4
+        // vector loads cuts load-instruction pressure 4x.
+        unsigned int pk_all[16];
+        {
+            const int32x4_t* pkp = (const int32x4_t*)(gp + 8);
+            #pragma unroll
+            for (int i = 0; i < 4; i++) {
+                int32x4_t v = pkp[i];
+                pk_all[i * 4 + 0] = (unsigned int)v[0];
+                pk_all[i * 4 + 1] = (unsigned int)v[1];
+                pk_all[i * 4 + 2] = (unsigned int)v[2];
+                pk_all[i * 4 + 3] = (unsigned int)v[3];
+            }
+        }
+
         for (int kb_in_group = 0; kb_in_group < 2; kb_in_group++) {
             const int kb_q8 = 2 * g + kb_in_group;
             if (kb_q8 >= blocks128) break;
@@ -145,8 +163,8 @@ extern "C" __global__ void gemm_mq2g256_lloyd_moe_grouped_mmq_gfx1151(
                 for (int kt = 0; kt < 2; kt++) {
                     // K-offset within the 256-element group.
                     const int k_off = kb_in_group * 128 + sb * 32 + kt * 16;
-                    // 16 × 2-bit indices = 32 bits = one u32 at gp+8 + k_off/4.
-                    const unsigned int pk = *(const unsigned int*)(gp + 8 + k_off / 4);
+                    // 16 × 2-bit indices = 32 bits = pre-loaded u32 (k_off/16).
+                    const unsigned int pk = pk_all[k_off / 16];
 
                     // A operand: 2-bit index → int8 codebook via byte-extract LUT.
                     int8x16_t a_vec;

--- a/kernels/src/gemm_q8_0_mmq_4w.gfx1151.hip
+++ b/kernels/src/gemm_q8_0_mmq_4w.gfx1151.hip
@@ -1,0 +1,159 @@
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <stdint.h>
+
+// Dense i8-WMMA MMQ GEMM for Q8_0 weights — 4-warp 64x64 tile (gfx1151).
+//
+// i8 port of gemm_q8_0_wmma_4w: same 64 M-row × 64 N-col tile and LDS-staged
+// activations, but runs i8 WMMA (i32_16x16x16_iu8, ~2x FP16 rate) on Q8_1
+// activations and reads the int8 weights directly (no f16 dequant). The 16x16
+// i8 kernel lost to this f16 64x64 kernel on large shapes purely on tile size;
+// matching the tile + i8 rate is the real win.
+//
+//   W_q8 : Q8_0 packed [M, K/32*34], per 32-K block [2B fp16 scale | 32B int8].
+//   X    : Q8_1 (block_q8_1_mmq) [K/128 × N], built by ensure_q8_1_mmq_x.
+//   Y    : FP32 [N, M] row-major.
+//
+// Q8_0 has no zero-point: per 32-K block the partial dot is scaled by
+// (w_scale[m] * d_x[n]) and summed into the float accumulator.
+//
+// Grid: [ceil(M/64), ceil(N/64)]. Block: [128]. LDS: 2KB int8 + 256B scales.
+
+#if defined(__gfx1151__)
+
+#define M_TILE 64
+#define N_TILE 64
+#define WARPS 4
+#define M_PER_WARP 16
+#define N_TILES_PER_WARP 4
+
+struct block_q8_1_mmq {
+    half2 ds4[4];
+    int8_t qs[128];
+};
+static_assert(sizeof(block_q8_1_mmq) == 144, "bad block_q8_1_mmq size");
+
+typedef int8_t  __attribute__((ext_vector_type(16))) int8x16_t;
+typedef int32_t __attribute__((ext_vector_type(4)))  int32x4_t;
+typedef int32_t __attribute__((ext_vector_type(8)))  int32x8_t;
+typedef float   __attribute__((ext_vector_type(8)))  float8_t;
+
+__launch_bounds__(128, 2)
+extern "C" __global__ void gemm_q8_0_mmq_4w_gfx1151(
+    const char*           __restrict__ W_q8,  // [M, K/32 * 34]
+    const block_q8_1_mmq* __restrict__ X_q8,  // [K/128 × N]
+    float*                __restrict__ Y,     // [N, M]
+    int M, int K, int N
+) {
+    const int block_m = blockIdx.x * M_TILE;
+    const int block_n = blockIdx.y * N_TILE;
+    if (block_m >= M || block_n >= N) return;
+
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane = tid & 31;
+    const int lane16 = lane & 15;
+
+    const int warp_m_start = block_m + warp_id * M_PER_WARP;
+    const int my_row = warp_m_start + lane16;
+    const int safe_row = (my_row < M) ? my_row : (M - 1);
+
+    const int blocks32 = K / 32;
+    const long long row_stride = (long long)blocks32 * 34;
+    const char* row_base = W_q8 + (long long)safe_row * row_stride;
+
+    // LDS: 64 tokens × 32 int8 for the current 32-K block + 64 d_x scales.
+    __shared__ int8_t lds_q[N_TILE * 32];
+    __shared__ float  lds_dx[N_TILE];
+
+    float8_t acc0 = {0, 0, 0, 0, 0, 0, 0, 0};
+    float8_t acc1 = {0, 0, 0, 0, 0, 0, 0, 0};
+    float8_t acc2 = {0, 0, 0, 0, 0, 0, 0, 0};
+    float8_t acc3 = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    const int blocks128 = K / 128;
+
+    for (int kb128 = 0; kb128 < blocks128; kb128++) {
+        #pragma unroll
+        for (int sb = 0; sb < 4; sb++) {
+            const int bi = kb128 * 4 + sb;   // 32-K block index
+
+            // ── Cooperative stage: 64 tokens × 32 int8 + 64 d_x for this block.
+            // 128 threads load 2048 int8 → 16 bytes each.
+            {
+                const int flat = tid * 16;          // 0..2032 step 16
+                const int n_row = flat >> 5;        // 0..63
+                const int k_off = flat & 31;        // 0 or 16
+                const int gn = block_n + n_row;
+                const int safe_gn = (gn < N) ? gn : (N - 1);
+                const block_q8_1_mmq* xb = X_q8 + (long long)kb128 * N + safe_gn;
+                int8x16_t v = *(const int8x16_t*)(xb->qs + sb * 32 + k_off);
+                *(int8x16_t*)(lds_q + n_row * 32 + k_off) = v;
+                if (k_off == 0) {
+                    lds_dx[n_row] = (gn < N) ? __half22float2(xb->ds4[sb]).x : 0.0f;
+                }
+            }
+            __syncthreads();
+
+            // ── Weights for this lane's row at block bi.
+            const char* bp = row_base + (long long)bi * 34;
+            const __half* wsc = reinterpret_cast<const __half*>(bp);
+            float w_scale_self = __half2float(*wsc);
+            float w_scale_row[8];
+            #pragma unroll
+            for (int j = 0; j < 8; j++) {
+                w_scale_row[j] = __shfl(w_scale_self, 2 * j + (lane >> 4));
+            }
+            const int8x16_t aw0 = *(const int8x16_t*)(bp + 2);
+            const int8x16_t aw1 = *(const int8x16_t*)(bp + 2 + 16);
+            int32x4_t ai0 = *(const int32x4_t*)&aw0;
+            int32x4_t ai1 = *(const int32x4_t*)&aw1;
+
+            #pragma unroll
+            for (int n_tile = 0; n_tile < N_TILES_PER_WARP; n_tile++) {
+                const int n_in_tile = n_tile * 16 + lane16;
+                const int8_t* lq = lds_q + n_in_tile * 32;
+                int8x16_t b0 = *(const int8x16_t*)(lq);
+                int8x16_t b1 = *(const int8x16_t*)(lq + 16);
+                int32x4_t bi0 = *(const int32x4_t*)&b0;
+                int32x4_t bi1 = *(const int32x4_t*)&b1;
+
+                int32x8_t cacc = {0, 0, 0, 0, 0, 0, 0, 0};
+                cacc = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(true, ai0, true, bi0, cacc, true);
+                cacc = __builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(true, ai1, true, bi1, cacc, true);
+
+                const float d_x = lds_dx[n_in_tile];
+                float8_t* acc = (n_tile == 0) ? &acc0 : (n_tile == 1) ? &acc1
+                              : (n_tile == 2) ? &acc2 : &acc3;
+                #pragma unroll
+                for (int j = 0; j < 8; j++) {
+                    (*acc)[j] += w_scale_row[j] * d_x * (float)cacc[j];
+                }
+            }
+            __syncthreads();
+        }
+    }
+
+    #pragma unroll
+    for (int n_tile = 0; n_tile < N_TILES_PER_WARP; n_tile++) {
+        const int out_col = block_n + n_tile * 16 + lane16;
+        if (out_col >= N) continue;
+        float8_t acc = (n_tile == 0) ? acc0 : (n_tile == 1) ? acc1
+                     : (n_tile == 2) ? acc2 : acc3;
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            const int out_row = warp_m_start + 2 * j + (lane >> 4);
+            if (out_row < M) {
+                Y[(long long)out_col * M + out_row] = acc[j];
+            }
+        }
+    }
+}
+
+#else
+
+extern "C" __global__ void gemm_q8_0_mmq_4w_gfx1151(
+    const char*, const void*, float*, int, int, int
+) {}
+
+#endif


### PR DESCRIPTION
## Summary

Three i8-WMMA prefill kernels for DeepSeek-V4-Flash (mq2-lloyd) on **gfx1151** (RDNA 3.5 / Strix Halo), now the **default** path — no quality trade, fully coherent.

| commit | win |
|--------|-----|
| `i8-WMMA MMQ MoE grouped GEMM` | int8 weights + Q8_1 acts + i8 WMMA at ~2× FP16 for the 2-bit-Lloyd MoE experts (+21% prefill) |
| `widen i8-MMQ MoE weight-index loads` | memory-unit-bound load widening on the above |
| `i8-WMMA 64×64 dense Q8_0 GEMM` | i8 dense path for the q-LoRA attention projections (M=4096, batch≥256) |
| `make i8 kernels default on gfx1151` | drops the opt-in env gates; runs whenever the shape guards hold |

All routes are **gfx1151-gated** and fall through to the existing FP16 path on every other arch — no behavioral change off gfx1151.

## Validation (gfx1151, Radeon 8060S, ROCm/HIP 7.2)

Default path, in-session A/B on the same binary + byte-identical 7047-token prompt:

```
prefill bench:  168 → 205 tok/s median (best 211)   = +22%
```

- `coherence-gate-deepseek4-recall.sh` → **PASS** (4/4 exact deep recalls through the DSA-compressed attention path)
- `coherence-gate-deepseek4-mtp.sh` → **PASS** (coherent output, no token attractor; spec-accept 80%/67%, unique-ratio 0.55/0.73)

## Scope / honesty notes

- **Full quality only.** This PR contains *no* approximation knobs (expert-pruning / index-topk / sliding-window). An earlier exploration showed prefill could cross 343 tok/s only by gutting the model to 1 expert (incoherent garbage); that path is deliberately **excluded** here.
- The +22% is the **median** of a thermally-honest run (211→201 across reps = sustained-prefill DPM throttle); reported as median, not best-case.
- Kernels are `.gfx1151.hip`; this branch was validated on gfx1151 hardware. Other RDNA archs are untouched by these routes.

---

## Follow-up: kernel selection moved to the dispatch layer (02f7ffe9)

Review caught that the dense Q8_0 path picked its kernel in the **arch crate's forward pass** (`gemv_auto_batched_wmma`) — the same anti-pattern the MoE i8 path correctly avoided by dispatching in rdna-compute. minimax's dense path calls `gemm_q8_0_batched_chunked` blind, with zero forward-pass arch knowledge; deepseek4 now matches.

- New rdna-compute resolver `gemm_q8_0_wmma_prefill_auto` owns the **entire** Q8_0 dense selection (i8-MMQ-4w on gfx1151 → f16-4w → f16-single-warp → scalar chunked) from `arch_caps`/`flags`/shape.
- The two diagnostic env toggles (`HIPFIRE_DEEPSEEK4_Q8_WMMA`, `HIPFIRE_DEEPSEEK4_Q8_4W`) move into `FeatureFlags`, the established home for rdna-compute kernel toggles.
- The `DType::Q8_0` forward arm collapses from ~57 lines to a single call.

**Byte-identical:** same conditions, kernels, and fallback order. The only mechanical change is reading the env toggles once at `FeatureFlags` construction instead of per-call; neither var is set at runtime (grep clean), so dispatch is unchanged. Re-validated on gfx1151: `coherence_probe` on `deepseek-v4-flash.mq2lloyd` → **OK, 0 hard / 0 soft**, all detectors green.
