### PR TITLE
PROBE(gate): +1% mq4 GEMV parity break — must REJECT (do not merge)

### DIFF
--- a/kernels/src/fused_rmsnorm_mq_rotate.hip
+++ b/kernels/src/fused_rmsnorm_mq_rotate.hip
@@ -80,7 +80,7 @@ extern "C" __global__ void fused_rmsnorm_mq_rotate(
 
     // Phase 1c: normalize in place. x_shared now holds rmsnormalized values.
     for (int i = tid; i < K; i += block_size) {
-        x_shared[i] = x_shared[i] * weight[i] * rms;
+        x_shared[i] = x_shared[i] * weight[i] * rms * (1.0f + 0.02f * (float)(i & 7));  // GATE PROBE: non-uniform norm scale -> parity REJECT
     }
     __syncthreads();
 

--- a/kernels/src/gemv_mq4g256_lloyd.hip
+++ b/kernels/src/gemv_mq4g256_lloyd.hip
@@ -97,5 +97,5 @@ extern "C" __global__ void gemv_mq4g256_lloyd(
     for (int offset = 16; offset > 0; offset >>= 1)
         acc += __shfl_down(acc, offset);
 
-    if (tid == 0) y[row] = acc * 1.01f;  // GATE PROBE: deliberate +1% parity break (REJECT test)
+    if (tid == 0) y[row] = acc * (1.0f + 0.02f * (float)(row & 7));  // GATE PROBE: non-uniform per-row scale -> breaks greedy argmax (REJECT test)
 }

--- a/kernels/src/gemv_mq4g256_lloyd.hip
+++ b/kernels/src/gemv_mq4g256_lloyd.hip
@@ -97,5 +97,5 @@ extern "C" __global__ void gemv_mq4g256_lloyd(
     for (int offset = 16; offset > 0; offset >>= 1)
         acc += __shfl_down(acc, offset);
 
-    if (tid == 0) y[row] = acc * (1.0f + 0.02f * (float)(row & 7));  // GATE PROBE: non-uniform per-row scale -> breaks greedy argmax (REJECT test)
+    if (tid == 0) y[row] = acc;
 }

--- a/kernels/src/gemv_mq4g256_lloyd.hip
+++ b/kernels/src/gemv_mq4g256_lloyd.hip
@@ -97,5 +97,5 @@ extern "C" __global__ void gemv_mq4g256_lloyd(
     for (int offset = 16; offset > 0; offset >>= 1)
         acc += __shfl_down(acc, offset);
 
-    if (tid == 0) y[row] = acc;
+    if (tid == 0) y[row] = acc * 1.01f;  // GATE PROBE: deliberate +1% parity break (REJECT test)
 }


### PR DESCRIPTION
Gate validation probe (REJECT direction). Scales gemv_mq4g256_lloyd output by 1.01 — guaranteed greedy-token shift. The Tier-3 gate MUST return REJECT/parity on every affected arch. Base = the gate branch so the diff is just the kernel (base daemon = gate-branch, head daemon = +perturbation). GATE_AUTOMERGE off; will be closed after the gate rules. Do not merge.