### PR TITLE
feat(container): multi-stage Containerfile — deliverable image + GPU gate-runner

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,64 @@
+# Build-context pruning for Containerfile (podman/docker).
+# The repo working tree carries ~160 GB of build output, venvs, and git
+# worktrees that must NOT be sent to the daemon. Goal: context < ~500 MB
+# (source + kernels/src + cli).
+
+# Rust build output
+/target
+/target-baseline
+**/target
+*.o
+*.so
+*.dll
+
+# Python venv + tooling state
+/.venv
+.venv/
+.serena/
+.remember/
+.codex
+
+# Git worktrees (79 GB + 43 GB on this box)
+/.worktrees
+/.claude
+
+# graphify knowledge-graph output
+/graphify-out
+/crates/graphify-out
+
+# Models & large weight blobs (runtime-only, mounted as a volume)
+/models
+*.gguf
+*.safetensors
+*.hfq
+*.mq2
+*.mq3
+*.mq4
+*.mq6
+
+# Quality-baseline reference dumps (~4.7 GB, mostly untracked) — used only by
+# offline KLD/PPL/astrea eval, never by the build or the GPU gates. The gates
+# read benchmarks/prompts/, which is kept.
+/benchmarks/quality-baselines
+
+# JIT kernel caches (rebuilt inside the container)
+kernels/compiled/
+.hipfire_kernels/
+.hipfire_kernels_*/
+
+# VCS / editor cruft
+/.git
+.gitignore
+*.swp
+*.swo
+*~
+.DS_Store
+.vscode/
+.idea/
+
+# Local build directories
+/dev/
+/dist/
+
+# The existing narrow gfx12-precompile helper is out of scope
+docker/

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,122 @@
+# hipfire container — multi-stage build (podman-native; docker-compatible).
+#
+# Two final targets share a base:
+#   base-rocm ──► builder ──► gate-runner   (PR / dev-build validation)
+#        └──────────────────► runtime        (deliverable inference image)
+#
+# Design notes:
+#   * ROCm/HIP is dlopen'd at runtime; the build itself needs no GPU.
+#   * gfx1151 requires ROCm 7.2+ (6.4.3 segfaults on it) — do NOT downgrade.
+#   * Kernels are JIT-compiled on first use: every .hip source AND its helper
+#     headers (turbo_common.h, *.cuh, ...) are embedded into the daemon binary
+#     via include_str! and stitched in Rust before hipcc runs. So neither
+#     kernels/src/ nor registry.json need to exist on disk in the runtime image;
+#     the image only needs `hipcc` + HIP headers (from the ROCm base) at runtime.
+#   * Models are runtime-only downloads — never baked in; mount as a volume.
+#
+# Build:
+#   podman build -f Containerfile --target runtime     -t hipfire .
+#   podman build -f Containerfile --target gate-runner  -t hipfire-gate .
+#
+# Run (deliverable, needs GPU passthrough):
+#   podman run --rm -it \
+#     --device /dev/kfd --device /dev/dri \
+#     --group-add keep-groups --security-opt seccomp=unconfined \
+#     -v hipfire-models:/root/.hipfire/models \
+#     -v hipfire-kcache:/var/cache/hipfire \
+#     -p 11435:11435 hipfire run qwen3.5:4b "2+2="
+
+# ─────────────────────────────────────────────────────────────────────────────
+# base-rocm — ROCm SDK (hipcc + clang + HIP headers + runtime .so set) + Bun.
+# The non-"-complete" dev image (~1.2 GB) ships hipcc and the HIP headers, which
+# is all the JIT path needs for gfx1151. If a build ever reports hipcc/headers
+# missing, switch the tag to `7.2.4-complete` (adds rocBLAS/MIOpen, ~7.4 GB).
+# ─────────────────────────────────────────────────────────────────────────────
+FROM docker.io/rocm/dev-ubuntu-24.04:7.2.4 AS base-rocm
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        unzip \
+        python3 \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Bun 1.3.13 (pins the CI-tested CLI runtime). Installs to $BUN_INSTALL/bin.
+ENV BUN_INSTALL=/usr/local
+RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.13" \
+    && bun --version
+
+# HIP install root (compiler.rs defaults HIP_PATH to /opt/rocm) and a writable
+# JIT cache dir (the default is CWD-relative .hipfire_kernels/ — unusable in a
+# read-only workdir, so pin it to a volume-friendly path).
+ENV HIP_PATH=/opt/rocm \
+    HIPFIRE_KERNEL_CACHE=/var/cache/hipfire
+RUN mkdir -p /var/cache/hipfire && chmod 1777 /var/cache/hipfire
+
+# ─────────────────────────────────────────────────────────────────────────────
+# builder — adds Rust, compiles the daemon and the standalone CLI binary.
+# ─────────────────────────────────────────────────────────────────────────────
+FROM base-rocm AS builder
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain stable --profile minimal
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /hipfire
+COPY . .
+
+# Daemon (a cargo --example, not a --bin). Default features already pull in the
+# arch crates; deltanet is additive (DeltaNet/DFlash arches). Matches CLAUDE.md.
+RUN cargo build --release --locked --features deltanet \
+        --example daemon -p hipfire-runtime
+
+# Compile the Bun CLI to a single self-contained binary. registry.json is a
+# static `import ... with { type: "json" }`, so it is inlined here — no runtime
+# copy needed. This drops the Bun runtime from the deliverable.
+RUN mkdir -p /out \
+    && cd cli \
+    && bun install --frozen-lockfile \
+    && bun build --compile --outfile /out/hipfire index.ts
+
+# ─────────────────────────────────────────────────────────────────────────────
+# runtime — TARGET A, deliverable. No Rust, no source tree, no gate scripts.
+# ─────────────────────────────────────────────────────────────────────────────
+FROM base-rocm AS runtime
+
+COPY --from=builder /hipfire/target/release/examples/daemon /opt/hipfire/bin/daemon
+COPY --from=builder /out/hipfire /usr/local/bin/hipfire
+
+ENV HIPFIRE_DAEMON_BIN=/opt/hipfire/bin/daemon \
+    HIPFIRE_DIR=/root/.hipfire
+
+# Models and the JIT kernel cache persist across runs via named volumes.
+VOLUME ["/root/.hipfire/models", "/var/cache/hipfire"]
+EXPOSE 11435
+
+ENTRYPOINT ["hipfire"]
+CMD ["--help"]
+
+# ─────────────────────────────────────────────────────────────────────────────
+# gate-runner — TARGET B, PR/dev-build validation. Full toolchain + source +
+# in-repo GPU gate scripts. Runs with GPU passthrough against mounted models.
+# ─────────────────────────────────────────────────────────────────────────────
+FROM builder AS gate-runner
+
+# pytest/numpy for the Python-backed detector arms in the gate scripts.
+RUN pip install --no-cache-dir --break-system-packages pytest numpy
+
+COPY --from=builder /out/hipfire /usr/local/bin/hipfire
+
+ENV HIPFIRE_DAEMON_BIN=/hipfire/target/release/examples/daemon \
+    HIPFIRE_DIR=/root/.hipfire \
+    MODELS_DIR=/root/.hipfire/models
+
+WORKDIR /hipfire
+# Default gate = coherence battery; override by appending another gate script,
+# e.g. `podman run ... hipfire-gate scripts/serve-multiturn-gate.sh`.
+ENTRYPOINT ["/bin/bash"]
+CMD ["scripts/coherence-gate.sh"]

--- a/README.md
+++ b/README.md
@@ -133,6 +133,21 @@ NixOS module:
 }
 ```
 
+## Container (podman/docker)
+
+A multi-stage `Containerfile` builds a slim deliverable inference image and a
+full-toolchain GPU gate-runner for reproducible PR/dev-build validation. See
+[docs/CONTAINER.md](docs/CONTAINER.md).
+
+```bash
+podman build -f Containerfile --target runtime -t hipfire .
+podman run --rm -it --device /dev/kfd --device /dev/dri \
+  --group-add keep-groups --security-opt seccomp=unconfined \
+  -v hipfire-models:/root/.hipfire/models \
+  -v hipfire-kcache:/var/cache/hipfire \
+  hipfire run qwen3.5:4b "2+2="
+```
+
 ## Inspiration: Lucebox
 
 hipfire's DFlash work was substantially shaped by Davide Ciffa's

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -1,0 +1,85 @@
+# Containerized hipfire (podman)
+
+A single multi-stage `Containerfile` (repo root) produces two images that share a
+ROCm base:
+
+| Target        | Purpose                              | Contains                                   |
+|---------------|--------------------------------------|--------------------------------------------|
+| `runtime`     | Deliverable inference image          | daemon + standalone `hipfire` CLI          |
+| `gate-runner` | PR / dev-build GPU-gate validation   | full toolchain + source + gate scripts     |
+
+Everything is podman-native but works unchanged with `docker` (swap the command).
+
+## Why it's built this way
+
+- **ROCm is dlopen'd at runtime** — the build needs no GPU. The base is
+  `rocm/dev-ubuntu-24.04:7.2.4` because **gfx1151 requires ROCm 7.2+** (6.4.3
+  segfaults on it). If a build reports `hipcc`/HIP headers missing, bump the base
+  tag to `7.2.4-complete`.
+- **Kernels JIT on first use.** Every `.hip` source and its helper headers
+  (`turbo_common.h`, `*.cuh`, …) are embedded into the daemon binary via
+  `include_str!` and stitched together in Rust before `hipcc` runs. The runtime
+  image therefore needs only `hipcc` + HIP headers (from the base) — **not**
+  `kernels/src/` on disk. First run is slower while kernels compile into the
+  cache volume; subsequent runs are fast.
+- **The CLI is compiled to a single binary** (`bun build --compile`), with
+  `registry.json` inlined, so the runtime image carries no Bun runtime or JS.
+- **Models are never baked in** — they are large runtime-only downloads mounted
+  as a volume.
+- **No `HSA_OVERRIDE_GFX_VERSION`** is baked in (project Rule 5); the arch is
+  detected at runtime via HIP `gcnArchName`.
+
+## Build
+
+```bash
+podman build -f Containerfile --target runtime     -t hipfire .
+podman build -f Containerfile --target gate-runner -t hipfire-gate .
+```
+
+`.containerignore` prunes the ~160 GB working tree (target/, worktrees, venv,
+models) down to a small source context.
+
+## Run the deliverable
+
+GPU passthrough is required. Rootless podman needs `--group-add keep-groups` to
+keep the host `render`/`video` gids for `/dev/kfd` + `/dev/dri`.
+
+```bash
+podman run --rm -it \
+  --device /dev/kfd --device /dev/dri \
+  --group-add keep-groups --security-opt seccomp=unconfined \
+  -v hipfire-models:/root/.hipfire/models \
+  -v hipfire-kcache:/var/cache/hipfire \
+  -p 11435:11435 \
+  hipfire run qwen3.5:4b "2+2="
+```
+
+`hipfire serve qwen3.5:4b 0.0.0.0:11435 -d` exposes the JSON-lines daemon on the
+published port. The `hipfire-kcache` volume persists JIT-compiled kernels across
+container runs; `hipfire-models` persists pulled models.
+
+## Validate a dev build / PR (GPU gates)
+
+`scripts/container-gate.sh` builds `gate-runner` and runs a gate inside it with
+GPU passthrough and the host models bind-mounted:
+
+```bash
+scripts/container-gate.sh                              # coherence battery (default)
+scripts/container-gate.sh scripts/serve-multiturn-gate.sh
+scripts/container-gate.sh scripts/coherence-gate-dflash.sh
+```
+
+Environment knobs:
+
+- `HIPFIRE_CONTAINER=docker` — use docker instead of podman.
+- `HIPFIRE_MODELS_DIR=<path>` — host models dir (default `~/.hipfire/models`).
+- `HIPFIRE_SKIP_BUILD=1` — reuse the existing `hipfire-gate` tag.
+
+The wrapper mounts the host GPU lock file (`/tmp/hipfire-gpu.lock`) when present
+so a containerized gate coordinates with host GPU work.
+
+## Related
+
+The older `docker/rocm7-builder.Dockerfile` is a separate, narrow helper for
+pre-compiling gfx12 kernels via `compile-kernels.sh`; it is not part of this
+build and is left as-is.

--- a/docs/CONTAINER.md
+++ b/docs/CONTAINER.md
@@ -78,6 +78,14 @@ Environment knobs:
 The wrapper mounts the host GPU lock file (`/tmp/hipfire-gpu.lock`) when present
 so a containerized gate coordinates with host GPU work.
 
+## Publishing to a registry (not yet wired)
+
+There is no CI workflow that publishes the image yet. When one is added, it
+should build the `runtime` target (no GPU needed — ROCm is dlopen'd) on a
+GitHub-hosted runner and push to a registry (Docker Hub or GHCR), e.g. `latest`
++ short SHA on `master` and a semver tag on release tags. The GPU gates cannot
+run in cloud CI and stay local via `scripts/container-gate.sh`.
+
 ## Related
 
 The older `docker/rocm7-builder.Dockerfile` is a separate, narrow helper for

--- a/scripts/container-gate.sh
+++ b/scripts/container-gate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Build the hipfire gate-runner image and run a GPU gate inside it, with the
+# host GPU (/dev/kfd + /dev/dri) passed through. This is the containerized
+# PR / dev-build validation path — the same in-repo gates, reproducibly.
+#
+# Usage:
+#   scripts/container-gate.sh [gate-script [args...]]
+#
+# Defaults to scripts/coherence-gate.sh. Examples:
+#   scripts/container-gate.sh                              # coherence battery
+#   scripts/container-gate.sh scripts/serve-multiturn-gate.sh
+#   scripts/container-gate.sh scripts/coherence-gate-dflash.sh
+#
+# Environment:
+#   HIPFIRE_CONTAINER=podman|docker   container runtime (default: podman)
+#   HIPFIRE_MODELS_DIR=<path>         host models dir (default: ~/.hipfire/models)
+#   HIPFIRE_IMAGE=<name>              image tag (default: hipfire-gate)
+#   HIPFIRE_SKIP_BUILD=1              skip the image build, run the existing tag
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RUNTIME="${HIPFIRE_CONTAINER:-podman}"
+IMAGE="${HIPFIRE_IMAGE:-hipfire-gate}"
+MODELS_DIR="${HIPFIRE_MODELS_DIR:-$HOME/.hipfire/models}"
+
+GATE_CMD=("$@")
+[ ${#GATE_CMD[@]} -eq 0 ] && GATE_CMD=("scripts/coherence-gate.sh")
+
+if [ ! -d "$MODELS_DIR" ]; then
+    echo "[container-gate] models dir not found: $MODELS_DIR" >&2
+    echo "  set HIPFIRE_MODELS_DIR, or pull models on the host first." >&2
+    exit 2
+fi
+
+if [ "${HIPFIRE_SKIP_BUILD:-0}" != "1" ]; then
+    echo "[container-gate] building $IMAGE (gate-runner target)..."
+    "$RUNTIME" build -f "$ROOT/Containerfile" --target gate-runner \
+        -t "$IMAGE" "$ROOT" || exit 1
+fi
+
+# Rootless podman needs --group-add keep-groups to keep the host render/video
+# gids for /dev/kfd + /dev/dri access. seccomp=unconfined avoids HSA syscall
+# filtering. Share the host GPU lock file if it exists so a containerized gate
+# coordinates with host GPU work (see scripts/gpu-lock.sh).
+GPU_ARGS=(
+    --device /dev/kfd
+    --device /dev/dri
+    --group-add keep-groups
+    --security-opt seccomp=unconfined
+    -v "$MODELS_DIR:/root/.hipfire/models"
+    -v hipfire-kcache:/var/cache/hipfire
+)
+LOCKFILE="${HIPFIRE_GPU_LOCKFILE:-/tmp/hipfire-gpu.lock}"
+[ -e "$LOCKFILE" ] && GPU_ARGS+=(-v "$LOCKFILE:$LOCKFILE")
+
+echo "[container-gate] running: ${GATE_CMD[*]}"
+exec "$RUNTIME" run --rm -i "${GPU_ARGS[@]}" "$IMAGE" "${GATE_CMD[@]}"


### PR DESCRIPTION
## Summary

Adds a podman-native (docker-compatible) multi-stage `Containerfile` that serves two roles from one build:

- **`runtime`** — slim deliverable inference image (`hipfire run` / `hipfire serve`)
- **`gate-runner`** — full-toolchain image for reproducible **PR / dev-build GPU-gate validation** with device passthrough

hipfire has no real container today (only `docker/rocm7-builder.Dockerfile`, a narrow gfx12 kernel-precompile helper, left untouched).

## Design

Stages: `base-rocm` (ROCm 7.2.4 dev + Bun 1.3.13) → `builder` (Rust release daemon + `bun build --compile` standalone CLI) → `{runtime, gate-runner}`.

- **ROCm 7.2.4** base because gfx1151 needs ≥7.2 (6.4.3 segfaults on it); the non-`-complete` tag ships `hipcc`+HIP headers, keeping the deliverable lean.
- **Kernels JIT on first use.** Every `.hip` source and helper header is `include_str!`-embedded in the daemon and spliced in Rust before `hipcc` runs, so the runtime image needs **neither `kernels/src/` nor `registry.json` on disk** (registry is inlined into the compiled CLI). Runtime carries only `hipcc` + HIP headers from the base.
- **Models** stay runtime-only (volume-mounted); **no `HSA_OVERRIDE`** baked in (Rule 5).
- `.containerignore` prunes the working tree (`target/`, worktrees, venv, models, `benchmarks/quality-baselines`) — a 165 GB tree down to a ~71 MB build context.
- `scripts/container-gate.sh` builds `gate-runner` and runs an in-repo GPU gate with `/dev/kfd`+`/dev/dri` passthrough and host models bind-mounted (rootless podman `--group-add keep-groups`).

## Verification (on gfx1151, ROCm 7.2.4)

- All four stages build; `.containerignore` yields a 71 MB context.
- Base ships `hipcc` (HIP 7.2.53211) + Bun 1.3.13; `runtime` is slim (no cargo/source), `gate-runner` has toolchain + gate scripts + prebuilt daemon.
- **Deliverable smoke in-container**: `hipfire run qwen3.5:0.8b` generated coherent, on-topic text at 100 tok/s with first-run kernel JIT into the cache volume.

Cloud CI publishing to a registry is intentionally **not** included here (see the deferred note in `docs/CONTAINER.md`); GPU gates can't run in cloud CI and stay local.

## Files

- `Containerfile`, `.containerignore`, `scripts/container-gate.sh`, `docs/CONTAINER.md`, README pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)