### PR TITLE
perf(deltanet): DPP wave reductions for gated_delta_net (opt-in; mechanism proven, e2e null)

### DIFF
--- a/crates/rdna-compute/src/norm.rs
+++ b/crates/rdna-compute/src/norm.rs
@@ -37,6 +37,65 @@ fn dn_requant_per_token() -> bool {
     })
 }
 
+/// Cheap Q8-state requant for the fast GDN kernel. DEFAULT OFF.
+///
+/// Returns the refresh period `P` passed to `gated_delta_net_q8_fast`:
+///   * `0`  → baseline: exact per-token cross-lane abs-max reduction.
+///   * `P>0` → CHEAP: carry the previous per-row scale (reduction-free) on the
+///     recurrent decode critical path, re-anchoring with the exact abs-max only
+///     every `P` frames (and on the first token of a sequence). The dropped
+///     `__shfl_xor` butterfly is the ~90% DEP_WAIT chain the ZINC dissection
+///     cited; the default EF (sigma-delta) requant makes a stale scale loss-free
+///     in the running sense (clip error is carried in the f16 residual).
+///
+/// Enable with `HIPFIRE_DN_CHEAP_REQUANT=1` (period defaults to 8); override the
+/// period with `HIPFIRE_DN_CHEAP_REQUANT_PERIOD=N`. NUMERICALLY LOSSY (the stored
+/// state changes) — gated on coherence, not byte-parity.
+fn dn_cheap_requant_period() -> i32 {
+    static V: std::sync::OnceLock<i32> = std::sync::OnceLock::new();
+    *V.get_or_init(|| {
+        let on = std::env::var("HIPFIRE_DN_CHEAP_REQUANT")
+            .map(|v| {
+                let v = v.trim();
+                !v.is_empty() && v != "0"
+            })
+            .unwrap_or(false);
+        if !on {
+            return 0;
+        }
+        std::env::var("HIPFIRE_DN_CHEAP_REQUANT_PERIOD")
+            .ok()
+            .and_then(|v| v.trim().parse::<i32>().ok())
+            .unwrap_or(8)
+            .max(1)
+    })
+}
+
+/// DPP (register-to-register) wave reductions for the fast GDN kernel, in place
+/// of the `__shfl_*` reductions that LLVM lowers to LDS-routed `ds_bpermute` +
+/// serial `s_wait_dscnt` on the recurrent decode critical path. DEFAULT OFF (0).
+///
+///   * `1` → DPP for the requant abs-max reduction only. BYTE-EXACT vs the
+///     `__shfl_xor` baseline (max is order-independent). This is the
+///     ZINC-cited kernel-exit reduction on the DEP_WAIT chain.
+///   * `2` → DPP for ALL reductions, including the kv/out_v dot-product sums.
+///     The sums become a butterfly-order reduction (bit-exact vs `__shfl_xor`
+///     but NOT vs the baseline `__shfl_down` shift-tree); the rounding-order
+///     change is far below the Q8 requant noise floor — coherence-gated.
+///
+/// Enable with `HIPFIRE_DN_DPP_REDUCE=1` (or `2`). Orthogonal to and composable
+/// with `HIPFIRE_DN_CHEAP_REQUANT`.
+fn dn_dpp_reduce() -> i32 {
+    static V: std::sync::OnceLock<i32> = std::sync::OnceLock::new();
+    *V.get_or_init(|| {
+        std::env::var("HIPFIRE_DN_DPP_REDUCE")
+            .ok()
+            .and_then(|v| v.trim().parse::<i32>().ok())
+            .unwrap_or(0)
+            .clamp(0, 2)
+    })
+}
+
 /// Use the chunked (parallel) FP32 GDN kernel on the multi-token (n>1) linear
 /// arm instead of the sequential batch_seq. DEFAULT OFF. Correctness-first
 /// PoC: each chunk is a separate host-side launch (cross-chunk is serial).
@@ -2150,6 +2209,8 @@ impl Gpu {
         // EF residual is supported in both paths; the split is only about cadence.
         let use_fast = !dn_requant_per_token();
 
+        let crq = dn_cheap_requant_period();
+        let dpr = dn_dpp_reduce();
         let result = if use_fast {
             self.ensure_kernel(
                 "gated_delta_net_q8_fast",
@@ -2170,6 +2231,8 @@ impl Gpu {
                 &hd as *const _ as *mut c_void,
                 &fr as *const _ as *mut c_void,
                 &efp as *const _ as *mut c_void,
+                &crq as *const _ as *mut c_void,
+                &dpr as *const _ as *mut c_void,
             ];
             let timer = crate::profile::begin_timer(
                 &self.hip,
@@ -2198,6 +2261,8 @@ impl Gpu {
                     b.push_i32(hd);
                     b.push_i32(fr);
                     b.push_ptr(efp);
+                    b.push_i32(crq);
+                    b.push_i32(dpr);
                     b
                 },
             );
@@ -2342,6 +2407,8 @@ impl Gpu {
             .map(|t| t.buf.as_ptr())
             .unwrap_or(std::ptr::null_mut());
         let mut rpt = dn_requant_per_token() as i32;
+        let mut crq = dn_cheap_requant_period();
+        let mut dpr = dn_dpp_reduce();
         let bytes = crate::profile::gated_delta_net_q8_bytes(n_tokens, n_heads, head_dim);
         let timer = crate::profile::begin_timer(
             &self.hip,
@@ -2365,6 +2432,8 @@ impl Gpu {
                 &mut hd as *mut _ as *mut c_void,
                 &mut fr as *mut _ as *mut c_void,
                 &mut efp as *mut _ as *mut c_void,
+                &mut crq as *mut _ as *mut c_void,
+                &mut dpr as *mut _ as *mut c_void,
             ];
             self.launch_maybe_blob(
                 "gated_delta_net_q8_fast",
@@ -2387,6 +2456,8 @@ impl Gpu {
                     b.push_i32(hd);
                     b.push_i32(fr);
                     b.push_ptr(efp);
+                    b.push_i32(crq);
+                    b.push_i32(dpr);
                     b
                 },
             )

--- a/kernels/src/gated_delta_net_q8_fast.hip
+++ b/kernels/src/gated_delta_net_q8_fast.hip
@@ -19,6 +19,53 @@
 #define HD 128
 #define TILE_ROWS 4
 
+// ── Register-to-register wave32 reductions via DPP (no LDS round-trip) ──────
+//
+// The __shfl_xor / __shfl_down reductions LLVM lowers to `ds_bpermute` — an
+// LDS-routed cross-lane op gated by a serial `s_wait_dscnt`. On this recurrent
+// GDN kernel the reductions sit on the decode critical path (n_tokens==1 → the
+// per-token dependency chain), so that LDS round-trip IS the DEP_WAIT latency.
+// DPP (`v_permlanex16` + `row_xmask`) does the same permutations in the VALU
+// register file with no LDS traffic and no `s_wait_dscnt`.
+//
+// wave32 = two DPP "rows" of 16 lanes. A full 32-lane butterfly is 4 intra-16
+// steps (xor 1,2,4,8 via row_xmask, DPP ctrl 0x160|n — RDNA-native, xor stays
+// in-row) + 1 cross-16 step (xor 16 via permlanex16 half-swap). Validated
+// on-device (gfx1201): the DPP max/sum are BIT-EXACT to the __shfl_xor
+// butterfly (max is order-independent, so the requant abs-max is byte-exact
+// vs the __shfl baseline; the kv/out_v sums are a butterfly-order reduction,
+// bit-exact vs __shfl_xor but NOT vs the baseline __shfl_down shift-tree —
+// a rounding-order change far below the Q8 requant noise floor).
+#define DN_DPP_ROW_XMASK(n) (0x160 | (n))
+template <int N>
+__device__ __forceinline__ float dn_dpp_xmask(float v) {
+    int vi = __float_as_int(v);
+    int r = __builtin_amdgcn_update_dpp(vi, vi, DN_DPP_ROW_XMASK(N), 0xf, 0xf, false);
+    return __int_as_float(r);
+}
+__device__ __forceinline__ float dn_dpp_swap16(float v) {
+    // dst[i] = src[i ^ 16] — swap the two 16-lane halves (position-preserving).
+    int vi = __float_as_int(v);
+    int r = __builtin_amdgcn_permlanex16(vi, vi, 0x76543210, 0xFEDCBA98, false, false);
+    return __int_as_float(r);
+}
+__device__ __forceinline__ float dn_wave32_max_dpp(float v) {
+    v = fmaxf(v, dn_dpp_xmask<1>(v));
+    v = fmaxf(v, dn_dpp_xmask<2>(v));
+    v = fmaxf(v, dn_dpp_xmask<4>(v));
+    v = fmaxf(v, dn_dpp_xmask<8>(v));
+    v = fmaxf(v, dn_dpp_swap16(v));
+    return v; // full-wave max in every lane
+}
+__device__ __forceinline__ float dn_wave32_sum_dpp(float v) {
+    v += dn_dpp_xmask<1>(v);
+    v += dn_dpp_xmask<2>(v);
+    v += dn_dpp_xmask<4>(v);
+    v += dn_dpp_xmask<8>(v);
+    v += dn_dpp_swap16(v);
+    return v; // full-wave sum in every lane
+}
+
 extern "C" __launch_bounds__(32, 8)
 __global__ void gated_delta_net_q8_fast(
     const float* __restrict__ q,
@@ -33,7 +80,16 @@ __global__ void gated_delta_net_q8_fast(
     int n_heads,
     int head_dim,
     unsigned int frame,
-    __half* __restrict__ s_ef_residual
+    __half* __restrict__ s_ef_residual,
+    int cheap_requant,  // 0 = exact per-token abs-max reduction (default);
+                        // P>0 = CHEAP requant: carry the previous per-row scale
+                        //       (reduction-free) and only re-run the exact abs-max
+                        //       reduction every P frames (or when unseeded).
+    int dpp_reduce      // 0 = __shfl reductions (ds_bpermute, default).
+                        // 1 = DPP for the requant abs-max only (BYTE-EXACT vs
+                        //     baseline — max is order-independent).
+                        // 2 = DPP for all reductions incl. the kv/out_v sums
+                        //     (butterfly-order sums, coherence-gated not parity).
 ) {
     const int h = blockIdx.x;
     const int tile = blockIdx.y;
@@ -67,9 +123,13 @@ __global__ void gated_delta_net_q8_fast(
             float s0 = sr[tid], s1 = sr[tid+32], s2 = sr[tid+64], s3 = sr[tid+96];
 
             float kv = s0*k0 + s1*k1 + s2*k2 + s3*k3;
-            for (int o = 16; o > 0; o >>= 1)
-                kv += __shfl_down(kv, o);
-            kv = __shfl(kv, 0);
+            if (dpp_reduce >= 2) {
+                kv = dn_wave32_sum_dpp(kv);   // butterfly, all lanes (no broadcast)
+            } else {
+                for (int o = 16; o > 0; o >>= 1)
+                    kv += __shfl_down(kv, o);
+                kv = __shfl(kv, 0);
+            }
 
             float delta = (v_t[row] - alpha * kv) * beta_v;
 
@@ -80,8 +140,12 @@ __global__ void gated_delta_net_q8_fast(
             sr[tid] = s0; sr[tid+32] = s1; sr[tid+64] = s2; sr[tid+96] = s3;
 
             float out_v = s0*q0 + s1*q1 + s2*q2 + s3*q3;
-            for (int o = 16; o > 0; o >>= 1)
-                out_v += __shfl_down(out_v, o);
+            if (dpp_reduce >= 2) {
+                out_v = dn_wave32_sum_dpp(out_v);
+            } else {
+                for (int o = 16; o > 0; o >>= 1)
+                    out_v += __shfl_down(out_v, o);
+            }
             if (tid == 0)
                 output[t * stride + h * HD + row] = out_v;
         }
@@ -103,9 +167,38 @@ __global__ void gated_delta_net_q8_fast(
             s3 += __half2float(efr[tid+96]);
         }
 
-        float my_max = fmaxf(fmaxf(fabsf(s0), fabsf(s1)), fmaxf(fabsf(s2), fabsf(s3)));
-        for (int o = 16; o > 0; o >>= 1)
-            my_max = fmaxf(my_max, __shfl_xor(my_max, o));
+        // Per-row Q8 requant scale. The baseline computes the exact row abs-max
+        // via a serial 5-step __shfl_xor butterfly — a cross-lane reduction that
+        // sits on the recurrent decode critical path (n_tokens==1 → this tail is
+        // pure added latency, ~90% DEP_WAIT). CHEAP requant (cheap_requant>0)
+        // drops that reduction on the common path: the scale must be warp-uniform
+        // (dequant reads one scale per row), and the previous step's scale — held
+        // in s_scales, read here BEFORE we overwrite it — is uniform, so we simply
+        // carry it. Under the default EF (sigma-delta) requant the carried scale
+        // is loss-free in the running sense: any element that clips at ±127 has
+        // its clip error stored in efr and re-injected next token (error feedback
+        // absorbs a stale scale). We re-anchor with the exact reduction every P
+        // frames, and always on the first token of a sequence (prev_scale<=0).
+        float my_max;
+        bool do_reduce = true;
+        if (cheap_requant > 0) {
+            float prev_scale = s_scales[h * HD + rr];   // uniform across the warp
+            unsigned int period = (unsigned int)cheap_requant;
+            bool refresh = (prev_scale <= 0.0f) || ((frame % period) == 0u);
+            if (!refresh) {
+                my_max = prev_scale * 127.0f;           // reduction-free carry
+                do_reduce = false;
+            }
+        }
+        if (do_reduce) {
+            my_max = fmaxf(fmaxf(fabsf(s0), fabsf(s1)), fmaxf(fabsf(s2), fabsf(s3)));
+            if (dpp_reduce >= 1) {
+                my_max = dn_wave32_max_dpp(my_max);   // BYTE-EXACT (order-independent)
+            } else {
+                for (int o = 16; o > 0; o >>= 1)
+                    my_max = fmaxf(my_max, __shfl_xor(my_max, o));
+            }
+        }
 
         float inv_s = (my_max > 0.0f) ? (127.0f / my_max) : 0.0f;
 


### PR DESCRIPTION
## Summary

Opt-in (DEFAULT-OFF) levers to shorten the Q8-requant / recurrence critical path on `gated_delta_net_q8_fast` by cutting the LDS round-trip out of its cross-lane reductions. A ZINC dissection + ISA audit found the `__shfl_xor`/`__shfl_down` reductions lower to LDS-routed `ds_bpermute` gated by a serial `s_wait_dscnt`, with ~90% of the kernel's wave cycles as DEP_WAIT on that chain.

- **`HIPFIRE_DN_DPP_REDUCE`** (primary): replace `__shfl` reductions with register-to-register **DPP** (`row_xmask` 0x160|n intra-16 butterfly + `permlanex16` half-swap cross-16).
  - `=1`: requant abs-max only — **BYTE-EXACT** vs baseline (validated on-device: DPP max bit-identical to `__shfl_xor` across all 32 lanes).
  - `=2`: all reductions incl. kv/out_v sums — butterfly-order sums (bit-exact vs `__shfl_xor`, not vs baseline `__shfl_down`), far below the Q8 noise floor, coherence-gated.
- **`HIPFIRE_DN_CHEAP_REQUANT`** (lossy fallback): carry the previous per-row scale (reduction-free), re-anchor every P frames; EF sigma-delta residual absorbs the stale-scale clip error.

## Validation (hiptrx dev2 / gfx1201, qwen3.6-35b-a3b.mq4r, DeltaNet Q8+EF)

- **Occupancy**: 56 VGPR / 0 spill (baseline 59 / 0), same 2 KB LDS.
- **Mechanism** (rocprofv3, profile_standard): GDN `SQ_WAIT_ANY` **91.54% → 88.39%** (dpp2); abs wait cycles **−16%** (8.34B→6.99B); kernel wall-clock **−9.0%** (9307→8465 ns). The 91.5% confirms the ZINC "~90% DEP_WAIT" diagnosis.
- **Coherence**: dpp1 byte-identical to baseline; dpp2 fluent/on-topic/no-attractor; cheap-requant coherent. No loops/leaks.

## HONEST NULL on decode tok/s

median-of-5 `decode_tok_s` (fresh proc, byte-identical prompt md5 `1029f1be577967ad94718f30f2abcfe0`):

| config | decode_tok_s | vs base | parity |
|---|---|---|---|
| baseline | 131.1 | — | — |
| dpp1 (max-only) | 131.2 | +0.08% | **byte-exact** |
| dpp2 (all) | 131.1 | +0.00% | coherent (reorder) |

**Root cause**: `gated_delta_net` is only **~4.05%** of decode kernel time (decode dominated by MoE GEMV: fused_qkvza 13%, moe_gate_up 11.5%, moe_down 9.5%, residual 8%). A −9% win on 4% of the work ≈ 0.35% end-to-end. Decode is batch-1 latency-limited across many kernels; the GDN reductions are not the bottleneck.

## Why land it (default OFF)

Correct, byte-exact (`=1`), zero-spill, mechanism-proven kernel improvement. Becomes a lever if GDN's decode share grows (longer context, prefill, or once MoE GEMV kernels are optimized). The history is the research.

🤖 Generated with [Claude Code](https://claude.com/claude-code)