### PR TITLE
feat(dspark): per-request drafter/τ/tok-s telemetry + non-fatal pre-warm

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -2830,16 +2830,30 @@ async function serve(port: number, host: string) {
       if (loadResult.type === "error") {
         console.error(`[hipfire] pre-warm load failed: ${loadResult.message} (will load on first request)`);
       } else {
-        for await (const msg of e.generate({ type: "generate", id: "warmup", prompt: "Hi", temperature: 0, max_tokens: 1 })) {
-          if (msg.type === "done") break;
+        // The `load` above already resident the model. The warmup generate only
+        // JITs kernels; its single token is discarded. So a hiccup on that
+        // throwaway token (e.g. a stray unparseable protocol line) must NOT tear
+        // down a successfully-loaded model — a full reload of a large MoE is
+        // minutes. Only a genuine daemon death (DaemonClosedError) warrants the
+        // outer restart; any other warmup error is logged and we keep serving.
+        let warmedOk = true;
+        try {
+          for await (const msg of e.generate({ type: "generate", id: "warmup", prompt: "Hi", temperature: 0, max_tokens: 1 })) {
+            if (msg.type === "done") break;
+          }
+          await e.send({ type: "reset" }); await e.recv();
+        } catch (warmErr: any) {
+          if (warmErr instanceof DaemonClosedError) throw warmErr; // daemon died → outer restart
+          warmedOk = false;
+          console.error(`[hipfire] warm-up generate hiccup: ${warmErr?.message} — model is loaded; serving anyway (kernels JIT on first request)`);
+          try { await e.drain(); } catch {} // resync the stdout stream if a stray line desynced it
         }
-        await e.send({ type: "reset" }); await e.recv();
         current = warmPath;
         currentMaxSeq = warmLoadMsg.params.max_seq;
         modelHasVL = loadResult.vl === true;
         currentArch = typeof loadResult.arch === "string" ? loadResult.arch : null;
         currentCacheCapable = typeof loadResult.cache_capable === "boolean" ? loadResult.cache_capable : null;
-        console.error(`[hipfire] warm-up complete`);
+        console.error(warmedOk ? `[hipfire] warm-up complete` : `[hipfire] warm-up complete (with warnings)`);
       }
     } catch (err: any) {
       console.error(`[hipfire] pre-warm failed: ${err?.message} — restarting daemon`);

--- a/crates/hipfire-arch-qwen35/src/dflash_spec.rs
+++ b/crates/hipfire-arch-qwen35/src/dflash_spec.rs
@@ -233,6 +233,10 @@ impl DflashSpeculator {
 }
 
 impl Speculator for DflashSpeculator {
+    fn name(&self) -> &'static str {
+        "dflash"
+    }
+
     fn prefill(
         &mut self,
         gpu: &mut Gpu,

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -4267,6 +4267,12 @@ fn generate_dflash(
         pflash_done_field,
     );
     let _ = stdout.flush();
+    // Per-request debug summary (stderr → serve.log): active drafter, τ, tok/s.
+    let drafter = m.speculator.as_ref().map(|s| s.name()).unwrap_or("none");
+    eprintln!(
+        "[req {id}] drafter={drafter} tau={tau:.2} tok/s={decode_tok_s:.1} decode ({} tok, {} windows)",
+        run.generated, run.spec_cycles
+    );
 }
 
 /// Arch-generic spec-decode core extracted from `generate_dflash` (Phase 4 T4a).
@@ -5466,6 +5472,11 @@ fn generate_qwen35_mtp(
         finish_reason,
     );
     let _ = stdout.flush();
+    // Per-request debug summary (stderr → serve.log): active drafter, τ, tok/s.
+    let drafter = m.speculator.as_ref().map(|s| s.name()).unwrap_or("none");
+    eprintln!(
+        "[req {id}] drafter={drafter} tau={tau:.2} tok/s={decode_tok_s:.1} decode ({generated} tok, {cycles} windows)"
+    );
 }
 
 /// Multi-GPU pipeline-parallel AR decode (Stage 7 of #58). Mirrors the pp=1
@@ -10008,6 +10019,15 @@ fn generate_deepseek4_spec(
     } else {
         "stop"
     };
+    // τ = mean tokens committed per verify window (the spec speedup factor).
+    let tau = if run.spec_cycles > 0 {
+        run.spec_accepted as f64 / run.spec_cycles as f64
+    } else {
+        0.0
+    };
+    // Which drafter actually ran (dspark vs the in-trunk mtp — both reach this
+    // function). Reported so a fall-through or a mis-selected drafter is visible.
+    let drafter = m.speculator.as_ref().map(|s| s.name()).unwrap_or("none");
     let done_envelope = serde_json::json!({
         "type": "done",
         "id": id,
@@ -10019,12 +10039,19 @@ fn generate_deepseek4_spec(
         "prefill_ms": (run.prefill_s * 1000.0) as u128,
         "total_ms": (run.total_s * 1000.0) as u128,
         "finish_reason": finish_reason,
+        "drafter": drafter,
+        "tau": tau,
         "spec_k": spec_k,
         "spec_windows": run.spec_cycles,
         "spec_accept_pct": accept_pct,
     });
     let _ = writeln!(stdout, "{}", done_envelope);
     let _ = stdout.flush();
+    // Per-request debug summary (stderr → serve.log): active drafter, τ, tok/s.
+    eprintln!(
+        "[req {id}] drafter={drafter} tau={tau:.2} tok/s={tok_s:.1} decode ({} tok, {} windows, accept={accept_pct:.0}%)",
+        run.generated, run.spec_cycles
+    );
 }
 
 fn generate_deepseek4(
@@ -10684,9 +10711,14 @@ fn generate_deepseek4(
         "prefill_ms": prefill_ms,
         "total_ms": total_ms,
         "finish_reason": finish_reason,
+        "drafter": "ar",
     });
     let _ = writeln!(stdout, "{}", done_envelope);
     let _ = stdout.flush();
+    // Per-request debug summary: this request ran autoregressive (no drafter),
+    // e.g. spec disabled or a temp path the loaded drafter can't verify. Making
+    // the AR fall-through visible is the point — a "stall" is often just AR.
+    eprintln!("[req {id}] drafter=ar tau=1.00 tok/s={tok_s:.1} decode ({generated_count} tok, autoregressive)");
 }
 
 fn generate_lfm2moe(

--- a/crates/hipfire-runtime/src/dflash_generic.rs
+++ b/crates/hipfire-runtime/src/dflash_generic.rs
@@ -397,6 +397,10 @@ fn committed_block_hidden_elems(accepted: usize, num_extract: usize, hidden: usi
 }
 
 impl Speculator for GenericDflashSpeculator {
+    fn name(&self) -> &'static str {
+        "dflash"
+    }
+
     fn prefill(
         &mut self,
         gpu: &mut Gpu,

--- a/crates/hipfire-runtime/src/dspark_core.rs
+++ b/crates/hipfire-runtime/src/dspark_core.rs
@@ -1046,6 +1046,10 @@ pub struct DsparkDrafter {
 }
 
 impl MtpDrafter for DsparkDrafter {
+    fn name(&self) -> &'static str {
+        "dspark"
+    }
+
     fn mtp_prefill(
         &mut self,
         gpu: &mut Gpu,

--- a/crates/hipfire-runtime/src/spec.rs
+++ b/crates/hipfire-runtime/src/spec.rs
@@ -609,6 +609,14 @@ pub trait Speculator {
         false
     }
 
+    /// Short, human-readable drafter identity for per-request debug output
+    /// (e.g. "dspark", "mtp", "dflash", "ngram"). The daemon logs this at
+    /// request end so it's unambiguous which drafter actually ran (several
+    /// drafters share the same generate function). Default "spec".
+    fn name(&self) -> &'static str {
+        "spec"
+    }
+
     /// Run one acceptance window starting from `seed` at absolute `position`.
     /// `target` is the borrowed verifier; `emitted` is the prior committed
     /// tokens (repeat-penalty / n-gram context); `grammar` constrains both the
@@ -781,6 +789,13 @@ pub trait MtpDrafter {
     /// Whether verification is greedy-only (temp≈0). qwen35 MTP → `true`.
     fn requires_greedy(&self) -> bool;
 
+    /// Short drafter identity surfaced by [`MtpSpeculator::name`] for per-request
+    /// debug output. Plain MTP drafters keep the default "mtp"; the DSpark
+    /// drafter overrides to "dspark".
+    fn name(&self) -> &'static str {
+        "mtp"
+    }
+
     /// Stash the request sampling params for the next `mtp_step`. The
     /// [`MtpSpeculator`] forwards `set_sampling` + the per-step `temp` here so a
     /// temp>0-capable drafter (DSpark) can drive a sampled verify. Default no-op
@@ -841,6 +856,10 @@ fn lower_mtp_window(w: MtpWindow) -> Result<SpecStep, String> {
 }
 
 impl<A: MtpDrafter> Speculator for MtpSpeculator<A> {
+    fn name(&self) -> &'static str {
+        self.arch.name()
+    }
+
     fn prefill(
         &mut self,
         gpu: &mut Gpu,

--- a/crates/hipfire-runtime/src/spec_ngram.rs
+++ b/crates/hipfire-runtime/src/spec_ngram.rs
@@ -183,6 +183,10 @@ impl<D: BlockDrafter> ChainSpeculator<D> {
 }
 
 impl<D: BlockDrafter> Speculator for ChainSpeculator<D> {
+    fn name(&self) -> &'static str {
+        "ngram"
+    }
+
     fn prefill(
         &mut self,
         gpu: &mut Gpu,


### PR DESCRIPTION
## Per-request drafter / τ / tok-s telemetry + non-fatal serve pre-warm

Adds a `Speculator::name()` / `MtpDrafter::name()` (`"dspark"|"mtp"|"dflash"|"ngram"`) so the daemon can report **which drafter actually ran** — several drafters share one generate function, so a bare "spec" label was ambiguous.

Every deepseek4 (spec + AR), dflash, and mtp done-path now emits a stderr summary you can watch in `serve.log`:

```
[req <id>] drafter=dspark tau=1.09 tok/s=17.0 decode (140 tok, 67 windows, accept=36%)
```

- The ds4 spec done JSON also gains `"drafter"` + `"tau"`.
- An AR fall-through prints `drafter=ar`, so a **silent drop from spec to autoregressive is visible** — a "stall" is often just AR under thinking-mode. This is what made the mq2-vs-mq3 drafter A/B measurable.

### Non-fatal serve pre-warm
The warmup generate only JITs kernels and its single token is discarded, so a hiccup on that throwaway token (a stray unparseable protocol line) must **not** tear down a successfully-loaded model — a full reload of an 82 GB MoE is minutes. Only a real daemon death (`DaemonClosedError`) restarts; any other warmup error is logged and we keep serving, draining the stream to resync.

### Validation
- `cargo build --release -p hipfire-runtime --example daemon --features deltanet` — clean (pre-existing warnings only), rebased on current `master` (post #498).
- Telemetry is stderr/JSON-only; the JSONL text event stream is unchanged for existing clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
