### PR TITLE
feat(dispatch): QKV-bias fold across all per-row fused-QKV dtypes (default-on, byte-identical, +2.5–4.1% decode)

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -7204,6 +7204,7 @@ fn run_fused_gate_up_key(
         k,
         rot_scratch: &[],
         batch_size: Some(n),
+        bias: None,
     };
     hipfire_runtime::llama::fused_qkv_family()
         .run(&ctx, gpu, &params)
@@ -7253,6 +7254,7 @@ fn run_fused_qkv_key(
         k,
         rot_scratch: &[],
         batch_size: Some(n),
+        bias: None,
     };
     hipfire_runtime::llama::fused_qkv_family()
         .run(&ctx, gpu, &params)
@@ -7300,6 +7302,7 @@ fn run_fused_qkvza_key(
         k,
         rot_scratch: &[],
         batch_size: Some(n),
+        bias: None,
     };
     hipfire_runtime::llama::fused_qkv_family()
         .run(&ctx, gpu, &params)

--- a/crates/hipfire-dispatch/src/families/fused_qkv.rs
+++ b/crates/hipfire-dispatch/src/families/fused_qkv.rs
@@ -20,6 +20,13 @@ pub struct FusedQkvParams<'a> {
     /// for `x_rot_up` internally). Empty slice for non-Paro keys; existing arms
     /// ignore it.
     pub rot_scratch: &'a [GpuTensor],
+    /// Optional Q/K/V bias tensors for `HIPFIRE_FUSE_QKV_BIAS`. When `Some`, the
+    /// bias is folded into the per-row fused-QKV decode kernel's lane-0 store
+    /// (eliminating 3 separate `bias_add` launches). Only the 3-way QKV decode
+    /// arms whose kernel has a `_with_bias` variant read this field; all other
+    /// arms (QKVZA, gate+up, Paro, prefill GEMM) ignore it. `None` (the default)
+    /// means no fold — existing callers pass `None` and stay byte-identical.
+    pub bias: Option<[&'a GpuTensor; 3]>,
     /// Batched-prefill row count (`#397 Ship 5.2 slice 2`). `None` = single-token
     /// DECODE: gate+up arms dispatch to the `gpu.fused_gate_up_*` kernels (the
     /// historical behavior; the decode pipeline in `pipeline::steps` passes
@@ -81,6 +88,26 @@ macro_rules! hip {
     };
 }
 
+/// Resolve optional Q/K/V bias tensors to raw device pointers for the
+/// `_with_bias` kernel variants. `None` → all-null (a kernel no-op, byte-identical
+/// to the unfused path).
+fn bias_ptrs(
+    bias: Option<[&GpuTensor; 3]>,
+) -> (
+    *mut std::ffi::c_void,
+    *mut std::ffi::c_void,
+    *mut std::ffi::c_void,
+) {
+    match bias {
+        Some([bq, bk, bv]) => (bq.buf.as_ptr(), bk.buf.as_ptr(), bv.buf.as_ptr()),
+        None => (
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        ),
+    }
+}
+
 fn dispatch_fused_qkv(gpu: &mut Gpu, params: &FusedQkvParams) -> Result<(), DispatchError> {
     let x = params.x;
     let k = params.k;
@@ -105,7 +132,14 @@ fn dispatch_fused_qkv(gpu: &mut Gpu, params: &FusedQkvParams) -> Result<(), Disp
                 <[usize; 3]>::try_from(params.m).map_err(|_| err_wrong_arity(params.kind, 3))?;
             match params.batch_size {
                 Some(n) => hip!(gpu.gemm_qkv_hfq4g256(wq, wk, wv, x, q, kout, v, mq, mk, mv, k, n)),
-                None => hip!(gpu.fused_qkv_hfq4g256(wq, wk, wv, x, q, kout, v, mq, mk, mv, k)),
+                None => {
+                    // Optionally fold Q/K/V bias (HIPFIRE_FUSE_QKV_BIAS). Null
+                    // pointers are a kernel no-op, so `None` is byte-identical.
+                    let (bq, bk, bv) = bias_ptrs(params.bias);
+                    hip!(gpu.fused_qkv_hfq4g256_with_bias(
+                        wq, wk, wv, x, q, kout, v, mq, mk, mv, k, bq, bk, bv
+                    ))
+                }
             }
         }
         KernelKey::FusedQkvMq3G256Lloyd => {

--- a/crates/hipfire-dispatch/src/families/fused_qkv.rs
+++ b/crates/hipfire-dispatch/src/families/fused_qkv.rs
@@ -194,9 +194,38 @@ fn dispatch_fused_qkv(gpu: &mut Gpu, params: &FusedQkvParams) -> Result<(), Disp
             match params.batch_size {
                 Some(n) => hip!(gpu.gemm_qkv_hfq6g256(wq, wk, wv, x, q, kout, v, mq, mk, mv, k, n)),
                 None if gpu.arch_caps.gemv_dp4a_enabled() => {
+                    // gfx906 dp4a fast-path. No bias params; the fold is guarded
+                    // off for dp4a archs in execute_steps (bias applied separately).
                     hip!(gpu.fused_qkv_hfq6g256_dp4a(wq, wk, wv, x, q, kout, v, mq, mk, mv, k))
                 }
-                None => hip!(gpu.gemm_qkv_hfq6g256(wq, wk, wv, x, q, kout, v, mq, mk, mv, k, 1)),
+                // Decode (n=1). HFQ6 has no per-row decode kernel historically —
+                // it ran the n=1 GEMM. Switching to per-row is a deliberate
+                // GEMM→per-row change (byte-target = 3×gemv_hfq6g256 + 3 bias, NOT
+                // the GEMM) and HFQ6 coherence can't be model-validated on this
+                // box, so it is gated to ONLY when the bias fold actually fires
+                // (Some(bias) ⇒ HIPFIRE_FUSE_QKV_BIAS on + a qwen2 bias model).
+                // With the fold off (bias None), keep the safe historical GEMM.
+                None => match params.bias {
+                    Some([bq, bk, bv]) => hip!(gpu.fused_qkv_hfq6g256_with_bias(
+                        wq,
+                        wk,
+                        wv,
+                        x,
+                        q,
+                        kout,
+                        v,
+                        mq,
+                        mk,
+                        mv,
+                        k,
+                        bq.buf.as_ptr(),
+                        bk.buf.as_ptr(),
+                        bv.buf.as_ptr()
+                    )),
+                    None => {
+                        hip!(gpu.gemm_qkv_hfq6g256(wq, wk, wv, x, q, kout, v, mq, mk, mv, k, 1))
+                    }
+                },
             }
         }
         KernelKey::FusedQkvQ4K => {

--- a/crates/hipfire-dispatch/src/families/fused_qkv.rs
+++ b/crates/hipfire-dispatch/src/families/fused_qkv.rs
@@ -156,7 +156,12 @@ fn dispatch_fused_qkv(gpu: &mut Gpu, params: &FusedQkvParams) -> Result<(), Disp
                     hip!(gpu
                         .gemm_qkv_mq3g256_lloyd_wmma(wq, wk, wv, x, q, kout, v, mq, mk, mv, k, n))
                 }
-                None => hip!(gpu.fused_qkv_mq3g256_lloyd(wq, wk, wv, x, q, kout, v, mq, mk, mv, k)),
+                None => {
+                    let (bq, bk, bv) = bias_ptrs(params.bias);
+                    hip!(gpu.fused_qkv_mq3g256_lloyd_with_bias(
+                        wq, wk, wv, x, q, kout, v, mq, mk, mv, k, bq, bk, bv
+                    ))
+                }
             }
         }
         KernelKey::FusedQkvMq4G256Lloyd => {
@@ -171,7 +176,12 @@ fn dispatch_fused_qkv(gpu: &mut Gpu, params: &FusedQkvParams) -> Result<(), Disp
                     hip!(gpu
                         .gemm_qkv_mq4g256_lloyd_wmma(wq, wk, wv, x, q, kout, v, mq, mk, mv, k, n))
                 }
-                None => hip!(gpu.fused_qkv_mq4g256_lloyd(wq, wk, wv, x, q, kout, v, mq, mk, mv, k)),
+                None => {
+                    let (bq, bk, bv) = bias_ptrs(params.bias);
+                    hip!(gpu.fused_qkv_mq4g256_lloyd_with_bias(
+                        wq, wk, wv, x, q, kout, v, mq, mk, mv, k, bq, bk, bv
+                    ))
+                }
             }
         }
         KernelKey::FusedQkvHfq6G256 => {
@@ -196,7 +206,8 @@ fn dispatch_fused_qkv(gpu: &mut Gpu, params: &FusedQkvParams) -> Result<(), Disp
                 .map_err(|_| err_wrong_arity(params.kind, 3))?;
             let [mq, mk, mv] =
                 <[usize; 3]>::try_from(params.m).map_err(|_| err_wrong_arity(params.kind, 3))?;
-            hip!(gpu.fused_qkv_q4k(wq, wk, wv, x, q, kout, v, mq, mk, mv, k))
+            let (bq, bk, bv) = bias_ptrs(params.bias);
+            hip!(gpu.fused_qkv_q4k_with_bias(wq, wk, wv, x, q, kout, v, mq, mk, mv, k, bq, bk, bv))
         }
         // ── Q8_0 fused QKV ──
         // None (decode, n=1): scalar `fused_qkv_q8_0` — cross-arch, no dp4a needed.
@@ -214,7 +225,12 @@ fn dispatch_fused_qkv(gpu: &mut Gpu, params: &FusedQkvParams) -> Result<(), Disp
                 Some(n) => {
                     hip!(gpu.gemm_qkv_q8_0_wmma(wq, wk, wv, x, q, kout, v, mq, mk, mv, k, n))
                 }
-                None => hip!(gpu.fused_qkv_q8_0(wq, wk, wv, x, q, kout, v, mq, mk, mv, k)),
+                None => {
+                    let (bq, bk, bv) = bias_ptrs(params.bias);
+                    hip!(gpu.fused_qkv_q8_0_with_bias(
+                        wq, wk, wv, x, q, kout, v, mq, mk, mv, k, bq, bk, bv
+                    ))
+                }
             }
         }
         // ── HFQ3G256 fused QKV — prefill-only key (#397 Ship 5.2 slice 3) ──

--- a/crates/hipfire-dispatch/src/pipeline/steps.rs
+++ b/crates/hipfire-dispatch/src/pipeline/steps.rs
@@ -641,7 +641,18 @@ fn qkv_bias_fold_supported(key: KernelKey, ctx: &DispatchCtx) -> bool {
     if ctx.arch.gemv_dp4a_enabled() {
         return false;
     }
-    matches!(key, KernelKey::FusedQkvHfq4G256)
+    // All per-row 3-way QKV decode keys whose `gpu.fused_qkv_*_with_bias`
+    // variant is wired and GPU-parity-validated (no-bias==0, with-bias==bias;
+    // see examples/test_fused_qkv_bias_parity.rs). HFQ4G256 additionally has the
+    // full three-way model byte-identity proof (see the Phase-1 commit).
+    matches!(
+        key,
+        KernelKey::FusedQkvHfq4G256
+            | KernelKey::FusedQkvMq4G256Lloyd
+            | KernelKey::FusedQkvMq3G256Lloyd
+            | KernelKey::FusedQkvQ4K
+            | KernelKey::FusedQkvQ8_0
+    )
 }
 
 /// If `steps[len..len+3]` are three `BiasAdd` ops whose `x` targets are exactly

--- a/crates/hipfire-dispatch/src/pipeline/steps.rs
+++ b/crates/hipfire-dispatch/src/pipeline/steps.rs
@@ -605,6 +605,21 @@ pub fn execute_steps(
     let mut i = 0;
     while i < steps.len() {
         if let Some((key, len)) = match_prefix(FUSED_TABLE, &steps[i..], ctx) {
+            // ── QKV bias fold (HIPFIRE_FUSE_QKV_BIAS) ────────────────────────
+            // When the flag is on, the matched window is a per-row 3-way QKV
+            // decode key whose kernel supports the fold, and the 3 steps right
+            // after the window are `BiasAdd` on the q/k/v outputs in order, fold
+            // the bias into the kernel's lane-0 store and skip those 3 steps.
+            // The fold is `acc + bias[row]` (fp32, same operand order as the
+            // separate `bias_add`) → byte-identical to the unfused path.
+            if ctx.flags.fuse_qkv_bias && len == QKV3.len() && qkv_bias_fold_supported(key, ctx) {
+                if let Some(biases) = match_trailing_qkv_bias(&steps[i..], len) {
+                    launch_fused_qkv_with_bias(gpu, ctx, key, &steps[i..i + len], biases)?;
+                    i += len + 3;
+                    continue;
+                }
+            }
+            // ─────────────────────────────────────────────────────────────────
             launch_fused(gpu, ctx, key, &steps[i..i + len])?;
             i += len;
         } else {
@@ -613,6 +628,95 @@ pub fn execute_steps(
         }
     }
     Ok(())
+}
+
+/// Keys whose 3-way QKV **decode** dispatch arm folds the optional Q/K/V bias
+/// into the kernel (a `_with_bias` kernel variant exists and is wired in
+/// `dispatch_fused_qkv`). The fold is additionally guarded off on dp4a archs
+/// (gfx906), whose fused-QKV kernel has no bias parameters — there the 3
+/// `BiasAdd` steps run separately as before (handover pitfall #4). Keys NOT
+/// listed here keep the unfused path: their `BiasAdd` steps are never consumed,
+/// so the result is unchanged.
+fn qkv_bias_fold_supported(key: KernelKey, ctx: &DispatchCtx) -> bool {
+    if ctx.arch.gemv_dp4a_enabled() {
+        return false;
+    }
+    matches!(key, KernelKey::FusedQkvHfq4G256)
+}
+
+/// If `steps[len..len+3]` are three `BiasAdd` ops whose `x` targets are exactly
+/// the q/k/v GEMV outputs of the fused window (`steps[1..4]`), return the three
+/// bias tensors `[bias_q, bias_k, bias_v]`. Otherwise `None` (no fold). The
+/// ptr-identity check guarantees we only fold the qwen2 `attention_bias` adds
+/// that immediately follow this exact QKV window, never an unrelated `BiasAdd`.
+fn match_trailing_qkv_bias<'a>(steps: &'a [Step<'a>], len: usize) -> Option<[&'a GpuTensor; 3]> {
+    if len + 3 > steps.len() {
+        return None;
+    }
+    let (
+        Step::BiasAdd {
+            x: bx_q, bias: bq, ..
+        },
+        Step::BiasAdd {
+            x: bx_k, bias: bk, ..
+        },
+        Step::BiasAdd {
+            x: bx_v, bias: bv, ..
+        },
+    ) = (&steps[len], &steps[len + 1], &steps[len + 2])
+    else {
+        return None;
+    };
+    let (_, out_q) = gemv_weight_out(&steps[1]);
+    let (_, out_k) = gemv_weight_out(&steps[2]);
+    let (_, out_v) = gemv_weight_out(&steps[3]);
+    if std::ptr::eq(*bx_q as *const GpuTensor, out_q as *const GpuTensor)
+        && std::ptr::eq(*bx_k as *const GpuTensor, out_k as *const GpuTensor)
+        && std::ptr::eq(*bx_v as *const GpuTensor, out_v as *const GpuTensor)
+    {
+        Some([bq, bk, bv])
+    } else {
+        None
+    }
+}
+
+/// Launch a 3-way QKV fused window with the Q/K/V bias folded into the kernel.
+/// Mirrors the QKV arm of [`launch_fused`] but sets `FusedQkvParams.bias`. Only
+/// reached for keys accepted by [`qkv_bias_fold_supported`].
+fn launch_fused_qkv_with_bias<'a>(
+    gpu: &mut Gpu,
+    ctx: &DispatchCtx,
+    key: KernelKey,
+    steps: &[Step<'a>],
+    bias: [&'a GpuTensor; 3],
+) -> Result<(), DispatchError> {
+    // Opt-in diagnostic (HIPFIRE_FUSE_QKV_BIAS_DEBUG=1): confirm the fold fires.
+    // Flag is resolved once at init — no per-launch env lock on the hot path.
+    if ctx.flags.fuse_qkv_bias_debug {
+        eprintln!("[qkv-bias-fold] fired ({:?})", key);
+    }
+    // Step 0 is RmsnormAutomatic — run it to fill the activated buffer.
+    launch_op(gpu, ctx, &steps[0])?;
+    let activated = rmsnorm_out(&steps[0]);
+    let (wq, q) = gemv_weight_out(&steps[1]);
+    let (wk, k) = gemv_weight_out(&steps[2]);
+    let (wv, v) = gemv_weight_out(&steps[3]);
+    let fused_qkv = FUSED_QKV.get_or_init(FusedQkvFamily::new);
+    fused_qkv.run(
+        ctx,
+        gpu,
+        &FusedQkvParams {
+            kind: key,
+            weights: &[wq.buf, wk.buf, wv.buf],
+            x: activated,
+            outputs: &[q, k, v],
+            m: &[wq.m, wk.m, wv.m],
+            k: wq.k,
+            rot_scratch: &[],
+            batch_size: None,
+            bias: Some(bias),
+        },
+    )
 }
 
 /// Per-op fallback. FULL enum match (no catch-all) so the compiler forces every
@@ -884,6 +988,7 @@ fn launch_fused(
                     k: wq.k,
                     rot_scratch: &[],
                     batch_size: None,
+                    bias: None,
                 },
             )
         }
@@ -908,6 +1013,7 @@ fn launch_fused(
                     k: wg.k,
                     rot_scratch: &[],
                     batch_size: None,
+                    bias: None,
                 },
             )
         }
@@ -934,6 +1040,7 @@ fn launch_fused(
                     k: wqkv.k,
                     rot_scratch: &[],
                     batch_size: None,
+                    bias: None,
                 },
             )
         }
@@ -992,6 +1099,7 @@ fn launch_fused(
                     k,
                     rot_scratch: &rot_aliases,
                     batch_size: None,
+                    bias: None,
                 },
             )
         }
@@ -1032,6 +1140,7 @@ fn launch_fused(
                     k,
                     rot_scratch: &rot_aliases,
                     batch_size: None,
+                    bias: None,
                 },
             )
         }
@@ -1071,6 +1180,7 @@ fn launch_fused(
                     k: kk,
                     rot_scratch: &rot_aliases,
                     batch_size: None,
+                    bias: None,
                 },
             )
         }

--- a/crates/hipfire-dispatch/src/pipeline/steps.rs
+++ b/crates/hipfire-dispatch/src/pipeline/steps.rs
@@ -652,6 +652,10 @@ fn qkv_bias_fold_supported(key: KernelKey, ctx: &DispatchCtx) -> bool {
             | KernelKey::FusedQkvMq3G256Lloyd
             | KernelKey::FusedQkvQ4K
             | KernelKey::FusedQkvQ8_0
+            // HFQ6/MQ6: the fold switches decode GEMM→per-row (Family B). The
+            // dispatch arm keeps the GEMM unless bias is present, so this only
+            // changes decode when the fold actually fires.
+            | KernelKey::FusedQkvHfq6G256
     )
 }
 

--- a/crates/rdna-compute/examples/test_fused_qkv_bias_parity.rs
+++ b/crates/rdna-compute/examples/test_fused_qkv_bias_parity.rs
@@ -23,6 +23,7 @@ const K: usize = 4096; // 16 groups of 256 (and 128 blocks of 32 for q8_0)
 fn row_bytes(dtype: &str) -> usize {
     match dtype {
         "hfq4g256" => (K / 256) * 136,
+        "hfq6g256" => (K / 256) * 200,
         "mq4g256_lloyd" => (K / 256) * 160,
         "mq3g256_lloyd" => (K / 256) * 112,
         "q4k" => (K / 256) * 144,
@@ -120,6 +121,70 @@ fn run_dtype(
     Ok(p_nb & p_wb)
 }
 
+/// Build `m` rows of HFQ6-G256 weight bytes with FINITE scale/zero (so the GEMV
+/// produces finite, deterministic values) and a deterministic 6-bit data pattern.
+/// Group layout: f32 scale | f32 zero | 192 data bytes (32 lanes × 6 B).
+fn build_hfq6(m: usize, seed: u32) -> Vec<u8> {
+    let groups = K / 256;
+    let mut out = Vec::with_capacity(m * groups * 200);
+    for row in 0..m {
+        for g in 0..groups {
+            let scale = 0.01f32 + ((row * 3 + g * 5 + seed as usize) % 7) as f32 * 0.001;
+            let zero = -0.1f32 + ((row + g) % 5) as f32 * 0.01;
+            out.extend_from_slice(&scale.to_le_bytes());
+            out.extend_from_slice(&zero.to_le_bytes());
+            for b in 0..192usize {
+                let h = row
+                    .wrapping_mul(31)
+                    .wrapping_add(g.wrapping_mul(53))
+                    .wrapping_add(b.wrapping_mul(7))
+                    .wrapping_add(seed as usize);
+                out.push((h & 0xFF) as u8);
+            }
+        }
+    }
+    out
+}
+
+/// Per-row fused_qkv_hfq6g256 (no bias) must be BIT-EXACT with three separate
+/// gemv_hfq6g256 calls (same row math, same accumulation order).
+fn test_hfq6_fused_vs_gemv(gpu: &mut Gpu) -> HipResult<bool> {
+    let wq = gpu.upload_raw(&build_hfq6(Q_M, 1), &[Q_M * (K / 256) * 200])?;
+    let wk = gpu.upload_raw(&build_hfq6(K_M, 2), &[K_M * (K / 256) * 200])?;
+    let wv = gpu.upload_raw(&build_hfq6(V_M, 3), &[V_M * (K / 256) * 200])?;
+    let xv: Vec<f32> = (0..K).map(|i| ((i % 13) as f32 - 6.0) * 0.05).collect();
+    let x = gpu.upload_f32(&xv, &[K])?;
+
+    // Fused.
+    let yqf = gpu.zeros(&[Q_M], DType::F32)?;
+    let ykf = gpu.zeros(&[K_M], DType::F32)?;
+    let yvf = gpu.zeros(&[V_M], DType::F32)?;
+    gpu.fused_qkv_hfq6g256(&wq, &wk, &wv, &x, &yqf, &ykf, &yvf, Q_M, K_M, V_M, K)?;
+    let fq = gpu.download_f32(&yqf)?;
+    let fk = gpu.download_f32(&ykf)?;
+    let fv = gpu.download_f32(&yvf)?;
+
+    // Three separate gemv_hfq6g256.
+    let yqg = gpu.zeros(&[Q_M], DType::F32)?;
+    let ykg = gpu.zeros(&[K_M], DType::F32)?;
+    let yvg = gpu.zeros(&[V_M], DType::F32)?;
+    gpu.gemv_hfq6g256(&wq, &x, &yqg, Q_M, K)?;
+    gpu.gemv_hfq6g256(&wk, &x, &ykg, K_M, K)?;
+    gpu.gemv_hfq6g256(&wv, &x, &yvg, V_M, K)?;
+    let gq = gpu.download_f32(&yqg)?;
+    let gk = gpu.download_f32(&ykg)?;
+    let gv = gpu.download_f32(&yvg)?;
+
+    let p = check("hfq6 fused_q == gemv_q", &fq, &gq)
+        & check("hfq6 fused_k == gemv_k", &fk, &gk)
+        & check("hfq6 fused_v == gemv_v", &fv, &gv);
+
+    for t in [wq, wk, wv, x, yqf, ykf, yvf, yqg, ykg, yvg] {
+        gpu.free_tensor(t)?;
+    }
+    Ok(p)
+}
+
 fn main() {
     let mut gpu = Gpu::init().expect("GPU init failed");
     eprintln!("GPU: {}", gpu.arch);
@@ -188,6 +253,23 @@ fn main() {
         g.fused_qkv_q8_0_with_bias(aq, ak, av, x, yq, yk, yv, Q_M, K_M, V_M, K, bq, bk, bv)
     })
     .expect("q8_0");
+
+    println!("--- hfq6g256 (Family B, new per-row kernel) ---");
+    all &= run_dtype(
+        &mut gpu,
+        "hfq6g256",
+        |g, aq, ak, av, x, yq, yk, yv, bias| {
+            let (bq, bk, bv) = ptrs!(bias);
+            g.fused_qkv_hfq6g256_with_bias(aq, ak, av, x, yq, yk, yv, Q_M, K_M, V_M, K, bq, bk, bv)
+        },
+    )
+    .expect("hfq6g256");
+
+    // Family B extra: the per-row fused_qkv_hfq6g256 (no bias) must be bit-exact
+    // with three separate gemv_hfq6g256 calls on REAL (finite, non-zero) weights —
+    // the handover's "validate new fused-per-row == per-row GEMV path" gate.
+    println!("--- hfq6g256 fused == 3×gemv_hfq6g256 (finite weights) ---");
+    all &= test_hfq6_fused_vs_gemv(&mut gpu).expect("hfq6 fused-vs-gemv");
 
     if !all {
         eprintln!("\nFAIL: at least one fused_qkv_*_with_bias kernel failed bias parity");

--- a/crates/rdna-compute/examples/test_fused_qkv_bias_parity.rs
+++ b/crates/rdna-compute/examples/test_fused_qkv_bias_parity.rs
@@ -1,0 +1,197 @@
+//! GPU wiring validation for the `fused_qkv_<dtype>_with_bias` kernels
+//! (HIPFIRE_FUSE_QKV_BIAS). Format-agnostic: we upload ZEROED weight bytes for
+//! each format, so every kernel's GEMV body produces exactly 0.0 (scale/codebook
+//! = 0 → 0 contribution, finite). The fused store is then `y[row] = 0 + bias[row]`,
+//! so the with-bias output MUST equal the per-projection bias bit-exactly, and
+//! the no-bias call MUST produce all zeros.
+//!
+//! This validates, without needing a real model, exactly the three things the
+//! bias fold can get wrong: (1) the kernarg ABI (count/order) — a mismatch
+//! crashes or corrupts; (2) the q/k/v→bias routing — each row must read its own
+//! projection's bias; (3) the `+bias` epilogue. Run on the target GPU:
+//!   cargo run --release --example test_fused_qkv_bias_parity -p rdna-compute
+
+use hip_bridge::HipResult;
+use rdna_compute::{DType, Gpu, GpuTensor};
+
+const Q_M: usize = 32;
+const K_M: usize = 16;
+const V_M: usize = 16;
+const K: usize = 4096; // 16 groups of 256 (and 128 blocks of 32 for q8_0)
+
+/// Per-row byte stride for each format (× number of groups/blocks per row).
+fn row_bytes(dtype: &str) -> usize {
+    match dtype {
+        "hfq4g256" => (K / 256) * 136,
+        "mq4g256_lloyd" => (K / 256) * 160,
+        "mq3g256_lloyd" => (K / 256) * 112,
+        "q4k" => (K / 256) * 144,
+        "q8_0" => (K / 32) * 34,
+        _ => unreachable!(),
+    }
+}
+
+fn zeros_weight(gpu: &mut Gpu, m: usize, dtype: &str) -> HipResult<GpuTensor> {
+    let bytes = vec![0u8; m * row_bytes(dtype)];
+    gpu.upload_raw(&bytes, &[bytes.len()])
+}
+
+/// Distinct, deterministic bias values per projection (offset keeps q/k/v apart
+/// so a mis-routed bias is caught).
+fn bias_vec(m: usize, offset: f32) -> Vec<f32> {
+    (0..m).map(|i| offset + (i as f32) * 0.5 - 1.0).collect()
+}
+
+fn check(label: &str, got: &[f32], want: &[f32]) -> bool {
+    let mut max_abs = 0f32;
+    for i in 0..got.len() {
+        max_abs = max_abs.max((got[i] - want[i]).abs());
+    }
+    // Exact: gemv=0 then +bias is a single fp32 store of the bias value.
+    let pass = max_abs == 0.0;
+    println!(
+        "  {label:40}  max_abs={max_abs:.3e}  {}",
+        if pass { "PASS" } else { "FAIL" }
+    );
+    pass
+}
+
+/// Run one dtype: no-bias must be all-zeros; with-bias must equal the bias.
+fn run_dtype(
+    gpu: &mut Gpu,
+    dtype: &str,
+    call: impl Fn(
+        &mut Gpu,
+        &GpuTensor,                                   // a_q
+        &GpuTensor,                                   // a_k
+        &GpuTensor,                                   // a_v
+        &GpuTensor,                                   // x
+        &GpuTensor,                                   // y_q
+        &GpuTensor,                                   // y_k
+        &GpuTensor,                                   // y_v
+        Option<(&GpuTensor, &GpuTensor, &GpuTensor)>, // bias
+    ) -> HipResult<()>,
+) -> HipResult<bool> {
+    let a_q = zeros_weight(gpu, Q_M, dtype)?;
+    let a_k = zeros_weight(gpu, K_M, dtype)?;
+    let a_v = zeros_weight(gpu, V_M, dtype)?;
+    let x = gpu.upload_f32(&vec![0.3f32; K], &[K])?;
+    let y_q = gpu.zeros(&[Q_M], DType::F32)?;
+    let y_k = gpu.zeros(&[K_M], DType::F32)?;
+    let y_v = gpu.zeros(&[V_M], DType::F32)?;
+
+    // No-bias → all zeros.
+    call(gpu, &a_q, &a_k, &a_v, &x, &y_q, &y_k, &y_v, None)?;
+    let nb_q = gpu.download_f32(&y_q)?;
+    let nb_k = gpu.download_f32(&y_k)?;
+    let nb_v = gpu.download_f32(&y_v)?;
+    let p_nb = check(&format!("{dtype} no-bias q"), &nb_q, &vec![0.0; Q_M])
+        & check(&format!("{dtype} no-bias k"), &nb_k, &vec![0.0; K_M])
+        & check(&format!("{dtype} no-bias v"), &nb_v, &vec![0.0; V_M]);
+
+    // With-bias → equals bias.
+    let bq = bias_vec(Q_M, 10.0);
+    let bk = bias_vec(K_M, 100.0);
+    let bv = bias_vec(V_M, 1000.0);
+    let d_bq = gpu.upload_f32(&bq, &[Q_M])?;
+    let d_bk = gpu.upload_f32(&bk, &[K_M])?;
+    let d_bv = gpu.upload_f32(&bv, &[V_M])?;
+    call(
+        gpu,
+        &a_q,
+        &a_k,
+        &a_v,
+        &x,
+        &y_q,
+        &y_k,
+        &y_v,
+        Some((&d_bq, &d_bk, &d_bv)),
+    )?;
+    let wb_q = gpu.download_f32(&y_q)?;
+    let wb_k = gpu.download_f32(&y_k)?;
+    let wb_v = gpu.download_f32(&y_v)?;
+    let p_wb = check(&format!("{dtype} with-bias q"), &wb_q, &bq)
+        & check(&format!("{dtype} with-bias k"), &wb_k, &bk)
+        & check(&format!("{dtype} with-bias v"), &wb_v, &bv);
+
+    for t in [a_q, a_k, a_v, x, y_q, y_k, y_v, d_bq, d_bk, d_bv] {
+        gpu.free_tensor(t)?;
+    }
+    Ok(p_nb & p_wb)
+}
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init failed");
+    eprintln!("GPU: {}", gpu.arch);
+    let mut all = true;
+
+    macro_rules! ptrs {
+        ($bias:expr) => {
+            match $bias {
+                Some((bq, bk, bv)) => (bq.buf.as_ptr(), bk.buf.as_ptr(), bv.buf.as_ptr()),
+                None => (
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                ),
+            }
+        };
+    }
+
+    println!("--- hfq4g256 ---");
+    all &= run_dtype(
+        &mut gpu,
+        "hfq4g256",
+        |g, aq, ak, av, x, yq, yk, yv, bias| {
+            let (bq, bk, bv) = ptrs!(bias);
+            g.fused_qkv_hfq4g256_with_bias(aq, ak, av, x, yq, yk, yv, Q_M, K_M, V_M, K, bq, bk, bv)
+        },
+    )
+    .expect("hfq4g256");
+
+    println!("--- mq4g256_lloyd ---");
+    all &= run_dtype(
+        &mut gpu,
+        "mq4g256_lloyd",
+        |g, aq, ak, av, x, yq, yk, yv, bias| {
+            let (bq, bk, bv) = ptrs!(bias);
+            g.fused_qkv_mq4g256_lloyd_with_bias(
+                aq, ak, av, x, yq, yk, yv, Q_M, K_M, V_M, K, bq, bk, bv,
+            )
+        },
+    )
+    .expect("mq4g256_lloyd");
+
+    println!("--- mq3g256_lloyd ---");
+    all &= run_dtype(
+        &mut gpu,
+        "mq3g256_lloyd",
+        |g, aq, ak, av, x, yq, yk, yv, bias| {
+            let (bq, bk, bv) = ptrs!(bias);
+            g.fused_qkv_mq3g256_lloyd_with_bias(
+                aq, ak, av, x, yq, yk, yv, Q_M, K_M, V_M, K, bq, bk, bv,
+            )
+        },
+    )
+    .expect("mq3g256_lloyd");
+
+    println!("--- q4k ---");
+    all &= run_dtype(&mut gpu, "q4k", |g, aq, ak, av, x, yq, yk, yv, bias| {
+        let (bq, bk, bv) = ptrs!(bias);
+        g.fused_qkv_q4k_with_bias(aq, ak, av, x, yq, yk, yv, Q_M, K_M, V_M, K, bq, bk, bv)
+    })
+    .expect("q4k");
+
+    println!("--- q8_0 ---");
+    all &= run_dtype(&mut gpu, "q8_0", |g, aq, ak, av, x, yq, yk, yv, bias| {
+        let (bq, bk, bv) = ptrs!(bias);
+        g.fused_qkv_q8_0_with_bias(aq, ak, av, x, yq, yk, yv, Q_M, K_M, V_M, K, bq, bk, bv)
+    })
+    .expect("q8_0");
+
+    if !all {
+        eprintln!("\nFAIL: at least one fused_qkv_*_with_bias kernel failed bias parity");
+        std::process::exit(1);
+    }
+    println!("\nALL PASS — every fused_qkv_*_with_bias folds bias bit-exactly (no-bias==0, with-bias==bias)");
+}

--- a/crates/rdna-compute/src/feature_flags.rs
+++ b/crates/rdna-compute/src/feature_flags.rs
@@ -108,6 +108,19 @@ pub struct FeatureFlags {
     /// fused-vs-unfused validation. Env: HIPFIRE_FORCE_UNFUSED=1. Single-GPU
     /// decode projection fusions only (see Phase-2a spec §4b honest-scope).
     pub force_unfused: bool,
+
+    /// Fold the 3 separate QKV `BiasAdd` launches (qwen2-family `attention_bias`)
+    /// into the per-row fused-QKV decode kernel's lane-0 store. Eliminates 3 tiny
+    /// overhead-dominated launches/layer. Env: HIPFIRE_FUSE_QKV_BIAS — default ON;
+    /// set `=0` to opt out (for bisection). NULL bias pointers are a kernel no-op,
+    /// so non-bias callers stay byte-identical regardless. Only fires for fused-QKV
+    /// keys whose dispatch arm reads the bias (see `qkv_bias_fold_supported`).
+    pub fuse_qkv_bias: bool,
+
+    /// Diagnostic: log each QKV-bias fold to stderr. Env:
+    /// HIPFIRE_FUSE_QKV_BIAS_DEBUG=1. Default off. Resolved once at init so the
+    /// default-on fold hot path takes no per-launch `env::var` lock.
+    pub fuse_qkv_bias_debug: bool,
 }
 
 impl FeatureFlags {
@@ -270,6 +283,10 @@ impl FeatureFlags {
             force_unfused: std::env::var("HIPFIRE_FORCE_UNFUSED")
                 .map(|v| v == "1")
                 .unwrap_or(false),
+
+            // QKV bias fold — default ON, opt out with HIPFIRE_FUSE_QKV_BIAS=0.
+            fuse_qkv_bias: parse_bool("HIPFIRE_FUSE_QKV_BIAS").unwrap_or(true),
+            fuse_qkv_bias_debug: std::env::var("HIPFIRE_FUSE_QKV_BIAS_DEBUG").as_deref() == Ok("1"),
         }
     }
 
@@ -405,6 +422,8 @@ impl FeatureFlags {
             rdna2_variant: None,
             hipcc_extra_flags: String::new(),
             force_unfused: false,
+            fuse_qkv_bias: true,
+            fuse_qkv_bias_debug: false,
         }
     }
 }
@@ -417,5 +436,11 @@ mod tests {
     fn force_unfused_defaults_false_in_test_ctor() {
         let f = FeatureFlags::from_env_for_test("gfx1151");
         assert!(!f.force_unfused);
+    }
+
+    #[test]
+    fn fuse_qkv_bias_defaults_on_in_test_ctor() {
+        let f = FeatureFlags::from_env_for_test("gfx1151");
+        assert!(f.fuse_qkv_bias);
     }
 }

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -2520,6 +2520,138 @@ impl Gpu {
         result
     }
 
+    /// Per-row 3-way fused HFQ6/MQ6-G256 QKV decode (qwen2-family). Authored
+    /// from `gemv_hfq6g256`'s row body; bit-exact with three sequential
+    /// `gemv_hfq6g256` calls. Replaces the n=1 `gemm_qkv_hfq6g256` decode path
+    /// (a deliberate decode-kernel change — see the FusedQkvHfq6G256 dispatch
+    /// arm). Null bias = byte-identical to 3×gemv_hfq6g256.
+    pub fn fused_qkv_hfq6g256(
+        &mut self,
+        a_q: &GpuTensor,
+        a_k: &GpuTensor,
+        a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor,
+        y_k: &GpuTensor,
+        y_v: &GpuTensor,
+        q_m: usize,
+        k_m: usize,
+        v_m: usize,
+        k: usize,
+    ) -> HipResult<()> {
+        self.fused_qkv_hfq6g256_with_bias(
+            a_q,
+            a_k,
+            a_v,
+            x,
+            y_q,
+            y_k,
+            y_v,
+            q_m,
+            k_m,
+            v_m,
+            k,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    }
+
+    /// `fused_qkv_hfq6g256` with an optional Q/K/V bias folded into the kernel's
+    /// lane-0 store (`HIPFIRE_FUSE_QKV_BIAS`). All-null = byte-identical.
+    #[allow(clippy::too_many_arguments)]
+    pub fn fused_qkv_hfq6g256_with_bias(
+        &mut self,
+        a_q: &GpuTensor,
+        a_k: &GpuTensor,
+        a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor,
+        y_k: &GpuTensor,
+        y_v: &GpuTensor,
+        q_m: usize,
+        k_m: usize,
+        v_m: usize,
+        k: usize,
+        bias_q_ptr: *mut c_void,
+        bias_k_ptr: *mut c_void,
+        bias_v_ptr: *mut c_void,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "fused_qkv_hfq6g256",
+            kernels::FUSED_QKV_HFQ6G256_SRC,
+            "fused_qkv_hfq6g256",
+        )?;
+
+        let aq = a_q.buf.as_ptr();
+        let ak = a_k.buf.as_ptr();
+        let av = a_v.buf.as_ptr();
+        let xp = x.buf.as_ptr();
+        let yq = y_q.buf.as_ptr();
+        let yk = y_k.buf.as_ptr();
+        let yv = y_v.buf.as_ptr();
+        let q_m_i = q_m as i32;
+        let k_m_i = k_m as i32;
+        let v_m_i = v_m as i32;
+        let k_i = k as i32;
+        let bq = bias_q_ptr;
+        let bk = bias_k_ptr;
+        let bv = bias_v_ptr;
+        let total = (q_m + k_m + v_m) as u32;
+
+        let mut params: Vec<*mut c_void> = vec![
+            &aq as *const _ as *mut c_void,
+            &ak as *const _ as *mut c_void,
+            &av as *const _ as *mut c_void,
+            &xp as *const _ as *mut c_void,
+            &yq as *const _ as *mut c_void,
+            &yk as *const _ as *mut c_void,
+            &yv as *const _ as *mut c_void,
+            &q_m_i as *const _ as *mut c_void,
+            &k_m_i as *const _ as *mut c_void,
+            &v_m_i as *const _ as *mut c_void,
+            &k_i as *const _ as *mut c_void,
+            &bq as *const _ as *mut c_void,
+            &bk as *const _ as *mut c_void,
+            &bv as *const _ as *mut c_void,
+        ];
+
+        let bytes = crate::profile::gemv_hfq6g256_bytes(q_m, k)
+            + crate::profile::gemv_hfq6g256_bytes(k_m, k)
+            + crate::profile::gemv_hfq6g256_bytes(v_m, k);
+        let timer = crate::profile::begin_timer(&self.hip, "fused", "fused_qkv_hfq6g256", bytes);
+        let result = self.launch_maybe_blob(
+            "fused_qkv_hfq6g256",
+            [total, 1, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(aq);
+                b.push_ptr(ak);
+                b.push_ptr(av);
+                b.push_ptr(xp);
+                b.push_ptr(yq);
+                b.push_ptr(yk);
+                b.push_ptr(yv);
+                b.push_i32(q_m_i);
+                b.push_i32(k_m_i);
+                b.push_i32(v_m_i);
+                b.push_i32(k_i);
+                b.push_ptr(bq);
+                b.push_ptr(bk);
+                b.push_ptr(bv);
+                b
+            },
+        );
+        if let Some(t) = timer {
+            t.finish(&self.hip);
+        }
+        result
+    }
+
     /// 4-way fused HFQ4-G256 projection — cross-arch.
     ///
     /// Performs y_qkv=A_qkv·x, y_z=A_z·x, y_beta=A_beta·x, y_alpha=A_alpha·x

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -2361,8 +2361,59 @@ impl Gpu {
         v_m: usize,
         k: usize,
     ) -> HipResult<()> {
+        // Null bias = byte-identical to the historical (pre-fold) path.
+        self.fused_qkv_hfq4g256_with_bias(
+            a_q,
+            a_k,
+            a_v,
+            x,
+            y_q,
+            y_k,
+            y_v,
+            q_m,
+            k_m,
+            v_m,
+            k,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    }
+
+    /// Variant of [`Self::fused_qkv_hfq4g256`] that optionally folds the Q/K/V
+    /// `bias_add` into the kernel's lane-0 store (`HIPFIRE_FUSE_QKV_BIAS`).
+    /// Non-null f32 device pointers `bias_q/k/v` are added inside the kernel;
+    /// passing null for all three is byte-identical to the unfused path
+    /// (fp32 store→load→add of the separate `bias_add` == the fused fp32 add,
+    /// same operand order). Called from `execute_steps` when the fold fires on
+    /// a per-row decode arch.
+    #[allow(clippy::too_many_arguments)]
+    pub fn fused_qkv_hfq4g256_with_bias(
+        &mut self,
+        a_q: &GpuTensor,
+        a_k: &GpuTensor,
+        a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor,
+        y_k: &GpuTensor,
+        y_v: &GpuTensor,
+        q_m: usize,
+        k_m: usize,
+        v_m: usize,
+        k: usize,
+        bias_q_ptr: *mut c_void,
+        bias_k_ptr: *mut c_void,
+        bias_v_ptr: *mut c_void,
+    ) -> HipResult<()> {
         self.bind_thread()?;
         if self.arch_caps.gemv_dp4a_enabled() {
+            // The gfx906 dp4a kernel has no bias parameters. The fold is guarded
+            // off for dp4a archs in `execute_steps` (bias applied separately), so
+            // bias must be null here; assert that invariant defensively.
+            debug_assert!(
+                bias_q_ptr.is_null() && bias_k_ptr.is_null() && bias_v_ptr.is_null(),
+                "fused_qkv_hfq4g256_with_bias: bias must be null on the dp4a path"
+            );
             return self.fused_qkv_hfq4g256_dp4a(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k);
         }
 
@@ -2418,6 +2469,10 @@ impl Gpu {
         let k_m_val = k_m as i32;
         let v_m_val = v_m as i32;
         let k_val = k as i32;
+        // Nullable bias pointers — null is a kernel no-op (byte-identical).
+        let bq = bias_q_ptr;
+        let bk = bias_k_ptr;
+        let bv = bias_v_ptr;
 
         let mut params: Vec<*mut c_void> = vec![
             &aq as *const _ as *mut c_void,
@@ -2431,6 +2486,9 @@ impl Gpu {
             &k_m_val as *const _ as *mut c_void,
             &v_m_val as *const _ as *mut c_void,
             &k_val as *const _ as *mut c_void,
+            &bq as *const _ as *mut c_void,
+            &bk as *const _ as *mut c_void,
+            &bv as *const _ as *mut c_void,
         ];
 
         let bytes = crate::profile::gemv_hfq4g256_bytes(q_m, k)
@@ -2451,6 +2509,9 @@ impl Gpu {
                 b.push_i32(k_m_val);
                 b.push_i32(v_m_val);
                 b.push_i32(k_val);
+                b.push_ptr(bq);
+                b.push_ptr(bk);
+                b.push_ptr(bv);
                 b
             });
         if let Some(t) = timer {

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -17336,6 +17336,46 @@ impl Gpu {
         v_m: usize,
         k: usize,
     ) -> HipResult<()> {
+        // Null bias = byte-identical to the historical (pre-fold) path.
+        self.fused_qkv_q4k_with_bias(
+            wq,
+            wk,
+            wv,
+            x,
+            yq,
+            yk,
+            yv,
+            q_m,
+            k_m,
+            v_m,
+            k,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    }
+
+    /// `fused_qkv_q4k` with an optional Q/K/V bias folded into the kernel's
+    /// lane-0 store (`HIPFIRE_FUSE_QKV_BIAS`). All-null = byte-identical to the
+    /// unfused path.
+    #[allow(clippy::too_many_arguments)]
+    pub fn fused_qkv_q4k_with_bias(
+        &mut self,
+        wq: &GpuTensor,
+        wk: &GpuTensor,
+        wv: &GpuTensor,
+        x: &GpuTensor,
+        yq: &GpuTensor,
+        yk: &GpuTensor,
+        yv: &GpuTensor,
+        q_m: usize,
+        k_m: usize,
+        v_m: usize,
+        k: usize,
+        bias_q_ptr: *mut c_void,
+        bias_k_ptr: *mut c_void,
+        bias_v_ptr: *mut c_void,
+    ) -> HipResult<()> {
         self.bind_thread()?;
         self.ensure_kernel("fused_qkv_q4k", kernels::FUSED_QKV_Q4K_SRC, "fused_qkv_q4k")?;
         let func = &self.functions["fused_qkv_q4k"];
@@ -17351,6 +17391,9 @@ impl Gpu {
         let mut km = k_m as i32;
         let mut vm = v_m as i32;
         let mut kk = k as i32;
+        let mut bq = bias_q_ptr;
+        let mut bk = bias_k_ptr;
+        let mut bv = bias_v_ptr;
 
         let mut params: Vec<*mut c_void> = vec![
             &mut aq as *mut _ as *mut c_void,
@@ -17364,6 +17407,9 @@ impl Gpu {
             &mut km as *mut _ as *mut c_void,
             &mut vm as *mut _ as *mut c_void,
             &mut kk as *mut _ as *mut c_void,
+            &mut bq as *mut _ as *mut c_void,
+            &mut bk as *mut _ as *mut c_void,
+            &mut bv as *mut _ as *mut c_void,
         ];
 
         let grid = (q_m + k_m + v_m) as u32;
@@ -18650,6 +18696,46 @@ impl Gpu {
         v_m: usize,
         k: usize,
     ) -> HipResult<()> {
+        // Null bias = byte-identical to the historical (pre-fold) path.
+        self.fused_qkv_q8_0_with_bias(
+            a_q,
+            a_k,
+            a_v,
+            x,
+            y_q,
+            y_k,
+            y_v,
+            q_m,
+            k_m,
+            v_m,
+            k,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    }
+
+    /// `fused_qkv_q8_0` with an optional Q/K/V bias folded into the kernel's
+    /// lane-0 store (`HIPFIRE_FUSE_QKV_BIAS`). All-null = byte-identical to the
+    /// unfused path.
+    #[allow(clippy::too_many_arguments)]
+    pub fn fused_qkv_q8_0_with_bias(
+        &mut self,
+        a_q: &GpuTensor,
+        a_k: &GpuTensor,
+        a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor,
+        y_k: &GpuTensor,
+        y_v: &GpuTensor,
+        q_m: usize,
+        k_m: usize,
+        v_m: usize,
+        k: usize,
+        bias_q_ptr: *mut c_void,
+        bias_k_ptr: *mut c_void,
+        bias_v_ptr: *mut c_void,
+    ) -> HipResult<()> {
         self.bind_thread()?;
         self.ensure_kernel(
             "fused_qkv_q8_0",
@@ -18668,6 +18754,9 @@ impl Gpu {
         let k_m_i = k_m as i32;
         let v_m_i = v_m as i32;
         let k_i = k as i32;
+        let bq = bias_q_ptr;
+        let bk = bias_k_ptr;
+        let bv = bias_v_ptr;
         let total = (q_m + k_m + v_m) as u32;
 
         let mut params: Vec<*mut c_void> = vec![
@@ -18682,6 +18771,9 @@ impl Gpu {
             &k_m_i as *const _ as *mut c_void,
             &v_m_i as *const _ as *mut c_void,
             &k_i as *const _ as *mut c_void,
+            &bq as *const _ as *mut c_void,
+            &bk as *const _ as *mut c_void,
+            &bv as *const _ as *mut c_void,
         ];
 
         self.launch_maybe_blob(
@@ -18703,6 +18795,9 @@ impl Gpu {
                 b.push_i32(k_m_i);
                 b.push_i32(v_m_i);
                 b.push_i32(k_i);
+                b.push_ptr(bq);
+                b.push_ptr(bk);
+                b.push_ptr(bv);
                 b
             },
         )

--- a/crates/rdna-compute/src/gemv.rs
+++ b/crates/rdna-compute/src/gemv.rs
@@ -1431,6 +1431,48 @@ impl Gpu {
         v_m: usize,
         k: usize,
     ) -> HipResult<()> {
+        // Null bias = byte-identical to the historical (pre-fold) path.
+        self.fused_qkv_mq4g256_lloyd_with_bias(
+            a_q,
+            a_k,
+            a_v,
+            x,
+            y_q,
+            y_k,
+            y_v,
+            q_m,
+            k_m,
+            v_m,
+            k,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    }
+
+    /// `fused_qkv_mq4g256_lloyd` with an optional Q/K/V bias folded into the
+    /// kernel's lane-0 store (`HIPFIRE_FUSE_QKV_BIAS`). All-null = byte-identical
+    /// to the unfused path (fp32 store→add). Both arch siblings (base + gfx1100)
+    /// carry the 3 trailing bias params, so the kernarg ABI matches whichever
+    /// `_for_arch` selects.
+    #[allow(clippy::too_many_arguments)]
+    pub fn fused_qkv_mq4g256_lloyd_with_bias(
+        &mut self,
+        a_q: &GpuTensor,
+        a_k: &GpuTensor,
+        a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor,
+        y_k: &GpuTensor,
+        y_v: &GpuTensor,
+        q_m: usize,
+        k_m: usize,
+        v_m: usize,
+        k: usize,
+        bias_q_ptr: *mut c_void,
+        bias_k_ptr: *mut c_void,
+        bias_v_ptr: *mut c_void,
+    ) -> HipResult<()> {
         self.bind_thread()?;
         let (src, module) = kernels::fused_qkv_mq4g256_lloyd_for_arch(
             &self.arch_caps,
@@ -1448,6 +1490,9 @@ impl Gpu {
         let k_m_i = k_m as i32;
         let v_m_i = v_m as i32;
         let k_i = k as i32;
+        let bq = bias_q_ptr;
+        let bk = bias_k_ptr;
+        let bv = bias_v_ptr;
         let mut params: Vec<*mut c_void> = vec![
             &aq as *const _ as *mut c_void,
             &ak as *const _ as *mut c_void,
@@ -1460,6 +1505,9 @@ impl Gpu {
             &k_m_i as *const _ as *mut c_void,
             &v_m_i as *const _ as *mut c_void,
             &k_i as *const _ as *mut c_void,
+            &bq as *const _ as *mut c_void,
+            &bk as *const _ as *mut c_void,
+            &bv as *const _ as *mut c_void,
         ];
         let total = (q_m + k_m + v_m) as u32;
         let bytes = crate::profile::gemv_mq4g256_lloyd_bytes(q_m, k)
@@ -1487,6 +1535,9 @@ impl Gpu {
                 b.push_i32(k_m_i);
                 b.push_i32(v_m_i);
                 b.push_i32(k_i);
+                b.push_ptr(bq);
+                b.push_ptr(bk);
+                b.push_ptr(bv);
                 b
             },
         );
@@ -1756,6 +1807,47 @@ impl Gpu {
         v_m: usize,
         k: usize,
     ) -> HipResult<()> {
+        // Null bias = byte-identical to the historical (pre-fold) path.
+        self.fused_qkv_mq3g256_lloyd_with_bias(
+            a_q,
+            a_k,
+            a_v,
+            x,
+            y_q,
+            y_k,
+            y_v,
+            q_m,
+            k_m,
+            v_m,
+            k,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    }
+
+    /// `fused_qkv_mq3g256_lloyd` with an optional Q/K/V bias folded into the
+    /// kernel's lane-0 store (`HIPFIRE_FUSE_QKV_BIAS`). All-null = byte-identical
+    /// to the unfused path. Both arch siblings (base + gfx1100) carry the 3
+    /// trailing bias params.
+    #[allow(clippy::too_many_arguments)]
+    pub fn fused_qkv_mq3g256_lloyd_with_bias(
+        &mut self,
+        a_q: &GpuTensor,
+        a_k: &GpuTensor,
+        a_v: &GpuTensor,
+        x: &GpuTensor,
+        y_q: &GpuTensor,
+        y_k: &GpuTensor,
+        y_v: &GpuTensor,
+        q_m: usize,
+        k_m: usize,
+        v_m: usize,
+        k: usize,
+        bias_q_ptr: *mut c_void,
+        bias_k_ptr: *mut c_void,
+        bias_v_ptr: *mut c_void,
+    ) -> HipResult<()> {
         self.bind_thread()?;
         let (src, module) = kernels::fused_qkv_mq3g256_lloyd_for_arch(
             &self.arch_caps,
@@ -1773,6 +1865,9 @@ impl Gpu {
         let k_m_i = k_m as i32;
         let v_m_i = v_m as i32;
         let k_i = k as i32;
+        let bq = bias_q_ptr;
+        let bk = bias_k_ptr;
+        let bv = bias_v_ptr;
         let mut params: Vec<*mut c_void> = vec![
             &aq as *const _ as *mut c_void,
             &ak as *const _ as *mut c_void,
@@ -1785,6 +1880,9 @@ impl Gpu {
             &k_m_i as *const _ as *mut c_void,
             &v_m_i as *const _ as *mut c_void,
             &k_i as *const _ as *mut c_void,
+            &bq as *const _ as *mut c_void,
+            &bk as *const _ as *mut c_void,
+            &bv as *const _ as *mut c_void,
         ];
         let total = (q_m + k_m + v_m) as u32;
         // Bandwidth: 3 weight matrices read once each, x shared (read once).
@@ -1813,6 +1911,9 @@ impl Gpu {
                 b.push_i32(k_m_i);
                 b.push_i32(v_m_i);
                 b.push_i32(k_i);
+                b.push_ptr(bq);
+                b.push_ptr(bk);
+                b.push_ptr(bv);
                 b
             },
         );

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -2285,6 +2285,11 @@ pub const FUSED_QKVZA_HFQ4G256_WAVE64_DP4A_SRC: &str =
 pub const FUSED_QKV_HFQ4G256_SRC: &str =
     include_str!("../../../kernels/src/fused_qkv_hfq4g256.hip");
 
+// Per-row 3-way fused HFQ6/MQ6-G256 preamble (qwen2-family decode). Authored
+// from gemv_hfq6g256's row body + qkv routing + optional bias epilogue.
+pub const FUSED_QKV_HFQ6G256_SRC: &str =
+    include_str!("../../../kernels/src/fused_qkv_hfq6g256.hip");
+
 // CDNA3 (MI300X / gfx94x) wave64-native 3-way fused preamble — 2 rows per
 // block via warp_id, halved grid. Byte-exact with the wave32 base kernel.
 pub const FUSED_QKV_HFQ4G256_WAVE64_SRC: &str =

--- a/kernels/src/fused_qkv_hfq4g256.hip
+++ b/kernels/src/fused_qkv_hfq4g256.hip
@@ -32,22 +32,28 @@ extern "C" __global__ void fused_qkv_hfq4g256(
     float*       __restrict__ y_k,
     float*       __restrict__ y_v,
     int q_m, int k_m, int v_m,
-    int K
+    int K,
+    // Optional Q/K/V bias (HIPFIRE_FUSE_QKV_BIAS). NULL = pure no-op, so the
+    // unfused callers that pass null stay byte-identical to the pre-fold path.
+    const float* __restrict__ bias_q,
+    const float* __restrict__ bias_k,
+    const float* __restrict__ bias_v
 ) {
     const int gid = blockIdx.x;
     const int total_m = q_m + k_m + v_m;
     if (gid >= total_m) return;
 
-    // Route to one of the three projections.
+    // Route to one of the three projections (and its matching bias).
     const char* A;
     float* y;
     int row;
+    const float* bias;
     if (gid < q_m) {
-        A = A_q; y = y_q; row = gid;
+        A = A_q; y = y_q; row = gid; bias = bias_q;
     } else if (gid < q_m + k_m) {
-        A = A_k; y = y_k; row = gid - q_m;
+        A = A_k; y = y_k; row = gid - q_m; bias = bias_k;
     } else {
-        A = A_v; y = y_v; row = gid - q_m - k_m;
+        A = A_v; y = y_v; row = gid - q_m - k_m; bias = bias_v;
     }
 
     const int tid = threadIdx.x;
@@ -143,5 +149,7 @@ extern "C" __global__ void fused_qkv_hfq4g256(
     for (int offset = 16; offset > 0; offset >>= 1)
         acc += __shfl_down(acc, offset);
 
-    if (tid == 0) y[row] = acc;
+    // NULL bias is a pure no-op: callers passing null stay byte-identical.
+    // fp32 store→load→add (separate path) == fused fp32 add (same order) → bit-exact.
+    if (tid == 0) y[row] = acc + (bias ? bias[row] : 0.0f);
 }

--- a/kernels/src/fused_qkv_hfq4g256_v2.gfx942.hip
+++ b/kernels/src/fused_qkv_hfq4g256_v2.gfx942.hip
@@ -26,7 +26,11 @@ extern "C" __global__ __launch_bounds__(128) void fused_qkv_hfq4g256_v2_gfx942(
     float*       __restrict__ y_k,
     float*       __restrict__ y_v,
     int q_m, int k_m, int v_m,
-    int K
+    int K,
+    // Optional Q/K/V bias (HIPFIRE_FUSE_QKV_BIAS). NULL = pure no-op.
+    const float* __restrict__ bias_q,
+    const float* __restrict__ bias_k,
+    const float* __restrict__ bias_v
 ) {
     const int tid = threadIdx.x;
     const int warp_id = tid >> 5;
@@ -39,12 +43,13 @@ extern "C" __global__ __launch_bounds__(128) void fused_qkv_hfq4g256_v2_gfx942(
     const char* A;
     float* y;
     int row;
+    const float* bias;
     if (gid < q_m) {
-        A = A_q; y = y_q; row = gid;
+        A = A_q; y = y_q; row = gid; bias = bias_q;
     } else if (gid < q_m + k_m) {
-        A = A_k; y = y_k; row = gid - q_m;
+        A = A_k; y = y_k; row = gid - q_m; bias = bias_k;
     } else {
-        A = A_v; y = y_v; row = gid - q_m - k_m;
+        A = A_v; y = y_v; row = gid - q_m - k_m; bias = bias_v;
     }
 
     const int groups_per_row = K / 256;
@@ -138,5 +143,5 @@ extern "C" __global__ __launch_bounds__(128) void fused_qkv_hfq4g256_v2_gfx942(
     for (int offset = 16; offset > 0; offset >>= 1)
         acc += __shfl_down(acc, offset);
 
-    if (lane == 0) y[row] = acc;
+    if (lane == 0) y[row] = acc + (bias ? bias[row] : 0.0f);
 }

--- a/kernels/src/fused_qkv_hfq4g256_wave64.hip
+++ b/kernels/src/fused_qkv_hfq4g256_wave64.hip
@@ -21,7 +21,11 @@ extern "C" __global__ void fused_qkv_hfq4g256_wave64(
     float*       __restrict__ y_k,
     float*       __restrict__ y_v,
     int q_m, int k_m, int v_m,
-    int K
+    int K,
+    // Optional Q/K/V bias (HIPFIRE_FUSE_QKV_BIAS). NULL = pure no-op.
+    const float* __restrict__ bias_q,
+    const float* __restrict__ bias_k,
+    const float* __restrict__ bias_v
 ) {
     const int tid = threadIdx.x;
     const int warp_id = tid >> 5;
@@ -34,12 +38,13 @@ extern "C" __global__ void fused_qkv_hfq4g256_wave64(
     const char* A;
     float* y;
     int row;
+    const float* bias;
     if (gid < q_m) {
-        A = A_q; y = y_q; row = gid;
+        A = A_q; y = y_q; row = gid; bias = bias_q;
     } else if (gid < q_m + k_m) {
-        A = A_k; y = y_k; row = gid - q_m;
+        A = A_k; y = y_k; row = gid - q_m; bias = bias_k;
     } else {
-        A = A_v; y = y_v; row = gid - q_m - k_m;
+        A = A_v; y = y_v; row = gid - q_m - k_m; bias = bias_v;
     }
 
     const int groups_per_row = K / 256;
@@ -133,5 +138,5 @@ extern "C" __global__ void fused_qkv_hfq4g256_wave64(
     for (int offset = 16; offset > 0; offset >>= 1)
         acc += __shfl_down(acc, offset);
 
-    if (lane == 0) y[row] = acc;
+    if (lane == 0) y[row] = acc + (bias ? bias[row] : 0.0f);
 }

--- a/kernels/src/fused_qkv_hfq6g256.hip
+++ b/kernels/src/fused_qkv_hfq6g256.hip
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+
+// 3-way fused HFQ6-G256 GEMV for the qwen2-family FullAttention preamble.
+// One launch performs all three projections from a single shared x:
+//
+//   y_q = W_q · x   (M=q_m)
+//   y_k = W_k · x   (M=k_m)
+//   y_v = W_v · x   (M=v_m)
+//
+// Per-row body is byte-identical to gemv_hfq6g256.hip (200 B / G256 group,
+// 6-bit packed 4-weights-per-3-bytes). Grid = q_m + k_m + v_m. Covers both
+// HFQ6G256 and MQ6G256 (same 6-bit on-disk layout).
+//
+// Bit-exact with three sequential gemv_hfq6g256 calls (+ the optional Q/K/V
+// bias add). NULL bias = pure no-op, so it is bit-exact with the unfused
+// 3×gemv_hfq6g256 path; non-null folds qwen2's QKV bias into the lane-0 store
+// (HIPFIRE_FUSE_QKV_BIAS), eliminating 3 separate bias_add launches.
+
+__launch_bounds__(32, 20)
+extern "C" __global__ void fused_qkv_hfq6g256(
+    const char*  __restrict__ A_q,
+    const char*  __restrict__ A_k,
+    const char*  __restrict__ A_v,
+    const float* __restrict__ x,
+    float*       __restrict__ y_q,
+    float*       __restrict__ y_k,
+    float*       __restrict__ y_v,
+    int q_m, int k_m, int v_m,
+    int K,
+    // Optional Q/K/V bias (HIPFIRE_FUSE_QKV_BIAS). NULL = pure no-op, so the
+    // unfused callers that pass null stay byte-identical to 3×gemv_hfq6g256.
+    const float* __restrict__ bias_q,
+    const float* __restrict__ bias_k,
+    const float* __restrict__ bias_v
+) {
+    const int gid = blockIdx.x;
+    const int total_m = q_m + k_m + v_m;
+    if (gid >= total_m) return;
+
+    // Route to one of the three projections (and its matching bias).
+    const char* A;
+    float* y;
+    int row;
+    const float* bias;
+    if (gid < q_m) {
+        A = A_q; y = y_q; row = gid; bias = bias_q;
+    } else if (gid < q_m + k_m) {
+        A = A_k; y = y_k; row = gid - q_m; bias = bias_k;
+    } else {
+        A = A_v; y = y_v; row = gid - q_m - k_m; bias = bias_v;
+    }
+
+    const int tid = threadIdx.x;
+    const int groups_per_row = K / 256;
+    const int row_bytes = groups_per_row * 200;
+    const char* row_ptr = A + (long long)row * row_bytes;
+
+    float acc = 0.0f;
+
+    for (int g = 0; g < groups_per_row; g++) {
+        const char* gptr = row_ptr + g * 200;
+        float scale = __builtin_bit_cast(float, *(const unsigned int*)(gptr));
+        float zero  = __builtin_bit_cast(float, *(const unsigned int*)(gptr + 4));
+        const unsigned char* data = (const unsigned char*)(gptr + 8);
+
+        // 256 weights / 32 threads = 8 weights per thread
+        // 4 weights per 3 bytes → 8 weights = 6 bytes per thread
+        int base_idx = g * 256 + tid * 8;
+        int byte_off = tid * 6;
+
+        unsigned char b0 = data[byte_off];
+        unsigned char b1 = data[byte_off + 1];
+        unsigned char b2 = data[byte_off + 2];
+        unsigned char b3 = data[byte_off + 3];
+        unsigned char b4 = data[byte_off + 4];
+        unsigned char b5 = data[byte_off + 5];
+
+        // 4 weights from first 3 bytes
+        int q0 = b0 & 63;
+        int q1 = (b0 >> 6) | ((b1 & 0xF) << 2);
+        int q2 = (b1 >> 4) | ((b2 & 3) << 4);
+        int q3 = b2 >> 2;
+        // 4 weights from next 3 bytes
+        int q4 = b3 & 63;
+        int q5 = (b3 >> 6) | ((b4 & 0xF) << 2);
+        int q6 = (b4 >> 4) | ((b5 & 3) << 4);
+        int q7 = b5 >> 2;
+
+        acc += (scale * (float)q0 + zero) * x[base_idx]
+             + (scale * (float)q1 + zero) * x[base_idx + 1]
+             + (scale * (float)q2 + zero) * x[base_idx + 2]
+             + (scale * (float)q3 + zero) * x[base_idx + 3]
+             + (scale * (float)q4 + zero) * x[base_idx + 4]
+             + (scale * (float)q5 + zero) * x[base_idx + 5]
+             + (scale * (float)q6 + zero) * x[base_idx + 6]
+             + (scale * (float)q7 + zero) * x[base_idx + 7];
+    }
+
+    for (int offset = 16; offset > 0; offset >>= 1)
+        acc += __shfl_down(acc, offset);
+
+    // NULL bias is a pure no-op: callers passing null stay byte-identical.
+    if (tid == 0) y[row] = acc + (bias ? bias[row] : 0.0f);
+}

--- a/kernels/src/fused_qkv_mq3g256_lloyd.gfx1100.hip
+++ b/kernels/src/fused_qkv_mq3g256_lloyd.gfx1100.hip
@@ -30,7 +30,11 @@ extern "C" __global__ void fused_qkv_mq3g256_lloyd(
     float*       __restrict__ y_k,
     float*       __restrict__ y_v,
     int q_m, int k_m, int v_m,
-    int K
+    int K,
+    // Optional Q/K/V bias (HIPFIRE_FUSE_QKV_BIAS). NULL = pure no-op.
+    const float* __restrict__ bias_q,
+    const float* __restrict__ bias_k,
+    const float* __restrict__ bias_v
 ) {
     const int gid = blockIdx.x;
     const int total_m = q_m + k_m + v_m;
@@ -39,12 +43,13 @@ extern "C" __global__ void fused_qkv_mq3g256_lloyd(
     const char* A;
     float* y;
     int row;
+    const float* bias;
     if (gid < q_m) {
-        A = A_q;  y = y_q;  row = gid;
+        A = A_q;  y = y_q;  row = gid; bias = bias_q;
     } else if (gid < q_m + k_m) {
-        A = A_k;  y = y_k;  row = gid - q_m;
+        A = A_k;  y = y_k;  row = gid - q_m; bias = bias_k;
     } else {
-        A = A_v;  y = y_v;  row = gid - (q_m + k_m);
+        A = A_v;  y = y_v;  row = gid - (q_m + k_m); bias = bias_v;
     }
 
     const int tid = threadIdx.x;
@@ -129,5 +134,5 @@ extern "C" __global__ void fused_qkv_mq3g256_lloyd(
     for (int offset = 16; offset > 0; offset >>= 1)
         acc += __shfl_down(acc, offset);
 
-    if (tid == 0) y[row] = acc;
+    if (tid == 0) y[row] = acc + (bias ? bias[row] : 0.0f);
 }

--- a/kernels/src/fused_qkv_mq3g256_lloyd.hip
+++ b/kernels/src/fused_qkv_mq3g256_lloyd.hip
@@ -21,7 +21,11 @@ extern "C" __global__ void fused_qkv_mq3g256_lloyd(
     float*       __restrict__ y_k,
     float*       __restrict__ y_v,
     int q_m, int k_m, int v_m,
-    int K
+    int K,
+    // Optional Q/K/V bias (HIPFIRE_FUSE_QKV_BIAS). NULL = pure no-op.
+    const float* __restrict__ bias_q,
+    const float* __restrict__ bias_k,
+    const float* __restrict__ bias_v
 ) {
     const int gid = blockIdx.x;
     const int total_m = q_m + k_m + v_m;
@@ -30,12 +34,13 @@ extern "C" __global__ void fused_qkv_mq3g256_lloyd(
     const char* A;
     float* y;
     int row;
+    const float* bias;
     if (gid < q_m) {
-        A = A_q;  y = y_q;  row = gid;
+        A = A_q;  y = y_q;  row = gid; bias = bias_q;
     } else if (gid < q_m + k_m) {
-        A = A_k;  y = y_k;  row = gid - q_m;
+        A = A_k;  y = y_k;  row = gid - q_m; bias = bias_k;
     } else {
-        A = A_v;  y = y_v;  row = gid - (q_m + k_m);
+        A = A_v;  y = y_v;  row = gid - (q_m + k_m); bias = bias_v;
     }
 
     const int tid = threadIdx.x;
@@ -96,5 +101,5 @@ extern "C" __global__ void fused_qkv_mq3g256_lloyd(
     for (int offset = 16; offset > 0; offset >>= 1)
         acc += __shfl_down(acc, offset);
 
-    if (tid == 0) y[row] = acc;
+    if (tid == 0) y[row] = acc + (bias ? bias[row] : 0.0f);
 }

--- a/kernels/src/fused_qkv_mq4g256_lloyd.gfx1100.hip
+++ b/kernels/src/fused_qkv_mq4g256_lloyd.gfx1100.hip
@@ -17,7 +17,11 @@ extern "C" __global__ void fused_qkv_mq4g256_lloyd(
     float*       __restrict__ y_k,
     float*       __restrict__ y_v,
     int q_m, int k_m, int v_m,
-    int K
+    int K,
+    // Optional Q/K/V bias (HIPFIRE_FUSE_QKV_BIAS). NULL = pure no-op.
+    const float* __restrict__ bias_q,
+    const float* __restrict__ bias_k,
+    const float* __restrict__ bias_v
 ) {
     const int gid = blockIdx.x;
     const int total_m = q_m + k_m + v_m;
@@ -26,12 +30,13 @@ extern "C" __global__ void fused_qkv_mq4g256_lloyd(
     const char* A;
     float* y;
     int row;
+    const float* bias;
     if (gid < q_m) {
-        A = A_q;  y = y_q;  row = gid;
+        A = A_q;  y = y_q;  row = gid; bias = bias_q;
     } else if (gid < q_m + k_m) {
-        A = A_k;  y = y_k;  row = gid - q_m;
+        A = A_k;  y = y_k;  row = gid - q_m; bias = bias_k;
     } else {
-        A = A_v;  y = y_v;  row = gid - (q_m + k_m);
+        A = A_v;  y = y_v;  row = gid - (q_m + k_m); bias = bias_v;
     }
 
     const int tid = threadIdx.x;
@@ -132,5 +137,5 @@ extern "C" __global__ void fused_qkv_mq4g256_lloyd(
     for (int offset = 16; offset > 0; offset >>= 1)
         acc += __shfl_down(acc, offset);
 
-    if (tid == 0) y[row] = acc;
+    if (tid == 0) y[row] = acc + (bias ? bias[row] : 0.0f);
 }

--- a/kernels/src/fused_qkv_mq4g256_lloyd.hip
+++ b/kernels/src/fused_qkv_mq4g256_lloyd.hip
@@ -16,7 +16,11 @@ extern "C" __global__ void fused_qkv_mq4g256_lloyd(
     float*       __restrict__ y_k,
     float*       __restrict__ y_v,
     int q_m, int k_m, int v_m,
-    int K
+    int K,
+    // Optional Q/K/V bias (HIPFIRE_FUSE_QKV_BIAS). NULL = pure no-op.
+    const float* __restrict__ bias_q,
+    const float* __restrict__ bias_k,
+    const float* __restrict__ bias_v
 ) {
     const int gid = blockIdx.x;
     const int total_m = q_m + k_m + v_m;
@@ -25,12 +29,13 @@ extern "C" __global__ void fused_qkv_mq4g256_lloyd(
     const char* A;
     float* y;
     int row;
+    const float* bias;
     if (gid < q_m) {
-        A = A_q;  y = y_q;  row = gid;
+        A = A_q;  y = y_q;  row = gid; bias = bias_q;
     } else if (gid < q_m + k_m) {
-        A = A_k;  y = y_k;  row = gid - q_m;
+        A = A_k;  y = y_k;  row = gid - q_m; bias = bias_k;
     } else {
-        A = A_v;  y = y_v;  row = gid - (q_m + k_m);
+        A = A_v;  y = y_v;  row = gid - (q_m + k_m); bias = bias_v;
     }
 
     const int tid = threadIdx.x;
@@ -101,5 +106,5 @@ extern "C" __global__ void fused_qkv_mq4g256_lloyd(
     for (int offset = 16; offset > 0; offset >>= 1)
         acc += __shfl_down(acc, offset);
 
-    if (tid == 0) y[row] = acc;
+    if (tid == 0) y[row] = acc + (bias ? bias[row] : 0.0f);
 }

--- a/kernels/src/fused_qkv_q4k.hip
+++ b/kernels/src/fused_qkv_q4k.hip
@@ -13,7 +13,11 @@ extern "C" __global__ void fused_qkv_q4k(
     float* __restrict__ y_q,
     float* __restrict__ y_k,
     float* __restrict__ y_v,
-    int q_m, int k_m, int v_m, int K
+    int q_m, int k_m, int v_m, int K,
+    // Optional Q/K/V bias (HIPFIRE_FUSE_QKV_BIAS). NULL = pure no-op.
+    const float* __restrict__ bias_q,
+    const float* __restrict__ bias_k,
+    const float* __restrict__ bias_v
 ) {
     const int gid = blockIdx.x;
     const int tid = threadIdx.x;
@@ -22,12 +26,13 @@ extern "C" __global__ void fused_qkv_q4k(
     const unsigned char* A;
     float* y;
     int local_row;
+    const float* bias;
     if (gid < q_m) {
-        A = A_q; y = y_q; local_row = gid;
+        A = A_q; y = y_q; local_row = gid; bias = bias_q;
     } else if (gid < q_m + k_m) {
-        A = A_k; y = y_k; local_row = gid - q_m;
+        A = A_k; y = y_k; local_row = gid - q_m; bias = bias_k;
     } else {
-        A = A_v; y = y_v; local_row = gid - q_m - k_m;
+        A = A_v; y = y_v; local_row = gid - q_m - k_m; bias = bias_v;
     }
 
     const int blocks_per_row = K / 256;
@@ -83,5 +88,5 @@ extern "C" __global__ void fused_qkv_q4k(
     for (int offset = 16; offset > 0; offset >>= 1) {
         sum += __shfl_down(sum, offset);
     }
-    if (tid == 0) y[local_row] = sum;
+    if (tid == 0) y[local_row] = sum + (bias ? bias[local_row] : 0.0f);
 }

--- a/kernels/src/fused_qkv_q8_0.hip
+++ b/kernels/src/fused_qkv_q8_0.hip
@@ -32,7 +32,11 @@ extern "C" __global__ void fused_qkv_q8_0(
     float*               __restrict__ y_k,
     float*               __restrict__ y_v,
     int q_m, int k_m, int v_m,
-    int K
+    int K,
+    // Optional Q/K/V bias (HIPFIRE_FUSE_QKV_BIAS). NULL = pure no-op.
+    const float* __restrict__ bias_q,
+    const float* __restrict__ bias_k,
+    const float* __restrict__ bias_v
 ) {
     const int gid = blockIdx.x;
     const int total_m = q_m + k_m + v_m;
@@ -42,12 +46,13 @@ extern "C" __global__ void fused_qkv_q8_0(
     const unsigned char* A;
     float* y;
     int row;
+    const float* bias;
     if (gid < q_m) {
-        A = A_q; y = y_q; row = gid;
+        A = A_q; y = y_q; row = gid; bias = bias_q;
     } else if (gid < q_m + k_m) {
-        A = A_k; y = y_k; row = gid - q_m;
+        A = A_k; y = y_k; row = gid - q_m; bias = bias_k;
     } else {
-        A = A_v; y = y_v; row = gid - q_m - k_m;
+        A = A_v; y = y_v; row = gid - q_m - k_m; bias = bias_v;
     }
 
     const int tid = threadIdx.x;
@@ -79,5 +84,5 @@ extern "C" __global__ void fused_qkv_q8_0(
 
     for (int offset = 16; offset > 0; offset >>= 1)
         sum += __shfl_down(sum, offset);
-    if (tid == 0) y[row] = sum;
+    if (tid == 0) y[row] = sum + (bias ? bias[row] : 0.0f);
 }


### PR DESCRIPTION
## QKV-bias fold: eliminate qwen2 per-layer `bias_add` launches (default-on, byte-identical, +2.5–4.1% decode)

Productizes the QKV-bias fold across **all per-row fused-QKV decode dtypes**. qwen2-family models (`attention_bias=true`) run 3 tiny, overhead-dominated `bias_add` kernels per layer right after the fused QKV projection. This folds the Q/K/V bias into the fused-QKV kernel's lane-0 store (`y[row] = acc + (bias ? bias[row] : 0.0f)`), so 3 separate launches/layer become 0 — a free fma at a store that already runs (no grid change, no barrier, no occupancy loss).

NULL bias pointers are an exact kernel no-op, so every existing (non-bias) caller stays byte-identical regardless.

### Mechanism
- **Flag** `fuse_qkv_bias` — env `HIPFIRE_FUSE_QKV_BIAS`, **default ON**, opt out with `=0` for bisection (resolved once at init; no per-launch env lock).
- **Kernels** gain 3 nullable `bias_q/k/v` params + the `+bias` epilogue (base + every arch sibling, so the kernarg ABI matches whatever the host dispatches).
- **Dispatch**: `FusedQkvParams.bias: Option<[&GpuTensor;3]>`; each per-row decode arm routes through a `gpu.fused_qkv_*_with_bias` variant (old methods delegate with nulls).
- **`execute_steps`**: a generalized peek-ahead — when a fold-supported 3-way QKV decode key is followed by 3 `BiasAdd` on the q/k/v outputs (ptr-identity checked), fold + skip them. dp4a archs (gfx906, no bias params in their kernel) are guarded off so the 3 bias adds run separately as before.

### Coverage
- **Family A** (clean byte-identical fold into existing per-row kernels): `fused_qkv_hfq4g256` (MQ4G256 + HFQ4G256), `mq4g256_lloyd`, `mq3g256_lloyd`, `q4k`, `q8_0` (+ gfx1100/wave64/v2 siblings).
- **Family B** (authored a new per-row kernel): `fused_qkv_hfq6g256` for HFQ6/MQ6, which previously had no per-row decode kernel (ran the n=1 GEMM). The GEMM→per-row decode swap is gated to only when the fold actually fires (bias present); fold-off keeps the historical GEMM.
- Correctly **skips** QKVZA/DeltaNet and qwen3/qwen35/MoE (no QKV bias), and research/unused formats (would be dead code).

### Validation (gfx1151)
**Correctness — bit-exact:**
- MQ4: three-way byte-identity — clean-master ≡ fold-off ≡ fold-on (fold fired 3060×).
- New GPU example `crates/rdna-compute/examples/test_fused_qkv_bias_parity.rs` (ALL bit-exact, max_abs=0): for every dtype `no-bias==0` and `with-bias==bias` (validates kernarg ABI + q/k/v→bias routing + epilogue); plus `fused_qkv_hfq6g256 == 3×gemv_hfq6g256` on finite weights (Family B's required gate).

**Coherent-model byte-identity** (Qwen2.5-1.5B-Instruct, dim 1536, a real coherent qwen2-bias model):

| dtype | output | distinct | fold-on ≡ fold-off |
|---|---|---|---|
| mq4-lloyd | coherent prose | 74 | ✅ byte-identical |
| mq3-lloyd | coherent prose | 59 | ✅ byte-identical |

**No regression:** `scripts/coherence-gate.sh` exit 0 across all present qwen3.5 models (qwen35 has no QKV bias → fold never fires there; confirms the dispatch additions don't regress).

### Performance (decode tok/s, fold-on vs fold-off; warm + 5 fresh procs each; byte-identical prompts; non-overlapping ranges = real signal)

| model / dtype | fold-off | fold-on | Δ |
|---|---|---|---|
| vibethinker-3b.mq4 (HFQ4/MQ4, 36L) | 91.70 | 94.03 | **+2.54%** |
| qwen2.5-1.5b.mq4-lloyd (28L) | 132.80 | 136.99 | **+3.16%** |
| qwen2.5-1.5b.mq3-lloyd (28L) | 148.59 | 154.68 | **+4.10%** |

The win scales with how launch-bound the decode is (smaller/faster models recover proportionally more launch tax) — matching the PoC's +2.6% and the thesis that the recoverable tax on gfx1151 dense decode is in the *tiny* ops.

### Notes
- q4k / q8_0 / hfq6 are validated by the GPU parity example; no dense qwen2 model in those formats was available for a model-level coherence run (the parity test is the hardware validation there).
- The original PoC test model (vibethinker-3b) produces degenerate greedy output; this was investigated and found to be **unrelated to this change** (identical on clean-master; a near-lossless Q8 re-quant also reproduces it, ruling out quantization) — a separate model/engine-interaction issue, tracked independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
