### PR TITLE
refactor(mmq-screening): make MMQ screening arch-generic via MmqScreenable trait

### DIFF
--- a/crates/hipfire-arch-dots-ocr/src/dots_ocr.rs
+++ b/crates/hipfire-arch-dots-ocr/src/dots_ocr.rs
@@ -42,6 +42,7 @@ use hip_bridge::HipResult;
 use hipfire_arch_qwen2::qwen2::{Qwen2Config, Qwen2Weights};
 use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::llama::{f16_to_f32, f32_to_f16, attention_family, DispatchCtx, FullAttnParams, KernelKey, ShapeInfo};
+use hipfire_runtime::MmqScreenable;
 use rdna_compute::{DType, Gpu, GpuTensor};
 
 // ─── Config ─────────────────────────────────────────────────────────────
@@ -332,6 +333,13 @@ impl DotsVisionWeights {
 pub struct DotsOcrWeights {
     pub text: Qwen2Weights,
     pub vision: DotsVisionWeights,
+}
+
+impl MmqScreenable for DotsOcrWeights {
+    fn screen_mmq_weights(&self, gpu: &mut Gpu) -> (usize, usize) {
+        // Vision tower is F16-only (no MMQ-eligible weights); delegate to text.
+        self.text.screen_mmq_weights(gpu)
+    }
 }
 
 impl DotsOcrWeights {

--- a/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
+++ b/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
@@ -17,6 +17,7 @@
 use crate::config::{Lfm2MoeConfig, MixerKind};
 use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::llama::{f16_to_f32, KvCache, WeightTensor};
+use hipfire_runtime::{screen_weight_tensor, MmqScreenable};
 use rdna_compute::{DType, Gpu, GpuTensor};
 
 // ───────────────────────── HFQ load helpers ─────────────────────────
@@ -218,6 +219,38 @@ pub struct Lfm2MoeWeights {
     pub embedding_norm: GpuTensor, // model.embedding_norm.weight (final norm)
     pub lm_head: WeightTensor, // tied = embed_tokens (loaded as Q8 weight)
     pub layers: Vec<Lfm2MoeLayerWeights>,
+}
+
+impl MmqScreenable for Lfm2MoeWeights {
+    fn screen_mmq_weights(&self, gpu: &mut Gpu) -> (usize, usize) {
+        let (mut n_safe, mut n_unsafe) = (0usize, 0usize);
+        screen_weight_tensor(&self.lm_head, gpu, &mut n_safe, &mut n_unsafe);
+        for layer in &self.layers {
+            match &layer.mixer {
+                Mixer::Conv(c) => {
+                    screen_weight_tensor(&c.in_proj, gpu, &mut n_safe, &mut n_unsafe);
+                    screen_weight_tensor(&c.out_proj, gpu, &mut n_safe, &mut n_unsafe);
+                }
+                Mixer::Attention(a) => {
+                    for wt in [&a.wq, &a.wk, &a.wv, &a.wo] {
+                        screen_weight_tensor(wt, gpu, &mut n_safe, &mut n_unsafe);
+                    }
+                }
+            }
+            match &layer.ffn {
+                Ffn::Dense(d) => {
+                    for wt in [&d.w1, &d.w3, &d.w2] {
+                        screen_weight_tensor(wt, gpu, &mut n_safe, &mut n_unsafe);
+                    }
+                }
+                // MoE router only; routed experts are out of scope.
+                Ffn::Moe(m) => {
+                    screen_weight_tensor(&m.router, gpu, &mut n_safe, &mut n_unsafe);
+                }
+            }
+        }
+        (n_safe, n_unsafe)
+    }
 }
 
 impl Lfm2MoeWeights {

--- a/crates/hipfire-arch-minimax/src/minimax.rs
+++ b/crates/hipfire-arch-minimax/src/minimax.rs
@@ -12,6 +12,7 @@
 
 use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::llama::{f16_to_f32, KvCache, WeightTensor};
+use hipfire_runtime::{screen_weight_tensor, MmqScreenable};
 use rdna_compute::{DType, Gpu, GpuTensor};
 use serde::Deserialize;
 
@@ -681,5 +682,20 @@ impl MiniMaxState {
 
     pub fn reset(&mut self) {
         self.n_tokens = 0;
+    }
+}
+
+impl MmqScreenable for MiniMaxWeights {
+    fn screen_mmq_weights(&self, gpu: &mut Gpu) -> (usize, usize) {
+        let (mut n_safe, mut n_unsafe) = (0usize, 0usize);
+        screen_weight_tensor(&self.lm_head, gpu, &mut n_safe, &mut n_unsafe);
+        // Attention projections + the (dense) router only. Routed experts are
+        // out of scope — see the `MmqScreenable` doc comment.
+        for layer in &self.layers {
+            for wt in [&layer.wq, &layer.wk, &layer.wv, &layer.wo, &layer.router] {
+                screen_weight_tensor(wt, gpu, &mut n_safe, &mut n_unsafe);
+            }
+        }
+        (n_safe, n_unsafe)
     }
 }

--- a/crates/hipfire-arch-qwen2/src/qwen2.rs
+++ b/crates/hipfire-arch-qwen2/src/qwen2.rs
@@ -36,6 +36,7 @@ use hipfire_dispatch::pipeline::superop::{
     self, EscapeKind, ForwardBindings, OpBinding, OpFlavor, SuperOp, SuperOpKind, WeightSlot,
 };
 use hipfire_dispatch::types::{dtype_rotation_plan, DispatchError};
+use hipfire_runtime::{screen_weight_tensor, MmqScreenable};
 use rdna_compute::{DType, Gpu, GpuTensor};
 
 /// Qwen2 model-shape constants parsed from `HfqFile::metadata_json`.
@@ -247,6 +248,27 @@ impl Qwen2Weights {
             let _ = gpu.free_tensor(l.w_up.buf);
             let _ = gpu.free_tensor(l.w_down.buf);
         }
+    }
+}
+
+impl MmqScreenable for Qwen2Weights {
+    fn screen_mmq_weights(&self, gpu: &mut Gpu) -> (usize, usize) {
+        let (mut n_safe, mut n_unsafe) = (0usize, 0usize);
+        screen_weight_tensor(&self.output, gpu, &mut n_safe, &mut n_unsafe);
+        for layer in &self.layers {
+            for wt in [
+                &layer.wq,
+                &layer.wk,
+                &layer.wv,
+                &layer.wo,
+                &layer.w_gate,
+                &layer.w_up,
+                &layer.w_down,
+            ] {
+                screen_weight_tensor(wt, gpu, &mut n_safe, &mut n_unsafe);
+            }
+        }
+        (n_safe, n_unsafe)
     }
 }
 

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -17,6 +17,7 @@ use hipfire_runtime::llama::{
 use hipfire_runtime::model_source::ModelSource;
 use hipfire_runtime::multi_gpu::Gpus;
 use hipfire_runtime::tp_shard::ShardConfig;
+use hipfire_runtime::{screen_weight_tensor, MmqScreenable};
 use rdna_compute::{DType, Gpu, GpuTensor};
 use hipfire_dispatch::context::DispatchCtx;
 use hipfire_dispatch::families::gemv::{GivensRef, WeightRef};
@@ -878,6 +879,44 @@ pub struct DeltaNetState {
     pub s_ef_residual: Vec<GpuTensor>,
     /// Current quantization mode
     pub quant: StateQuant,
+}
+
+impl MmqScreenable for Qwen35Weights {
+    fn screen_mmq_weights(&self, gpu: &mut Gpu) -> (usize, usize) {
+        let (mut n_safe, mut n_unsafe) = (0usize, 0usize);
+        screen_weight_tensor(&self.output, gpu, &mut n_safe, &mut n_unsafe);
+        for layer in &self.layers {
+            match layer {
+                LayerWeights::DeltaNet(w) => {
+                    for wt in [
+                        &w.wqkv, &w.wz, &w.w_alpha, &w.w_beta, &w.wo, &w.w_gate, &w.w_up,
+                        &w.w_down,
+                    ] {
+                        screen_weight_tensor(wt, gpu, &mut n_safe, &mut n_unsafe);
+                    }
+                }
+                LayerWeights::FullAttn(w) => {
+                    for wt in [&w.wq, &w.wk, &w.wv, &w.wo, &w.w_gate, &w.w_up, &w.w_down] {
+                        screen_weight_tensor(wt, gpu, &mut n_safe, &mut n_unsafe);
+                    }
+                }
+                // MoE layers: attention + the (single, dense) router only. Routed
+                // experts / shared expert are intentionally out of scope — see the
+                // `MmqScreenable` doc comment.
+                LayerWeights::DeltaNetMoe(w) => {
+                    for wt in [&w.wqkv, &w.wz, &w.w_alpha, &w.w_beta, &w.wo, &w.ffn.router] {
+                        screen_weight_tensor(wt, gpu, &mut n_safe, &mut n_unsafe);
+                    }
+                }
+                LayerWeights::FullAttnMoe(w) => {
+                    for wt in [&w.wq, &w.wk, &w.wv, &w.wo, &w.ffn.router] {
+                        screen_weight_tensor(wt, gpu, &mut n_safe, &mut n_unsafe);
+                    }
+                }
+            }
+        }
+        (n_safe, n_unsafe)
+    }
 }
 
 impl DeltaNetState {

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -36,6 +36,7 @@ use hipfire_arch_qwen35::speculative::{
 };
 use hipfire_arch_qwen35_vl::image;
 use hipfire_arch_qwen35_vl::qwen35_vl;
+use hipfire_runtime::arch::MmqScreenable;
 use hipfire_runtime::cask::CaskCtx;
 use hipfire_runtime::dflash::{DflashConfig, DflashScratch, DflashWeights};
 use hipfire_runtime::eos_filter::{EosFilter, EosFilterConfig, FilterAction};
@@ -3505,6 +3506,7 @@ fn load_model(
         use hipfire_runtime::arch::Architecture;
         let config = <Qwen2 as Architecture>::config_from_hfq(&hfq)?;
         let weights = <Qwen2 as Architecture>::load_weights(&mut hfq, &config, gpu)?;
+        maybe_screen_mmq(&weights, gpu);
         let state = qwen2::Qwen2State::new_with_max_seq(gpu, &config, max_seq)
             .map_err(|e| format!("qwen2: Qwen2State::new_with_max_seq failed: {e:?}"))?;
         let chat_template = resolve_chat_template(&hfq, path);
@@ -3588,6 +3590,7 @@ fn load_model(
         use hipfire_runtime::arch::Architecture;
         let config = <DotsOcr as Architecture>::config_from_hfq(&hfq)?;
         let weights = <DotsOcr as Architecture>::load_weights(&mut hfq, &config, gpu)?;
+        maybe_screen_mmq(&weights, gpu);
         // Size the decode KV cache to the requested window (the trait's
         // new_state uses a default max_seq; OCR prompts are long).
         let state = qwen2::Qwen2State::new_with_max_seq(gpu, &config.text, max_seq)
@@ -3778,6 +3781,7 @@ fn load_model(
         let _ = state_quant_override;
         let config = lfm2moe::config::Lfm2MoeConfig::from_hfq(&hfq)?;
         let weights = lfm2moe::lfm2moe::Lfm2MoeWeights::load(&mut hfq, &config, gpu)?;
+        maybe_screen_mmq(&weights, gpu);
         // Size the KV + conv-state cache to the requested window.
         let state = lfm2moe::lfm2moe::Lfm2MoeState::new_with_max_seq(gpu, &config, max_seq)
             .map_err(|e| format!("lfm2moe: Lfm2MoeState::new_with_max_seq failed: {e}"))?;
@@ -3885,6 +3889,7 @@ fn load_model(
         use hipfire_runtime::arch::Architecture;
         let config = <minimax::MiniMaxM2 as Architecture>::config_from_hfq(&hfq)?;
         let weights = <minimax::MiniMaxM2 as Architecture>::load_weights(&mut hfq, &config, gpu)?;
+        maybe_screen_mmq(&weights, gpu);
         // Size the KV cache to the requested window (the trait's new_state
         // caps at 8192; honour the caller's max_seq when it's larger/smaller).
         let state = minimax::MiniMaxState::new_with_max_seq(gpu, &config, max_seq)
@@ -4005,36 +4010,7 @@ fn load_model(
         };
 
         let weights = <Qwen35 as Architecture>::load_weights(&mut hfq, &config, gpu)?;
-
-        // MMQ per-weight screening (#87): pre-screen all weight matrices at
-        // load time so the first prefill doesn't pay the screening overhead.
-        // Results are cached by device pointer in gpu.mmq_screen.cache.
-        // Disabled by default on all arches; opt-in via mmq_screen=true or
-        // HIPFIRE_MMQ_SCREEN=1. gfx906 is included for the opt-in case so
-        // its ~700 µs/weight screening-reference dispatch doesn't surprise
-        // first prefill if a user enables it.
-        if gpu.mmq_screen.enabled
-            && matches!(
-                gpu.arch.as_str(),
-                "gfx906"
-                    | "gfx1100"
-                    | "gfx1101"
-                    | "gfx1102"
-                    | "gfx1103"
-                    | "gfx1150"
-                    | "gfx1151"
-                    | "gfx1152"
-            )
-        {
-            let t0 = std::time::Instant::now();
-            let (n_safe, n_unsafe) = screen_weights_qwen35(&weights, gpu);
-            let elapsed = t0.elapsed();
-            eprintln!(
-                "  MMQ screening: {n_safe} safe, {n_unsafe} unsafe (threshold={:.2}, {:.1}ms)",
-                gpu.mmq_screen.threshold,
-                elapsed.as_secs_f64() * 1000.0,
-            );
-        }
+        maybe_screen_mmq(&weights, gpu);
 
         // KV cache modes (RotorQuant-style asymmetric: K rotated + V Q8):
         //   asym3 (default) — K at 3-bit rotated, V at Q8_0. 5.5× vs fp32.
@@ -4436,6 +4412,7 @@ fn load_model(
         use hipfire_runtime::arch::Architecture;
         let config = <Llama as Architecture>::config_from_hfq(&hfq).map_err(|e| e.to_string())?;
         let weights = <Llama as Architecture>::load_weights(&mut hfq, &config, gpu)?;
+        maybe_screen_mmq(&weights, gpu);
         eprintln!("  KV cache: Q8");
         let kv = llama::KvCache::new_gpu_q8(
             gpu,
@@ -5049,71 +5026,38 @@ fn load_model_pp(
     })
 }
 
-/// Pre-screen all Qwen3.5/3.6 weight matrices for MMQ safety (#87).
-/// Returns (n_safe, n_unsafe). Results are cached in gpu.mmq_screen.cache.
-fn screen_weights_qwen35(
-    weights: &qwen35::Qwen35Weights,
-    gpu: &mut rdna_compute::Gpu,
-) -> (usize, usize) {
-    use hipfire_arch_qwen35::qwen35::LayerWeights;
-    let mut n_safe = 0usize;
-    let mut n_unsafe = 0usize;
-
-    for layer in &weights.layers {
-        // Collect all weight tensors for this layer that could use MMQ
-        let wts: Vec<(&hipfire_runtime::llama::WeightTensor, &str)> = match layer {
-            LayerWeights::DeltaNet(l) => vec![
-                (&l.wqkv, "qkvza.qkv"),
-                (&l.wz, "qkvza.z"),
-                (&l.w_beta, "qkvza.beta"),
-                (&l.w_alpha, "qkvza.alpha"),
-                (&l.w_gate, "gate_up.gate"),
-                (&l.w_up, "gate_up.up"),
-                (&l.wo, "residual"),
-            ],
-            LayerWeights::FullAttn(l) => vec![
-                (&l.wq, "qkv.q"),
-                (&l.wk, "qkv.k"),
-                (&l.wv, "qkv.v"),
-                (&l.w_gate, "gate_up.gate"),
-                (&l.w_up, "gate_up.up"),
-                (&l.wo, "residual"),
-            ],
-            LayerWeights::DeltaNetMoe(l) => vec![
-                (&l.wqkv, "qkvza.qkv"),
-                (&l.wz, "qkvza.z"),
-                (&l.w_beta, "qkvza.beta"),
-                (&l.w_alpha, "qkvza.alpha"),
-                (&l.wo, "residual"),
-            ],
-            LayerWeights::FullAttnMoe(l) => vec![
-                (&l.wq, "qkv.q"),
-                (&l.wk, "qkv.k"),
-                (&l.wv, "qkv.v"),
-                (&l.wo, "residual"),
-            ],
-        };
-
-        for (wt, _name) in wts {
-            // MMQ kernels only operate on HFQ4G256 weights. Other formats
-            // (MQ3, MQ2, HFQ6, etc.) use different dispatch paths and must
-            // not be fed to the HFQ4-specific screening kernels — buffer
-            // layout mismatch would read past the end. See PR #106.
-            if !matches!(
-                wt.gpu_dtype,
-                rdna_compute::DType::HFQ4G256 | rdna_compute::DType::MQ4G256
-            ) {
-                continue;
-            }
-            if gpu.mmq_screen_weight(&wt.buf, wt.m, wt.k) {
-                n_safe += 1;
-            } else {
-                n_unsafe += 1;
-            }
-        }
+/// Load-time MMQ per-weight screening (#87): pre-screen an arch's weight
+/// matrices so the first prefill doesn't pay the screening overhead. Results
+/// are cached by device pointer in `gpu.mmq_screen.cache`. Disabled by default
+/// on all arches; opt-in via `mmq_screen=true` or `HIPFIRE_MMQ_SCREEN=1`.
+/// gfx906 is included for the opt-in case so its ~700 µs/weight
+/// screening-reference dispatch doesn't surprise first prefill if enabled.
+///
+/// Each arch owns iteration over its own weights via `MmqScreenable`; this
+/// helper just applies the enable + arch guard uniformly across call sites.
+fn maybe_screen_mmq(weights: &impl MmqScreenable, gpu: &mut rdna_compute::Gpu) {
+    if !gpu.mmq_screen.enabled
+        || !matches!(
+            gpu.arch.as_str(),
+            "gfx906"
+                | "gfx1100"
+                | "gfx1101"
+                | "gfx1102"
+                | "gfx1103"
+                | "gfx1150"
+                | "gfx1151"
+                | "gfx1152"
+        )
+    {
+        return;
     }
-
-    (n_safe, n_unsafe)
+    let t0 = std::time::Instant::now();
+    let (n_safe, n_unsafe) = weights.screen_mmq_weights(gpu);
+    eprintln!(
+        "  MMQ screening: {n_safe} safe, {n_unsafe} unsafe (threshold={:.2}, {:.1}ms)",
+        gpu.mmq_screen.threshold,
+        t0.elapsed().as_secs_f64() * 1000.0,
+    );
 }
 
 /// Expert-parallel (EP) model load — shards the routed experts across `tp`

--- a/crates/hipfire-runtime/src/arch.rs
+++ b/crates/hipfire-runtime/src/arch.rs
@@ -46,7 +46,8 @@
 //!      time.
 
 use crate::hfq::HfqFile;
-use rdna_compute::Gpu;
+use crate::llama::WeightTensor;
+use rdna_compute::{DType, Gpu};
 
 /// Bring-up contract for a hipfire architecture.
 ///
@@ -273,4 +274,43 @@ pub struct EosFilterOverrides {
     /// If `Some`, override whether to strip `<think>...</think>` blocks
     /// from the visible stream. Default is on for thinking-mode arches.
     pub strip_think: Option<bool>,
+}
+
+/// Load-time MMQ safety pre-screen (#87).
+///
+/// The Q8_1 MMQ integer dot-product path produces unacceptable error on some
+/// outlier-heavy weight rows. Screening probes each MMQ-eligible weight tensor
+/// at load time against the WMMA/FP16 reference and records a per-device-pointer
+/// verdict in `Gpu::mmq_screen.cache`, so the first serve-time GEMM doesn't pay
+/// the probe cost. Each arch iterates its own weights and returns
+/// `(n_safe, n_unsafe)`.
+///
+/// MoE routed experts and the shared expert are intentionally NOT screened:
+/// their `WeightTensor` Vecs are empty at load time under paged / EP-shard modes
+/// (buffers owned by the weight pager / packed EP blobs), so a naive `experts[i]`
+/// loop would screen nothing anyway. That coverage is a follow-up.
+pub trait MmqScreenable {
+    fn screen_mmq_weights(&self, gpu: &mut Gpu) -> (usize, usize);
+}
+
+/// Screen one `WeightTensor`; bumps `n_safe`/`n_unsafe` only for MMQ-eligible
+/// formats.
+///
+/// The dtype guard is load-bearing: non-HFQ4/MQ4 formats (e.g. the `*Lloyd`
+/// variants) have different buffer layouts and must NOT be fed to the HFQ4
+/// reference kernel — doing so reads past the buffer end (see PR #106).
+pub fn screen_weight_tensor(
+    wt: &WeightTensor,
+    gpu: &mut Gpu,
+    n_safe: &mut usize,
+    n_unsafe: &mut usize,
+) {
+    if !matches!(wt.gpu_dtype, DType::HFQ4G256 | DType::MQ4G256) {
+        return;
+    }
+    if gpu.mmq_screen_weight(&wt.buf, wt.m, wt.k) {
+        *n_safe += 1;
+    } else {
+        *n_unsafe += 1;
+    }
 }

--- a/crates/hipfire-runtime/src/lib.rs
+++ b/crates/hipfire-runtime/src/lib.rs
@@ -44,3 +44,5 @@ pub mod tokenizer;
 pub mod eos_filter;
 pub mod prompt_frame;
 pub mod tool_call;
+
+pub use crate::arch::{screen_weight_tensor, MmqScreenable};

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -5,6 +5,7 @@
 //! LLaMA model implementation using RDNA GPU compute.
 //! Supports loading from GGUF files and running inference.
 
+use crate::arch::{screen_weight_tensor, MmqScreenable};
 use crate::gguf::{GgmlType, GgufFile, TensorInfo};
 use crate::multi_gpu::Gpus;
 use hip_bridge::HipResult;
@@ -692,6 +693,20 @@ impl LlamaWeights {
             let _ = gpu.free_tensor(l.w_up.buf);
             let _ = gpu.free_tensor(l.w_down.buf);
         }
+    }
+}
+
+impl MmqScreenable for LlamaWeights {
+    fn screen_mmq_weights(&self, gpu: &mut Gpu) -> (usize, usize) {
+        let (mut n_safe, mut n_unsafe) = (0usize, 0usize);
+        screen_weight_tensor(&self.output, gpu, &mut n_safe, &mut n_unsafe);
+        for layer in &self.layers {
+            for wt in [&layer.wq, &layer.wk, &layer.wv, &layer.wo,
+                       &layer.w_gate, &layer.w_up, &layer.w_down] {
+                screen_weight_tensor(wt, gpu, &mut n_safe, &mut n_unsafe);
+            }
+        }
+        (n_safe, n_unsafe)
     }
 }
 


### PR DESCRIPTION
## Summary

- Extracts a `MmqScreenable` trait + `screen_weight_tensor` helper into `hipfire-runtime::arch`, replacing the qwen35-only `screen_weights_qwen35` free function in `daemon.rs`
- Adds impls for **llama, qwen35, qwen2, minimax, lfm2moe, dots-ocr** (6 arches); deepseek4 excluded (packed blob layout, no `WeightTensor`)
- Fixes two gaps in the prior qwen35 impl: `w_down` on dense layers and the top-level `output` tensor were not screened before
- Replaces 6 bespoke call sites with a single `maybe_screen_mmq(&weights, gpu)` that applies the enable guard and arch allowlist (`gfx906`, `gfx1100`–`gfx1152`) uniformly

Default behavior is unchanged: screening is off by default (`mmq_screen_default = false`).

## Test plan
- [ ] `cargo check --workspace --examples` passes (with and without `deltanet` feature)
- [ ] No-GPU lib tests pass
- [ ] GPU smoke on gfx1151 with `HIPFIRE_MMQ_SCREEN=1`: llama 111/86, lfm2moe 42/24, dots-ocr 0/0 (q8, correct), qwen35 baseline 180/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)