### PR TITLE
perf(gfx1201): S_PREFETCH on MoE decode GEMV — DEAD (documented null)

### DIFF
--- a/.agent-memory/notes/sprefetch-gfx1201-decode-gemv-falsified.md
+++ b/.agent-memory/notes/sprefetch-gfx1201-decode-gemv-falsified.md
@@ -1,0 +1,69 @@
+---
+title: S_PREFETCH_DATA on gfx1201 a3b decode GEMVs FALSIFIED (DO-NOT-RETRY) — qkvza/gate_up/down all DEAD, TLP already hides latency
+date: 2026-07-09
+tags: [sprefetch, s_prefetch_data, gfx1201, rdna4, decode, gemv, moe, qkvza, gate_up, moe_down, falsified, do-not-retry, phantom-win, occupancy, certify-v2p]
+---
+
+**Verdict: DEAD across the board. Scalar S_PREFETCH_DATA is NOT a decode lever for
+the a3b mq4r batch-1 decode GEMVs on gfx1201/R9700.** Certified vs f33ae7e9 with the
+canonical `autoresearch/harness/ab_certify_v2p.sh` (adaptive-sampled decode tok/s +
+token-id parity gate + coherence + profile), qwen3.6-35b-a3b.mq4r, kv q8, AUTO clock,
+clean card (dev2/card2). All three targets: token-id EXACT, var_coh OK, perf DEAD.
+
+| kernel (KERNEL arg) | variant | verdict | delta_pct | f | rounds | occ (base→var) |
+|---|---|---|---|---|---|---|
+| fused_qkvza_hfq4g256 | next-quad gp0+544 len0 (the extracted ledger "win") | **DEAD** | −0.26% | 0.625 | 4 | 47.8% |
+| gemv_hfq4g256_moe_gate_up_indexed | next-quad gate+up len0 | **DEAD** | +0.16% | 0.611 | 6 | 71.6→51.0% |
+| gemv_hfq4g256_moe_down_k8_indexed_batched_expanded | next-quad ×4row len0 | **DEAD** | +0.46% | 0.635 | 10 | 65.5% |
+
+**Mechanism (harness profile_feedback, profile_standard PMC — this is the DEP_WAIT
+answer):** the a3b batch-1 decode GEMVs are NOT latency-exposed. They run at **48–72%
+achieved occupancy**, so thread-level parallelism (many concurrent waves) ALREADY hides
+the weight-load latency. The original hypothesis ("83–94% exposed DEP_WAIT / SQ_WAIT_ANY
+= exposed weight-load latency for prefetch to overlap") does not hold *in-model* — that
+was an isolated-not-in-model read. `s_prefetch_data` is a wave-uniform SCALAR hint whose
+only in-model effect is +VGPR pressure (gate_up 72→96, qkvza 72→88), which **DROPS
+occupancy** (gate_up 71.6%→51.0%) and thus HURTS the very TLP that was hiding the latency.
+Weights are also 61–76% L2-resident, so little DRAM latency remains to overlap. Harness
+strings: qkvza "mem_busy 57.8%+occ 47.8%=TLP already hides latency, NOT MLP-limited";
+gate_up "occ 71.6->51.0% DROPPED-WAVES … NOT MLP-limited"; down "no clear lever signal".
+
+**Phantom-win falsified:** the ledger row `c3_fused_qkvza_prefetch4_gfx1201`
+(swarm_gfx1201_fused_qkvza_hfq4g256.jsonl) reported **+3.78%** and was cited as an
+unbanked, bankable win. It does NOT replicate: re-certified against f33ae7e9 on a clean
+card it is DEAD −0.26% (f=0.625). It was never folded because it never actually wins
+(NOT because it failed coherence — var_coh=OK). Another "synth/cross-build → prod-falsify"
+per the memory pattern (feedback_v2_sgpr_lut, dot2_trickle_down, fp8_wmma). The qkvza
+prefetch idiom (`gp0 + 544`, len 0) that scored +3.78% in a noisier cross-build A/B is
+the same one that measures DEAD here.
+
+**S_PREFETCH_DATA encoding (verified clang -S, gfx1201):**
+`s_prefetch_data s[base:base+1], <byte-offset>, null, <LEN>` — base is a wave-uniform SGPR
+pair (gate_ptr/up_ptr are uniform → legal), LEN is an immediate cache-line count (0..31
+valid, one RDNA4 line = 128 B). The builtin's 2nd arg = LEN. len0 issues the instruction
+(not folded away). This is the mechanism the qkvza-win idiom used (`len 0`).
+
+**Dead-file correction:** `kernels/src/gemv_hfq4g256.gfx1201.hip` (the file the task pointed
+at for the "existing" prefetch idiom, line 43) is NOT wired into the runtime — it is not
+`include_str!`'d anywhere in crates/, there is no `kernels/compiled/` blob, and
+`gemv_hfq4g256_for_arch()` routes gfx1200/gfx1201 to the BASE `gemv_hfq4g256.hip` (its
+gfx1201 arm is commented out). So the "existing" S_PREFETCH on gfx1201 never executed
+in-model. Only the wired MoE decode GEMVs matter, and prefetch on those is DEAD.
+
+**Reproduce:** drop-in variant .hip (function name unchanged) then
+`BASELINE_REF=f33ae7e9 SCLK=/sys/class/drm/card<N>/device/pp_dpm_sclk bash
+autoresearch/harness/ab_certify_v2p.sh gfx1201 <dev> <card> ~/.hipfire/models/qwen3.6-35b-a3b.mq4r <KERNEL> <label> <variant.hip>`.
+A gated same-daemon lever also shipped: `HIPFIRE_GFX1201_MOE_PREFETCH∈{1,2,3,4}` selects
+gate_up prefetch variants in gemv_hfq4g256_moe_gate_up_indexed_prefetch.hip (default OFF).
+
+**Op note:** `pkill -9` of a running kernel WEDGES that card — subsequent daemon generate
+page-faults in the GPU `sample_top_p` kernel (gfxhub VM fault, code 700) while the forward
+still loads/runs fine. card0/card1 got wedged this way; dev2/dev3 stayed clean. Prefer
+`pkill -9 -x daemon`/`bench_qwen35_mq4` at a quiescent point; if a card page-faults in
+sample_top_p across models+builds, it's a wedge, not a real bug — use a fresh card.
+
+**Endpoint:** every single-kernel scalar-prefetch lever on gfx1201 a3b decode is dead;
+decode is TLP-latency-hidden (occupancy-work-limited), not MLP/latency-exposed — consistent
+with project_dp4a_moe_decode_bw_bound_falsified and the "decode kernel TAPPED" conclusion.
+Do not re-file scalar prefetch on these kernels. The remaining regime-changer stays
+MTP/spec-decode batch-K, not a single-kernel decode-GEMV edit.

--- a/crates/rdna-compute/src/gemv.rs
+++ b/crates/rdna-compute/src/gemv.rs
@@ -5821,10 +5821,42 @@ impl Gpu {
             // Token-id exact vs base (per-row math unchanged). Grid divisor here
             // MUST match the kernel's MOE_GATE_UP_NUM_ROWS.
             use std::sync::OnceLock;
+            // RESEARCH ARTIFACT — CERTIFIED DEAD (opt-in HIPFIRE_GFX1201_MOE_PREFETCH
+            // ∈ {1,2,3,4}, gfx12/RDNA4 only, default OFF). Swaps in an
+            // S_PREFETCH_DATA variant of this decode-hot GEMV. Byte-identical math
+            // (prefetch is a pure hint) → token-id EXACT. ab_certify_v2p.sh vs
+            // f33ae7e9 measured DEAD (+0.16%, f=0.611): the a3b decode GEMVs are
+            // TLP-latency-hidden, so prefetch only adds VGPR pressure / drops
+            // occupancy. Same grid/block as the base kernel.
+            static MOE_PREFETCH: OnceLock<u32> = OnceLock::new();
+            let pf = *MOE_PREFETCH.get_or_init(|| {
+                let v = std::env::var("HIPFIRE_GFX1201_MOE_PREFETCH")
+                    .ok()
+                    .and_then(|s| s.parse::<u32>().ok())
+                    .unwrap_or(0);
+                if (1..=4).contains(&v) {
+                    eprintln!("  MoE gate_up S_PREFETCH variant: pf{v} (research; certified DEAD)");
+                }
+                v
+            });
+            let pf_gfx12 = (1..=4).contains(&pf) && self.arch_caps.arch().starts_with("gfx12");
             static GATE_UP_FUSED: OnceLock<bool> = OnceLock::new();
             let fused = *GATE_UP_FUSED
                 .get_or_init(|| std::env::var("HIPFIRE_MOE_GATE_UP_FUSED").as_deref() == Ok("1"));
-            if fused {
+            if pf_gfx12 {
+                let func = match pf {
+                    1 => "gemv_hfq4g256_moe_gate_up_k8_indexed_pf1",
+                    2 => "gemv_hfq4g256_moe_gate_up_k8_indexed_pf2",
+                    3 => "gemv_hfq4g256_moe_gate_up_k8_indexed_pf3",
+                    _ => "gemv_hfq4g256_moe_gate_up_k8_indexed_pf0",
+                };
+                self.ensure_kernel(
+                    "gemv_hfq4g256_moe_gate_up_indexed_prefetch",
+                    kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_PREFETCH_SRC,
+                    func,
+                )?;
+                (func, [32u32, 1, 1], m as u32)
+            } else if fused {
                 self.ensure_kernel(
                     "gemv_hfq4g256_moe_gate_up_indexed_rowtile",
                     kernels::GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_ROWTILE_SRC,
@@ -6476,7 +6508,8 @@ impl Gpu {
         ];
         // Fused path skips the expanded [N×K_TOP×M] write + re-read; traffic
         // is the routed-expert weight reads plus the per-token residual write.
-        let bytes = batch_size * k_top * crate::profile::gemv_hfq4g256_bytes(m, k) + batch_size * m * 4;
+        let bytes =
+            batch_size * k_top * crate::profile::gemv_hfq4g256_bytes(m, k) + batch_size * m * 4;
         let timer = crate::profile::begin_timer(
             &self.hip,
             "gemv",

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -1249,6 +1249,16 @@ pub const GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_SRC: &str =
 pub const GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_ROWTILE_SRC: &str =
     include_str!("../../../kernels/src/gemv_hfq4g256_moe_gate_up_indexed_rowtile.hip");
 
+/// RESEARCH ARTIFACT — CERTIFIED DEAD. S_PREFETCH_DATA variants of the indexed
+/// MoE gate_up decode GEMV (gfx12/RDNA4 only, opt-in HIPFIRE_GFX1201_MOE_PREFETCH
+/// ∈ {1,2,3,4}, default OFF). Byte-identical math; kept as a reproducible
+/// same-daemon A/B lever. ab_certify_v2p.sh vs f33ae7e9 → DEAD (+0.16%, f=0.611);
+/// the a3b decode GEMVs are TLP-latency-hidden (48–72% occ), so scalar prefetch
+/// only adds VGPR pressure and drops occupancy. See the falsification note
+/// project_sprefetch_gfx1201_decode_gemv_falsified_2026_07_09.
+pub const GEMV_HFQ4G256_MOE_GATE_UP_INDEXED_PREFETCH_SRC: &str =
+    include_str!("../../../kernels/src/gemv_hfq4g256_moe_gate_up_indexed_prefetch.hip");
+
 /// HFQ4G128 (ParoQuant) variant of the indexed MoE gate_up GEMV. Same
 /// device-side expert-pointer table + topk_indices contract as the
 /// HFQ4G256 sibling; closes the residual hipGraph-capture gap for

--- a/kernels/src/gemv_hfq4g256_moe_gate_up_indexed_prefetch.hip
+++ b/kernels/src/gemv_hfq4g256_moe_gate_up_indexed_prefetch.hip
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+
+// ── RESEARCH ARTIFACT — CERTIFIED DEAD (do not enable in production) ──────────
+// S_PREFETCH_DATA variants of the indexed MoE gate_up decode GEMV. gfx12/RDNA4
+// only, opt-in via HIPFIRE_GFX1201_MOE_PREFETCH ∈ {1,2,3,4}; default OFF. Byte-
+// identical math to gemv_hfq4g256_moe_gate_up_indexed.hip (prefetch is a pure
+// hint), so token-id parity holds. Kept as a reproducible same-daemon A/B lever
+// behind the falsification below.
+//
+// VERDICT (2026-07-09, ab_certify_v2p.sh vs f33ae7e9, gfx1201/R9700, a3b mq4r,
+// kv q8, adaptive-sampled): DEAD. gate_up next-quad len0 = +0.16%, f=0.611
+// (noise). Sibling probes on the same card: qkvza next-quad len0 = DEAD −0.26%
+// (f=0.625); moe_down next-quad len0 = DEAD +0.46% (f=0.635). All token-id
+// exact, all var_coh=OK.
+//
+// WHY (harness profile_feedback, profile_standard PMC): the a3b batch-1 decode
+// GEMVs are NOT latency-exposed — they run at 48–72% achieved occupancy, so
+// thread-level parallelism (many concurrent waves) ALREADY hides the weight-load
+// latency; the hypothesised "83–94% exposed DEP_WAIT" does not hold in-model.
+// s_prefetch_data only ADDS VGPR pressure (gate_up 72→96 VGPR), which DROPS
+// occupancy (gate_up 71.6%→51.0%) and thus HURTS the very TLP that was hiding
+// the latency. Weights are also 61–76% L2-resident, so little DRAM latency
+// remains to overlap. Net: zero-to-negative. See the agent-memory note
+// project_sprefetch_gfx1201_decode_gemv_falsified_2026_07_09.
+//
+// Encoding (verified via clang -S, gfx1201):
+//   s_prefetch_data s[base:base+1], <byte-offset>, null, <LEN>
+//   base = wave-uniform SGPR pair (gate_ptr/up_ptr are uniform → legal);
+//   LEN = immediate cache-line count (0..31; one RDNA4 line = 128 B).
+//
+// Variants (HIPFIRE_GFX1201_MOE_PREFETCH selector):
+//   1 (_pf1): NEXT quad (g+4), gate+up, LEN=0  — the certified DEAD idiom.
+//   2 (_pf2): NEXT quad (g+4), gate+up, LEN=5  — prefetch whole quad (~5 lines).
+//   3 (_pf3): 2 quads ahead (g+8), gate+up, LEN=5 — deeper.
+//   4 (_pf0): NEXT quad (g+4), gate+up, LEN=2  — light.
+
+#define MOE_GATE_UP_PREFETCH_BODY(FN, PF_DIST_GROUPS, PF_LEN)                 \
+extern "C" __global__ void FN(                                                \
+    const unsigned long long* __restrict__ expert_ptrs,                       \
+    const int* __restrict__ topk_indices,                                     \
+    const float* __restrict__ x,                                              \
+    float* __restrict__ y_gate,                                               \
+    float* __restrict__ y_up,                                                 \
+    int M, int K                                                              \
+) {                                                                           \
+    const int mi = M >> 1;                                                     \
+    const int row = blockIdx.x;                                               \
+    if (row >= mi) return;                                                     \
+    const int krank = blockIdx.y;                                             \
+    const int tid = threadIdx.x;                                              \
+    const int expert_id = topk_indices[krank];                                \
+    const char* __restrict__ A =                                              \
+        reinterpret_cast<const char*>(expert_ptrs[expert_id]);                \
+    const int groups_per_row = K / 256;                                       \
+    const char* gate_ptr = A + (long long)row * groups_per_row * 136;         \
+    const char* up_ptr = A + (long long)(row + mi) * groups_per_row * 136;    \
+    const int boff = tid * 4;                                                  \
+    float gacc0 = 0.0f, gacc1 = 0.0f, gacc2 = 0.0f, gacc3 = 0.0f;             \
+    float uacc0 = 0.0f, uacc1 = 0.0f, uacc2 = 0.0f, uacc3 = 0.0f;             \
+    const int quads = groups_per_row >> 2;                                    \
+    const int tail = groups_per_row & 3;                                      \
+    for (int q = 0; q < quads; q++) {                                         \
+        const int g = q << 2;                                                  \
+        const int base0 = g * 256 + tid * 8;                                  \
+        { const int gpf = g + (PF_DIST_GROUPS);                               \
+          if (gpf < groups_per_row) {                                         \
+            __builtin_amdgcn_s_prefetch_data(                                 \
+                (const void*)(gate_ptr + (long long)gpf * 136), (PF_LEN));    \
+            __builtin_amdgcn_s_prefetch_data(                                 \
+                (const void*)(up_ptr + (long long)gpf * 136), (PF_LEN));      \
+          } }                                                                 \
+        { LOAD_X8(base0);       DOG_X8(gate_ptr + g * 136, gacc0);            \
+                                DOG_X8(up_ptr + g * 136, uacc0); }            \
+        { LOAD_X8(base0 + 256); DOG_X8(gate_ptr + (g + 1) * 136, gacc1);      \
+                                DOG_X8(up_ptr + (g + 1) * 136, uacc1); }      \
+        { LOAD_X8(base0 + 512); DOG_X8(gate_ptr + (g + 2) * 136, gacc2);      \
+                                DOG_X8(up_ptr + (g + 2) * 136, uacc2); }      \
+        { LOAD_X8(base0 + 768); DOG_X8(gate_ptr + (g + 3) * 136, gacc3);      \
+                                DOG_X8(up_ptr + (g + 3) * 136, uacc3); }      \
+    }                                                                         \
+    if (tail >= 1) { const int g = quads << 2; int base = g * 256 + tid * 8;  \
+        LOAD_X8(base); DOG_X8(gate_ptr + g * 136, gacc0);                     \
+        DOG_X8(up_ptr + g * 136, uacc0); }                                    \
+    if (tail >= 2) { const int g = (quads << 2) + 1; int base = g*256+tid*8;  \
+        LOAD_X8(base); DOG_X8(gate_ptr + g * 136, gacc1);                     \
+        DOG_X8(up_ptr + g * 136, uacc1); }                                    \
+    if (tail >= 3) { const int g = (quads << 2) + 2; int base = g*256+tid*8;  \
+        LOAD_X8(base); DOG_X8(gate_ptr + g * 136, gacc2);                     \
+        DOG_X8(up_ptr + g * 136, uacc2); }                                    \
+    float gacc = (gacc0 + gacc1) + (gacc2 + gacc3);                           \
+    float uacc = (uacc0 + uacc1) + (uacc2 + uacc3);                           \
+    for (int offset = 16; offset > 0; offset >>= 1) gacc += __shfl_down(gacc, offset); \
+    for (int offset = 16; offset > 0; offset >>= 1) uacc += __shfl_down(uacc, offset); \
+    if (tid == 0) { y_gate[krank * mi + row] = gacc; y_up[krank * mi + row] = uacc; } \
+}
+
+#define LOAD_X8(b) \
+    const float x0 = x[(b) + 0]; \
+    const float x1 = x[(b) + 1]; \
+    const float x2 = x[(b) + 2]; \
+    const float x3 = x[(b) + 3]; \
+    const float x4 = x[(b) + 4]; \
+    const float x5 = x[(b) + 5]; \
+    const float x6 = x[(b) + 6]; \
+    const float x7 = x[(b) + 7]
+
+#define DOG_X8(gp, a) do { \
+    float sc = __builtin_bit_cast(float, *(const unsigned int*)(gp)); \
+    float zp = __builtin_bit_cast(float, *(const unsigned int*)((gp) + 4)); \
+    unsigned int pk = *(const unsigned int*)((gp) + 8 + boff); \
+    (a) += (sc * (float)((pk) & 0xFu)         + zp) * x0 \
+         + (sc * (float)(((pk) >> 4) & 0xFu)  + zp) * x1 \
+         + (sc * (float)(((pk) >> 8) & 0xFu)  + zp) * x2 \
+         + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x3 \
+         + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x4 \
+         + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x5 \
+         + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x6 \
+         + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x7; \
+} while (0)
+
+MOE_GATE_UP_PREFETCH_BODY(gemv_hfq4g256_moe_gate_up_k8_indexed_pf1, 4, 0)
+MOE_GATE_UP_PREFETCH_BODY(gemv_hfq4g256_moe_gate_up_k8_indexed_pf2, 4, 5)
+MOE_GATE_UP_PREFETCH_BODY(gemv_hfq4g256_moe_gate_up_k8_indexed_pf3, 8, 5)
+MOE_GATE_UP_PREFETCH_BODY(gemv_hfq4g256_moe_gate_up_k8_indexed_pf0, 4, 2)
+
+#undef DOG_X8
+#undef LOAD_X8
+#undef MOE_GATE_UP_PREFETCH_BODY


### PR DESCRIPTION
## Result: DEAD (documented null). S_PREFETCH_DATA is not a decode lever for gfx1201 a3b GEMVs.

Tested whether RDNA4 `__builtin_amdgcn_s_prefetch_data` overlaps the exposed weight-load latency of the a3b mq4r batch-1 decode GEMVs. **It does not.** Certified against **f33ae7e9** with the canonical `autoresearch/harness/ab_certify_v2p.sh` (adaptive-sampled decode tok/s + token-id parity gate + coherence + profile), qwen3.6-35b-a3b mq4r, kv q8, AUTO clock, gfx1201/R9700, clean card.

| KERNEL (harness arg) | variant | verdict | delta_pct | f | occ base→var |
|---|---|---|---|---|---|
| `fused_qkvza_hfq4g256` | next-quad `gp0+544` len0 (extracted ledger "win") | **DEAD** | −0.26% | 0.625 | 47.8% |
| `gemv_hfq4g256_moe_gate_up_indexed` | next-quad gate+up len0 | **DEAD** | +0.16% | 0.611 | 71.6→51.0% |
| `gemv_hfq4g256_moe_down_k8_indexed_batched_expanded` | next-quad ×4-row len0 | **DEAD** | +0.46% | 0.635 | 65.5% |

All three: **token-id EXACT** (parity gate passed) and **var_coh=OK** (coherent). Perf DEAD.

### Mechanism (profile_standard PMC — the DEP_WAIT answer)
The decode GEMVs are **not latency-exposed**. They run at **48–72% achieved occupancy**, so thread-level parallelism (many concurrent waves) already hides the weight-load latency — the hypothesised "83–94% exposed DEP_WAIT/SQ_WAIT_ANY" does not hold *in-model* (that was an isolated-not-in-model read). `s_prefetch_data` is a wave-uniform scalar hint whose only in-model effect is **+VGPR pressure** (gate_up 72→96), which **drops occupancy** (71.6%→51.0%) and thus *hurts* the very TLP that was hiding the latency. Weights are also 61–76% L2-resident. Net zero-to-negative. Harness `profile_feedback`: qkvza "TLP already hides latency, NOT MLP-limited"; gate_up "occ … DROPPED-WAVES"; down "no clear lever signal".

### Corrections to the search space
- **Phantom win:** ledger row `c3_fused_qkvza_prefetch4_gfx1201` (+3.78%) does **not** replicate vs f33ae7e9 (DEAD −0.26%). A cross-build noise artifact; never folded because it never actually wins — **not** a coherence-at-rollover failure (var_coh=OK).
- **Dead file:** `kernels/src/gemv_hfq4g256.gfx1201.hip` (the "existing" prefetch idiom, line 43) is **not wired** into the runtime — not `include_str!`'d, no compiled blob, and `gemv_hfq4g256_for_arch()` routes gfx1201 to the base `gemv_hfq4g256.hip`. Its `s_prefetch_data` never executed in-model.
- **S_PREFETCH encoding** (verified `clang -S`, gfx1201): `s_prefetch_data s[base:base+1], <off>, null, <LEN>` — the builtin's 2nd arg is LEN (immediate cache-line count 0..31; one RDNA4 line = 128 B). `len 0` still issues the instruction.

### What ships
An **opt-in, default-OFF** research lever: `HIPFIRE_GFX1201_MOE_PREFETCH ∈ {1,2,3,4}` (gfx12 only) selects the gate_up prefetch variants in `gemv_hfq4g256_moe_gate_up_indexed_prefetch.hip`. Flag unset ⇒ **byte-identical dispatch to f33ae7e9** (no production behavior change; coherence structurally preserved). Kept as a reproducible same-daemon A/B lever behind the falsification. Full record + reproduce steps: `.agent-memory/notes/sprefetch-gfx1201-decode-gemv-falsified.md`.

**Draft:** documented null for the record; not intended to enable the lever. Merge-if-useful as a search-space marker (DO-NOT-RETRY), or close after harvest into the oracle corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)