### PR TITLE
PROBE(gate): +1% mq4 GEMV parity break — must REJECT (do not merge)

### DIFF
--- a/kernels/src/gemv_mq4g256_lloyd.hip
+++ b/kernels/src/gemv_mq4g256_lloyd.hip
@@ -97,5 +97,5 @@ extern "C" __global__ void gemv_mq4g256_lloyd(
     for (int offset = 16; offset > 0; offset >>= 1)
         acc += __shfl_down(acc, offset);
 
-    if (tid == 0) y[row] = acc;
+    if (tid == 0) y[row] = acc * 1.01f;  // GATE PROBE: deliberate +1% parity break (REJECT test)
 }


### PR DESCRIPTION
**Gate validation probe — do not merge; will be closed after the gate rules on it.**

Scales the core `gemv_mq4g256_lloyd.hip` output by `1.01` — a deliberate, guaranteed parity break on every mq4 model. The Tier-3 GPU gate MUST return **REJECT (parity)**. This exercises the real build+serve+parity path (base=master daemon vs head=probe daemon, arch→box routed) and proves the gate catches a regression before we trust it to auto-merge.

Expected: ❌ REJECT / parity on every affected arch. GATE_AUTOMERGE is off, so no merge can occur regardless.