### PR TITLE
fix(quantize): handle "qwen35" architecture alias without underscore

### DIFF
--- a/crates/hipfire-quantize/src/main.rs
+++ b/crates/hipfire-quantize/src/main.rs
@@ -5744,7 +5744,7 @@ fn run_gguf_pipeline(
     let auto_arch_id: u32 = match arch_str.as_str() {
         "llama" => 0,
         "qwen3" | "qwen2" => 1,
-        "qwen3_5" | "qwen3_5_text" => 5,
+        "qwen3_5" | "qwen3_5_text" | "qwen35" => 5,
         "qwen3moe" => 6,
         other => {
             // Structural-pillar guard: a qwen3* GGUF that doesn't match an
@@ -7058,7 +7058,7 @@ fn main() {
     let auto_arch_id = match arch_str {
         "llama" => 0u32,
         "qwen3" | "qwen2" => 1,
-        "qwen3_5" | "qwen3_5_text" => 5,
+        "qwen3_5" | "qwen3_5_text" | "qwen35" => 5,
         // Qwen3.5 MoE (Qwen3.5-35B-A3B and friends): hybrid LA+FA attention identical
         // to qwen3_5 dense, but every layer's FFN is MoE with stacked-3D expert
         // tensors (mlp.experts.gate_up_proj/down_proj are [num_experts, ...]).


### PR DESCRIPTION
## Summary

GGUF files from HuggingFace may carry `general.architecture = "qwen35"` (without underscore) instead of the canonical `"qwen3_5"`. Both denote the same Qwen 3.5 family and must map to `arch_id=5` for correct dispatch through the qwen35 crate.

This affects models like Qwen 3.6 Uncensored fine-tunes that ship with `"qwen35"` as their architecture string — currently they fail with:
```
error: GGUF architecture 'qwen35' looks like a qwen3* family model but maps to no known arch_id; refusing to silently stamp arch_id=0 (would break the froggeric pillar). Re-run with an explicit --arch-id 5 (dense) or 6 (MoE).
```

### Changes
- Added `"qwen35"` to the match arms in both `run_gguf_pipeline()` and `main()` that map architecture strings to arch_id, alongside the existing `"qwen3_5" | "qwen3_5_text"` patterns.

## Test plan
- [ ] `cargo build --release -p hipfire-quantize` — compiles clean
- [ ] Quantize a GGUF model with `general.architecture = "qwen35"` → should auto-detect arch_id=5 without `--arch-id 5` flag
- [ ] Regression: models with `"qwen3_5"` still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)