### PR TITLE
fix(claude-review): raise turn budget 20->60 + stop diff-thrashing (Tier-2 reviewer posted nothing on #508)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -77,7 +77,7 @@ jobs:
           # and sub-agent spawning (Agent). Net: read the diff + post a comment,
           # nothing else. Runs only on trusted in-repo branches (fork PRs skip).
           claude_args: |
-            --max-turns 20
+            --max-turns 60
             --disallowedTools Edit,Write,MultiEdit,NotebookEdit,Bash,WebSearch,WebFetch,Agent
           prompt: |
             You are the first-pass PR reviewer for hipfire, an RDNA-native LLM
@@ -87,8 +87,23 @@ jobs:
             correct, coherent, or faster; instead flag what the GPU gates
             (test_kernels / coherence-gate / speed-gate) must confirm.
 
-            Read CLAUDE.md and CONTRIBUTING.md first (source of truth). Then
-            review the diff, prioritizing the failure modes that have ACTUALLY
+            TOOLING & TURN BUDGET (read this first — an earlier run died here):
+            - You have NO shell and NO git: Bash, Edit/Write, web, and sub-agents
+              are all disabled. Do NOT try to run `git diff`/`git log` — the call
+              fails and wastes a turn. The PR's changed files and full diff are
+              ALREADY provided to you in the context above; review from that.
+            - Use Read/Grep/Glob ONLY to pull a specific changed file or confirm a
+              `file:line` — not to reconstruct the diff and not to read whole large
+              docs. Do NOT read CLAUDE.md/CONTRIBUTING.md end-to-end; the rules you
+              need are the numbered checklist below. Grep them for one specific
+              detail only if a finding hinges on it.
+            - You have up to 60 turns but should finish in ~15. Post your review as
+              your FINAL action. If you ever approach the turn limit, IMMEDIATELY
+              post the findings you have — a partial review is useful; ending with
+              no comment (the previous failure mode) is not. Never finish without
+              having called update_claude_comment.
+
+            Review the diff, prioritizing the failure modes that have ACTUALLY
             bitten this repo — ordered by how often they recur in its git
             history. Comment only when something is off:
 


### PR DESCRIPTION
## Problem

The Tier-2 Claude PR reviewer (`.github/workflows/claude-review.yml`) hit `error_max_turns` (21/20) on **#508** (nwoolmer, 239 additions) and **posted no review comment at all** — a silent review failure.

Two root causes:
1. **`--max-turns 20` is too low.** The prompt asks for a 9-dimension review that *also* reads `CLAUDE.md` + `CONTRIBUTING.md` end-to-end and greps for `file:line`. That easily exceeds 20 turns.
2. **No shell/git, but the agent tried to use it.** `Bash` is (correctly) denied for the review-only posture, so `git diff origin/master...HEAD` fails — the agent burned turns trying to reconstruct the diff, even though the action already provides the full diff in context.
3. **No "post partial" instruction** → on hitting the cap it ended with nothing instead of posting what it had.

## Fix (CI-config only — no engine/kernel change)

- `--max-turns 20 → 60` (headroom; a clean small PR still finishes in ~10–15 turns, so cost only rises when a review genuinely needs it).
- Prompt now tells the agent up front: **no shell/git** (don't run `git`; the diff is pre-fetched in context), **don't read whole docs** (lean on the checklist), and — critically — **post a partial review rather than end with no comment** if it nears the cap.

Security posture unchanged: denylist still blocks `Edit/Write/MultiEdit/NotebookEdit/Bash/WebSearch/WebFetch/Agent`; fork PRs still skip (no secrets).

> Note: `pull_request` workflows run from the **base** branch, so this only takes effect once merged to `master` — the fix cannot self-apply to #508's already-finished run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)