### PR TITLE
bench(mq4): 128B-align microbench — cacheline-alignment lever FALSIFIED (DRAM traffic identical)

### DIFF
--- a/benchmarks/mq4_align/README.md
+++ b/benchmarks/mq4_align/README.md
@@ -1,0 +1,109 @@
+# MQ4 (HFQ4-G256) 128B weight-layout alignment — DOCUMENTED NEGATIVE
+
+**TL;DR — the cacheline-alignment lever is FALSIFIED. Do not re-chase.**
+Separating the MQ4 scale/zp out so the 128B nibble blocks land on 128B
+boundaries does **not** speed up decode: the actual DRAM traffic is byte-for-byte
+identical (measured), the residual effect is a size-fragile L1-request artifact,
+and at the *real* a3b decode working-set scale the aligned layout is **noise on
+gfx1201 and a net −12 % REGRESSION on gfx1100**. Both layouts are bit-exact.
+
+## The hypothesis
+
+hipfire's MQ4 (HFQ4-G256) weight group is **136 bytes, interleaved**:
+`[4B scale][4B zp][128B nibble-block (256 nibbles)]`. The 128B nibble block —
+the bulk of every weight load — sits at **offset 8**, so it is NOT 128B-aligned.
+Claim: on gfx1100 (128B lines) / gfx1201 (256B lines) the misaligned 128B block
+straddles two cachelines → extra fetches → higher decode load-latency (the
+83–94 % DEP_WAIT MoE GEMVs, ~42 % of decode). Proposed fix: split scale/zp into
+a separate array so the 128B nibble blocks are 128B-aligned.
+
+Two layouts, identical dequant math and values (`mq4_align_bench.hip`):
+- **A (current):** 136B interleaved. Warp's 32×4B nibble load spans
+  `[group_base+8, group_base+136)` — a 128B window at a non-128-aligned offset.
+- **B (aligned):** nibble blocks in their own 128B-stride array (aligned) +
+  scales/zp in a separate array. Warp's nibble load is a fully aligned 128B span.
+
+`mq4_align_moe.hip` is a scattered-multi-expert variant (grid=(rows,E), each
+block reads a different expert base) mirroring `gemv_hfq4g256_moe_gate_up_k8_indexed`.
+
+Build/run:
+```
+hipcc -O3 --offload-arch=gfx1201 mq4_align_bench.hip -o mq4b
+HIP_VISIBLE_DEVICES=<gfx1201-dev> ./mq4b -M 16384 -K 4096 -iters 200 -runs 5
+```
+
+## Why it's a negative — the measurement
+
+Parity is **bit-exact** (`max|A-B| = 0.000e+00`) at every size on both archs —
+the re-layout changes only memory placement, not values.
+
+### 1. DRAM traffic is IDENTICAL (the strong-form hypothesis is falsified)
+
+rocprofv3 (`profile_standard` perf level, gfx1201, M=4096 K=2048, per-dispatch):
+
+| counter | A (136B) | B (aligned) | reading |
+|---|---:|---:|---|
+| **GL2C_MISS** (L2→DRAM fetches) | **17505** | **17505** | **identical → same DRAM bytes** |
+| GL2C_HIT | 30696 | 43065 | B re-references L2 more (extra scale stream) but all hit |
+| TCP_REQ (L1 requests) | 624640 | 561152 | A +11.3 % more L1 requests |
+| SQ_INSTS_TEX_LOAD | 131072 | 98304 | A issues more VMEM loads |
+
+**Root cause.** The 136B group is *densely* read — scale(4) + zp(4) + all 128B
+of nibbles, no gaps. So when the warp's 128B nibble load straddles two 128B L2
+lines, the **second line's bytes are still consumed** (by the neighbouring
+group's scale/zp), i.e. it is already resident — a **cache hit, not an extra
+DRAM fetch**. `GL2C_MISS` proves it: the actual bottleneck (DRAM traffic) is
+unchanged. The misalignment costs only extra *L1 request slots* (+11 % TCP_REQ),
+not memory bandwidth. The hypothesis's causal chain (misalignment → extra
+fetches → DEP_WAIT) is broken at "extra fetches."
+
+### 2. Wall-time benefit is size-fragile and REVERSES at real scale
+
+gfx1201 (R9700, L2=8MB), B-vs-A, best-of-5, AUTO clock:
+
+| working set | gpr | Δ (B faster) | note |
+|---|---:|---:|---|
+| 1.06 MB | 8 | +0.7 % | ≈ single a3b expert gate_up — **noise** |
+| 1.59 MB | 8 | +1.3 % | noise band |
+| **4.25 MB** | 8 | **+39.2 %** | **L2-aliasing resonance of the 136B non-pow2 stride — artifact** |
+| 8.50 MB | 8 | +4.7 % | ≈ one 8-expert decode gate_up launch |
+| 17.0 MB | 16 | −0.5 % | noise |
+| 34.0 MB | 16 | +1.6 % | DRAM-bound |
+| **68.0 MB** | 16 | **−16.7 %** | **B SLOWER** (two-stream layout pathology) |
+
+gfx1100 (7900 XTX, L2=6MB, RDNA3 128B lines — the arch the hypothesis targets):
+
+| working set | gpr | Δ (B faster) | note |
+|---|---:|---:|---|
+| 1.06 MB | 8 | +24.8 % | tiny, L2-resident aliasing (not the decode regime) |
+| 4.25 MB | 8 | +5.3 % | |
+| **8.50 MB** | 8 | **−12.5 %** | **≈ real 8-expert decode gate_up → B is a REGRESSION** |
+| **34.0 MB** | 16 | **−13.3 %** | **DRAM-bound → B is a REGRESSION** |
+
+**The direction flips with working set.** The "+" only appears when the whole
+matrix is L2-resident *and* small (an L2-set-mapping quirk of the 136B non-power-
+of-2 stride, not a per-load straddle — see the razor-thin +39 % spike at exactly
+4.25 MB). At the sizes decode actually touches — ~8.5 MB scattered across 8
+experts, partly DRAM-bound — the aligned two-region layout is **worse**, because
+splitting nibbles and scales into two streams costs more than the aligned L1 load
+saves (two DRAM access streams / more row activations vs one contiguous 136B
+burst). On gfx1100 this is a clean **−12 to −13 % regression** at real scale.
+
+## Real a3b decode regime (settles it)
+
+`qwen3.6-35b-a3b.mq4r` confirmed **MQ4G256 / 136B** (routed experts
+`experts.N.gate_up_proj.weight`, no PaRo sidecars → `load_moe_ffn` HFQ path).
+`moe_intermediate=512` → per-expert gate_up = **1.06 MB** (M=1024, K=2048,
+gpr=8); top-8 → **~8.5 MB scattered per gate_up launch**. That is exactly the
+row where gfx1201 = +4.7 % (largely the aliasing artifact) and **gfx1100 = −12.5 %**.
+Net expected end-to-end decode effect: **≤ noise on gfx1201, negative on gfx1100.**
+
+## Verdict
+
+The 128B weight-layout alignment is **not** a decode lever. It does not reduce
+DRAM traffic (the real bottleneck), its microbench "wins" are an L2-aliasing
+artifact of the 136B stride that vanishes or reverses at decode scale, and on the
+very arch the hypothesis targeted (gfx1100) it is a net regression. A real-path
+encoder/loader/kernel prototype was scoped but **deliberately not landed** — the
+expected end-to-end value straddles zero (worse on gfx1100), not worth the MQ4
+wire-format churn. Recorded here so it is never re-chased.

--- a/benchmarks/mq4_align/mq4_align_bench.hip
+++ b/benchmarks/mq4_align/mq4_align_bench.hip
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+// MQ4 (HFQ4-G256) weight-layout cacheline-alignment microbench.
+//
+// Layout A (CURRENT): 136B interleaved groups.
+//   group @ (row*gpr+g)*136 : [0:4]=scale f32, [4:8]=zp f32, [8:136]=128B nibbles(256)
+//   The warp's 32x4B nibble load spans [group_base+8, group_base+136) -> a 128B
+//   span at a NON-128-aligned offset -> straddles two 128B lines.
+// Layout B (ALIGNED): nibble blocks in their own array @ 128B stride (aligned),
+//   scales+zp in separate arrays. The warp's nibble load is a fully aligned 128B
+//   span -> one transaction.
+//
+// Same dequant math, same values (B derived from A). Measures wall time + a
+// checksum for A/B parity. rocprofv3 supplies the L1/L2/DEP_WAIT counters.
+
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+#include <random>
+
+#define HIP_CHECK(x) do { hipError_t e=(x); if(e){ \
+    printf("HIP err %s @ %d: %s\n",#x,__LINE__,hipGetErrorString(e)); exit(1);} } while(0)
+
+#define DOG8(sc,zp,pk,x0,x1,x2,x3,x4,x5,x6,x7) ( \
+      (sc*(float)((pk)&0xFu)         + zp)*x0 \
+    + (sc*(float)(((pk)>>4)&0xFu)    + zp)*x1 \
+    + (sc*(float)(((pk)>>8)&0xFu)    + zp)*x2 \
+    + (sc*(float)(((pk)>>12)&0xFu)   + zp)*x3 \
+    + (sc*(float)(((pk)>>16)&0xFu)   + zp)*x4 \
+    + (sc*(float)(((pk)>>20)&0xFu)   + zp)*x5 \
+    + (sc*(float)(((pk)>>24)&0xFu)   + zp)*x6 \
+    + (sc*(float)(((pk)>>28)&0xFu)   + zp)*x7)
+
+// Layout A: interleaved 136B groups (current hipfire MQ4).
+__global__ void gemvA(const char* __restrict__ W, const float* __restrict__ x,
+                      float* __restrict__ y, int gpr, int M, int rpb) {
+    const int tid = threadIdx.x;
+    const int boff = tid * 4;
+    const int row0 = blockIdx.x * rpb;
+    for (int r = 0; r < rpb; r++) {
+        const int row = row0 + r;
+        if (row >= M) break;
+        const char* base = W + (long long)row * gpr * 136;
+        float acc = 0.0f;
+        for (int g = 0; g < gpr; g++) {
+            const char* gp = base + (long long)g * 136;
+            float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+            float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+            unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+            const int b = g * 256 + tid * 8;
+            float x0=x[b],x1=x[b+1],x2=x[b+2],x3=x[b+3],x4=x[b+4],x5=x[b+5],x6=x[b+6],x7=x[b+7];
+            acc += DOG8(sc,zp,pk,x0,x1,x2,x3,x4,x5,x6,x7);
+        }
+        for (int o = 16; o > 0; o >>= 1) acc += __shfl_down(acc, o);
+        if (tid == 0) y[row] = acc;
+    }
+}
+
+// Layout B: 128B-aligned nibble blocks + separate scale/zp arrays.
+__global__ void gemvB(const char* __restrict__ nib, const float* __restrict__ sc_arr,
+                      const float* __restrict__ zp_arr, const float* __restrict__ x,
+                      float* __restrict__ y, int gpr, int M, int rpb) {
+    const int tid = threadIdx.x;
+    const int boff = tid * 4;
+    const int row0 = blockIdx.x * rpb;
+    for (int r = 0; r < rpb; r++) {
+        const int row = row0 + r;
+        if (row >= M) break;
+        float acc = 0.0f;
+        for (int g = 0; g < gpr; g++) {
+            const int gi = row * gpr + g;
+            float sc = sc_arr[gi];
+            float zp = zp_arr[gi];
+            const char* nb = nib + (long long)gi * 128;   // aligned
+            unsigned int pk = *(const unsigned int*)(nb + boff);
+            const int b = g * 256 + tid * 8;
+            float x0=x[b],x1=x[b+1],x2=x[b+2],x3=x[b+3],x4=x[b+4],x5=x[b+5],x6=x[b+6],x7=x[b+7];
+            acc += DOG8(sc,zp,pk,x0,x1,x2,x3,x4,x5,x6,x7);
+        }
+        for (int o = 16; o > 0; o >>= 1) acc += __shfl_down(acc, o);
+        if (tid == 0) y[row] = acc;
+    }
+}
+
+int main(int argc, char** argv) {
+    int M = 16384, K = 4096, rpb = 1, iters = 200, warm = 30, runs = 5;
+    int which = 2; // 0=A only, 1=B only, 2=both
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "-M")) M = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "-K")) K = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "-rpb")) rpb = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "-iters")) iters = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "-warm")) warm = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "-runs")) runs = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "-which")) which = atoi(argv[++i]);
+    }
+    const int gpr = K / 256;
+    const long long ngroups = (long long)M * gpr;
+    const long long bytesA = ngroups * 136;
+    const long long bytesB = ngroups * 128 + ngroups * 8; // nibbles + (sc+zp)
+    printf("M=%d K=%d gpr=%d rpb=%d iters=%d runs=%d | A=%.2fMB B=%.2fMB (L2=8MB)\n",
+           M, K, gpr, rpb, iters, runs, bytesA/1048576.0, bytesB/1048576.0);
+
+    // Host build of layout A.
+    std::vector<char> hA(bytesA);
+    std::mt19937 rng(1234);
+    std::uniform_int_distribution<unsigned> nd(0, 0xFFFFFFFFu);
+    std::uniform_real_distribution<float> sd(0.001f, 0.05f), zd(-0.3f, 0.3f);
+    std::vector<float> hsc(ngroups), hzp(ngroups);
+    std::vector<char> hnib((size_t)ngroups * 128);
+    for (long long gi = 0; gi < ngroups; gi++) {
+        char* gp = hA.data() + gi * 136;
+        float sc = sd(rng), zp = zd(rng);
+        memcpy(gp, &sc, 4); memcpy(gp + 4, &zp, 4);
+        hsc[gi] = sc; hzp[gi] = zp;
+        for (int b = 0; b < 32; b++) {
+            unsigned pk = nd(rng);
+            memcpy(gp + 8 + b * 4, &pk, 4);
+            memcpy(hnib.data() + gi * 128 + b * 4, &pk, 4);
+        }
+    }
+    std::vector<float> hx(K);
+    std::uniform_real_distribution<float> xd(-1.0f, 1.0f);
+    for (int i = 0; i < K; i++) hx[i] = xd(rng);
+
+    char *dA, *dnib; float *dsc, *dzp, *dx, *dyA, *dyB;
+    HIP_CHECK(hipMalloc(&dA, bytesA));
+    HIP_CHECK(hipMalloc(&dnib, (size_t)ngroups * 128));
+    HIP_CHECK(hipMalloc(&dsc, ngroups * sizeof(float)));
+    HIP_CHECK(hipMalloc(&dzp, ngroups * sizeof(float)));
+    HIP_CHECK(hipMalloc(&dx, K * sizeof(float)));
+    HIP_CHECK(hipMalloc(&dyA, M * sizeof(float)));
+    HIP_CHECK(hipMalloc(&dyB, M * sizeof(float)));
+    HIP_CHECK(hipMemcpy(dA, hA.data(), bytesA, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dnib, hnib.data(), (size_t)ngroups * 128, hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dsc, hsc.data(), ngroups * sizeof(float), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dzp, hzp.data(), ngroups * sizeof(float), hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dx, hx.data(), K * sizeof(float), hipMemcpyHostToDevice));
+
+    const int nblk = (M + rpb - 1) / rpb;
+    dim3 grid(nblk), block(32);
+
+    // Alignment sanity: report the dA base and offsets mod 128.
+    printf("dA base %% 128 = %ld ; layout-A nibble off(group0) = (base+8) %% 128 = %ld\n",
+           (long)((uintptr_t)dA % 128), (long)(((uintptr_t)dA + 8) % 128));
+    printf("dnib base %% 128 = %ld (layout-B nibble blocks must be 0)\n",
+           (long)((uintptr_t)dnib % 128));
+
+    auto runK = [&](int mode)->double {
+        hipEvent_t t0, t1; HIP_CHECK(hipEventCreate(&t0)); HIP_CHECK(hipEventCreate(&t1));
+        for (int i = 0; i < warm; i++) {
+            if (mode==0) gemvA<<<grid,block>>>(dA,dx,dyA,gpr,M,rpb);
+            else         gemvB<<<grid,block>>>(dnib,dsc,dzp,dx,dyB,gpr,M,rpb);
+        }
+        HIP_CHECK(hipDeviceSynchronize());
+        double best = 1e30;
+        for (int run = 0; run < runs; run++) {
+            HIP_CHECK(hipEventRecord(t0));
+            for (int i = 0; i < iters; i++) {
+                if (mode==0) gemvA<<<grid,block>>>(dA,dx,dyA,gpr,M,rpb);
+                else         gemvB<<<grid,block>>>(dnib,dsc,dzp,dx,dyB,gpr,M,rpb);
+            }
+            HIP_CHECK(hipEventRecord(t1)); HIP_CHECK(hipEventSynchronize(t1));
+            float ms=0; HIP_CHECK(hipEventElapsedTime(&ms,t0,t1));
+            double us = (double)ms*1000.0/iters;
+            if (us < best) best = us;
+        }
+        return best; // us/iter, best-of-runs
+    };
+
+    double tA=0, tB=0;
+    if (which==0 || which==2) tA = runK(0);
+    if (which==1 || which==2) tB = runK(1);
+
+    // Parity check (only if both ran).
+    if (which==2) {
+        std::vector<float> yA(M), yB(M);
+        HIP_CHECK(hipMemcpy(yA.data(), dyA, M*sizeof(float), hipMemcpyDeviceToHost));
+        HIP_CHECK(hipMemcpy(yB.data(), dyB, M*sizeof(float), hipMemcpyDeviceToHost));
+        double maxabs=0; int nbad=0;
+        for (int i=0;i<M;i++){ double d=fabs((double)yA[i]-(double)yB[i]); if(d>maxabs)maxabs=d; if(d>1e-3)nbad++; }
+        printf("PARITY: max|A-B|=%.3e  nbad(>1e-3)=%d  y[0]=%.5f\n", maxabs, nbad, yA[0]);
+    }
+
+    double effGB_A = (double)bytesA * iters / (tA*1e-6*iters) / 1e9; // = bytesA/tA_s
+    if (which==0||which==2) printf("A (136B interleaved): %.3f us/iter  %.1f GB/s\n", tA, bytesA/(tA*1e-6)/1e9);
+    if (which==1||which==2) printf("B (128B aligned)    : %.3f us/iter  %.1f GB/s\n", tB, bytesB/(tB*1e-6)/1e9);
+    if (which==2) printf("DELTA: B vs A = %+.2f%% (%s)\n", (tA-tB)/tA*100.0, tB<tA?"B faster":"A faster");
+    (void)effGB_A;
+    return 0;
+}

--- a/benchmarks/mq4_align/mq4_align_moe.hip
+++ b/benchmarks/mq4_align/mq4_align_moe.hip
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Faithful MoE gate_up microbench: E scattered expert weight regions, grid=(mi,E),
+// each block reads expert[blockIdx.y]'s base — mirrors gemv_hfq4g256_moe_gate_up_indexed.
+// Layout A = 136B interleaved (current); Layout B = 128B-aligned nibbles + separate scales.
+#include <hip/hip_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+#include <random>
+
+#define HIP_CHECK(x) do { hipError_t e=(x); if(e){ \
+    printf("HIP err %s @ %d: %s\n",#x,__LINE__,hipGetErrorString(e)); exit(1);} } while(0)
+
+#define DOG8(sc,zp,pk,x0,x1,x2,x3,x4,x5,x6,x7) ( \
+      (sc*(float)((pk)&0xFu)+zp)*x0 + (sc*(float)(((pk)>>4)&0xFu)+zp)*x1 \
+    + (sc*(float)(((pk)>>8)&0xFu)+zp)*x2 + (sc*(float)(((pk)>>12)&0xFu)+zp)*x3 \
+    + (sc*(float)(((pk)>>16)&0xFu)+zp)*x4 + (sc*(float)(((pk)>>20)&0xFu)+zp)*x5 \
+    + (sc*(float)(((pk)>>24)&0xFu)+zp)*x6 + (sc*(float)(((pk)>>28)&0xFu)+zp)*x7)
+
+// A: expert bases point to 136B-interleaved matrices.
+__global__ void moeA(const unsigned long long* __restrict__ bases, const float* __restrict__ x,
+                     float* __restrict__ y, int gpr, int M) {
+    const int row = blockIdx.x; const int e = blockIdx.y; const int tid = threadIdx.x;
+    const char* base = reinterpret_cast<const char*>(bases[e]);
+    const char* rp = base + (long long)row * gpr * 136;
+    const int boff = tid * 4; float acc = 0.0f;
+    for (int g = 0; g < gpr; g++) {
+        const char* gp = rp + (long long)g * 136;
+        float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp));
+        float zp = __builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        unsigned int pk = *(const unsigned int*)(gp + 8 + boff);
+        const int b = g * 256 + tid * 8;
+        float x0=x[b],x1=x[b+1],x2=x[b+2],x3=x[b+3],x4=x[b+4],x5=x[b+5],x6=x[b+6],x7=x[b+7];
+        acc += DOG8(sc,zp,pk,x0,x1,x2,x3,x4,x5,x6,x7);
+    }
+    for (int o=16;o>0;o>>=1) acc += __shfl_down(acc,o);
+    if (tid==0) y[e*M + row] = acc;
+}
+// B: expert bases point to 128B-aligned nibble matrices; separate per-expert scale/zp arrays.
+__global__ void moeB(const unsigned long long* __restrict__ nbases, const unsigned long long* __restrict__ sbases,
+                     const float* __restrict__ x, float* __restrict__ y, int gpr, int M) {
+    const int row = blockIdx.x; const int e = blockIdx.y; const int tid = threadIdx.x;
+    const char* nb0 = reinterpret_cast<const char*>(nbases[e]);
+    const float* sc0 = reinterpret_cast<const float*>(sbases[e]); // [rows*gpr*2] : sc,zp interleaved per group
+    const int boff = tid * 4; float acc = 0.0f;
+    for (int g = 0; g < gpr; g++) {
+        const int gi = row * gpr + g;
+        float sc = sc0[gi*2]; float zp = sc0[gi*2+1];
+        const char* nb = nb0 + (long long)gi * 128;
+        unsigned int pk = *(const unsigned int*)(nb + boff);
+        const int b = g * 256 + tid * 8;
+        float x0=x[b],x1=x[b+1],x2=x[b+2],x3=x[b+3],x4=x[b+4],x5=x[b+5],x6=x[b+6],x7=x[b+7];
+        acc += DOG8(sc,zp,pk,x0,x1,x2,x3,x4,x5,x6,x7);
+    }
+    for (int o=16;o>0;o>>=1) acc += __shfl_down(acc,o);
+    if (tid==0) y[e*M + row] = acc;
+}
+
+int main(int argc, char** argv) {
+    int M = 1536, K = 2048, E = 8, iters = 300, warm = 30, runs = 5;
+    for (int i=1;i<argc;i++){
+        if(!strcmp(argv[i],"-M"))M=atoi(argv[++i]); else if(!strcmp(argv[i],"-K"))K=atoi(argv[++i]);
+        else if(!strcmp(argv[i],"-E"))E=atoi(argv[++i]); else if(!strcmp(argv[i],"-iters"))iters=atoi(argv[++i]);
+        else if(!strcmp(argv[i],"-runs"))runs=atoi(argv[++i]);
+    }
+    const int gpr = K/256; const long long ngr = (long long)M*gpr;
+    const long long bytesA = ngr*136, bytesB = ngr*128, bytesS = ngr*2*sizeof(float);
+    printf("MoE: E=%d M=%d K=%d gpr=%d | per-expert A=%.2fMB total=%.2fMB (L2=8MB)\n",
+           E, M, K, gpr, bytesA/1048576.0, E*bytesA/1048576.0);
+    std::mt19937 rng(7); std::uniform_int_distribution<unsigned> nd(0,0xFFFFFFFFu);
+    std::uniform_real_distribution<float> sd(0.001f,0.05f), zd(-0.3f,0.3f), xd(-1.f,1.f);
+
+    std::vector<char*> dA(E), dnib(E); std::vector<float*> dsc(E);
+    std::vector<unsigned long long> hbA(E), hbN(E), hbS(E);
+    std::vector<char> hA(bytesA), hN(bytesB); std::vector<float> hS(ngr*2);
+    for (int e=0;e<E;e++){
+        for(long long gi=0;gi<ngr;gi++){
+            char* gp=hA.data()+gi*136; float sc=sd(rng),zp=zd(rng);
+            memcpy(gp,&sc,4);memcpy(gp+4,&zp,4); hS[gi*2]=sc;hS[gi*2+1]=zp;
+            for(int b=0;b<32;b++){unsigned pk=nd(rng);memcpy(gp+8+b*4,&pk,4);memcpy(hN.data()+gi*128+b*4,&pk,4);}
+        }
+        HIP_CHECK(hipMalloc(&dA[e],bytesA)); HIP_CHECK(hipMalloc(&dnib[e],bytesB)); HIP_CHECK(hipMalloc(&dsc[e],bytesS));
+        HIP_CHECK(hipMemcpy(dA[e],hA.data(),bytesA,hipMemcpyHostToDevice));
+        HIP_CHECK(hipMemcpy(dnib[e],hN.data(),bytesB,hipMemcpyHostToDevice));
+        HIP_CHECK(hipMemcpy(dsc[e],hS.data(),bytesS,hipMemcpyHostToDevice));
+        hbA[e]=(unsigned long long)dA[e]; hbN[e]=(unsigned long long)dnib[e]; hbS[e]=(unsigned long long)dsc[e];
+    }
+    unsigned long long *dbA,*dbN,*dbS; HIP_CHECK(hipMalloc(&dbA,E*8));HIP_CHECK(hipMalloc(&dbN,E*8));HIP_CHECK(hipMalloc(&dbS,E*8));
+    HIP_CHECK(hipMemcpy(dbA,hbA.data(),E*8,hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dbN,hbN.data(),E*8,hipMemcpyHostToDevice));
+    HIP_CHECK(hipMemcpy(dbS,hbS.data(),E*8,hipMemcpyHostToDevice));
+    std::vector<float> hx(K); for(int i=0;i<K;i++)hx[i]=xd(rng);
+    float *dx,*dyA,*dyB; HIP_CHECK(hipMalloc(&dx,K*4));HIP_CHECK(hipMalloc(&dyA,E*M*4));HIP_CHECK(hipMalloc(&dyB,E*M*4));
+    HIP_CHECK(hipMemcpy(dx,hx.data(),K*4,hipMemcpyHostToDevice));
+    dim3 grid(M,E), block(32);
+    auto run=[&](int mode)->double{
+        hipEvent_t t0,t1;HIP_CHECK(hipEventCreate(&t0));HIP_CHECK(hipEventCreate(&t1));
+        for(int i=0;i<warm;i++){ if(mode==0)moeA<<<grid,block>>>(dbA,dx,dyA,gpr,M); else moeB<<<grid,block>>>(dbN,dbS,dx,dyB,gpr,M);}
+        HIP_CHECK(hipGetLastError()); HIP_CHECK(hipDeviceSynchronize()); double best=1e30;
+        for(int r=0;r<runs;r++){HIP_CHECK(hipEventRecord(t0));
+            for(int i=0;i<iters;i++){ if(mode==0)moeA<<<grid,block>>>(dbA,dx,dyA,gpr,M); else moeB<<<grid,block>>>(dbN,dbS,dx,dyB,gpr,M);}
+            HIP_CHECK(hipEventRecord(t1));HIP_CHECK(hipEventSynchronize(t1));float ms;HIP_CHECK(hipEventElapsedTime(&ms,t0,t1));
+            double us=ms*1000.0/iters; if(us<best)best=us;}
+        return best;};
+    double tA=run(0), tB=run(1);
+    std::vector<float> yA(E*M),yB(E*M);
+    HIP_CHECK(hipMemcpy(yA.data(),dyA,E*M*4,hipMemcpyDeviceToHost));
+    HIP_CHECK(hipMemcpy(yB.data(),dyB,E*M*4,hipMemcpyDeviceToHost));
+    double maxabs=0; for(size_t i=0;i<yA.size();i++){double d=fabs((double)yA[i]-(double)yB[i]);if(d>maxabs)maxabs=d;}
+    printf("PARITY max|A-B|=%.3e\n",maxabs);
+    printf("A (136B interleaved): %.3f us/iter\n", tA);
+    printf("B (128B aligned)    : %.3f us/iter\n", tB);
+    printf("DELTA B vs A = %+.2f%% (%s)\n",(tA-tB)/tA*100.0, tB<tA?"B faster":"A faster");
+    return 0;
+}


### PR DESCRIPTION
## Documented NEGATIVE — the MQ4 128B weight-layout alignment is not a decode lever. Do not re-chase.

Verifies the hypothesis that hipfire's MQ4/HFQ4-G256 group (136B interleaved:
`[4B scale][4B zp][128B nibbles]`, nibble block at offset 8 → not 128B-aligned)
loses decode perf to cacheline straddling on the MoE GEMVs, and that separating
scale/zp so the 128B nibble blocks align would help.

**It doesn't.** Standalone HIP microbench (`benchmarks/mq4_align/`) A/B-ing the
current 136B interleaved layout vs a 128B-aligned layout (aligned nibble blocks +
separate scale array), measured on **gfx1201** (hiptrx R9700) and **gfx1100**
(hipx 7900 XTX — the arch the hypothesis targeted).

### Findings
- **Bit-exact parity** (`max|A-B| = 0`) at every size — the re-layout is
  value-preserving (would be token-id exact).
- **Strong-form hypothesis FALSIFIED.** rocprofv3 `GL2C_MISS` (L2→DRAM fetches)
  is **byte-identical between layouts (17505 = 17505)**. The 136B group is
  *densely* read, so a straddling nibble load pulls its 2nd 128B line from
  **cache** (the neighbouring group's scale/zp already required it), **not** from
  DRAM. Misalignment costs only **+11.3 % L1 request slots** (`TCP_REQ`), not
  memory bandwidth — and DRAM bandwidth is the actual decode bottleneck.
- **Wall-time benefit is size-fragile and REVERSES at decode scale.** A +39 %
  spike at 4.25 MB is an L2-aliasing artifact of the 136B non-power-of-2 stride
  (razor-thin at exactly that size). At the real ~8.5 MB 8-expert gate_up working
  set: gfx1201 = +4.7 % (mostly artifact), **gfx1100 = −12.5 % (regression)**;
  DRAM-bound (34 MB) gfx1100 = **−13.3 %**. The aligned two-stream layout hurts
  DRAM streaming (two access streams / more row activations) more than the
  aligned L1 load helps.
- **Real a3b regime.** `qwen3.6-35b-a3b.mq4r` confirmed MQ4G256/136B
  (`load_moe_ffn` HFQ path); `moe_intermediate=512` → 1.06 MB/expert, ~8.5 MB
  scattered/launch → net **≤ noise on gfx1201, negative on gfx1100**.

A real-path encoder/loader/kernel prototype was scoped but **deliberately not
landed** — expected end-to-end value straddles zero (worse on gfx1100), not worth
the MQ4 wire-format churn. This PR lands only the microbench + write-up so the
lever is recorded as falsified and never re-chased.

Draft: verification/negative result only, no engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)