### PR TITLE
feat(qwen35): render tool calls in native XML, not legacy Hermes JSON

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1417,6 +1417,31 @@ function resolveNgramBlock(value: "auto" | boolean, modelTag: string | null | un
   return /(:|-)(0\.[68]b|0\.6b|1b|2b|4b)\b/.test(t);
 }
 
+// Whether the Hermes JSON tool-call grammar (daemon's HIPFIRE_QWEN35_GRAMMAR)
+// should be enabled for a model. Only Hermes-format models — the ones that
+// natively emit `<tool_call>{"name":..,"arguments":{..}}</tool_call>` (the
+// carnice family, registry desc "Hermes …") — want it. Plain qwen3.x is
+// Qwen-XML-native (`<function=><parameter=>`); forcing JSON on it makes the
+// model drift back into XML close tags mid-call and drop JSON braces, which
+// corrupts code-writing tool calls. So default OFF and only turn it ON for
+// Hermes-format cards. Explicit `HIPFIRE_QWEN35_GRAMMAR` in the shell always
+// wins (handled by the caller). Keyed on the pre-warm/loaded model, so a
+// single-model serve gets the right mode; a mixed serve would need per-load
+// threading (mirrors the same limitation kv_mode notes for a live serve).
+function resolveToolGrammar(modelTag: string | null | undefined): boolean {
+  if (!modelTag) return false;
+  const card = REGISTRY[resolveModelTag(modelTag)] as
+    | { desc?: string; default_tool_format?: string | null }
+    | undefined;
+  const fmt = card?.default_tool_format;
+  if (fmt === "hermes") return true;
+  if (fmt === "qwen_xml") return false;
+  // Fallback inference when no explicit card field: Hermes-format models are
+  // described as "Hermes …", and the carnice family is the Hermes tool-use set.
+  if (card?.desc && /hermes/i.test(card.desc)) return true;
+  return /(^|[:/_-])(carnice|hermes)\b/i.test(modelTag);
+}
+
 // Set all config-driven env vars in one place so every daemon-spawning
 // codepath picks up the user's current settings consistently.
 // Called before `new Engine().start()`. Optional `modelTag` enables
@@ -1424,6 +1449,13 @@ function resolveNgramBlock(value: "auto" | boolean, modelTag: string | null | un
 // dflash_ngram_block).
 function applyConfigEnv(cfg: HipfireConfig, modelTag?: string | null): void {
   process.env.HIPFIRE_KV_MODE = resolveKvMode(cfg, modelTag);
+  // Tool-call grammar (Hermes JSON) — enable ONLY for Hermes-format models.
+  // qwen3.x is Qwen-XML-native; forcing JSON on it corrupts code-writing tool
+  // calls (XML-tag drift + dropped braces). A set shell env wins (explicit
+  // override / kill-switch); otherwise resolve from the model's registry card.
+  if (process.env.HIPFIRE_QWEN35_GRAMMAR === undefined) {
+    process.env.HIPFIRE_QWEN35_GRAMMAR = resolveToolGrammar(modelTag) ? "1" : "0";
+  }
   // Only set HIPFIRE_ATTN_FLASH if the user hasn't already set it in their
   // shell (env overrides config). `auto` is the engine default — skip the
   // env var in that case so the engine's own default applies.
@@ -2599,7 +2631,11 @@ async function run(model: string, prompt: string, image?: string, temp = 0.3, ma
 }
 
 async function serve(port: number, host: string) {
-  applyConfigEnv(cfg);
+  // Resolve the model this serve will pre-warm (HIPFIRE_MODEL env or the config
+  // default) BEFORE spawning the daemon, so per-model env — notably the
+  // Hermes-JSON tool grammar — is set correctly on the daemon's inherited env.
+  const serveModel = process.env.HIPFIRE_MODEL || cfg.default_model;
+  applyConfigEnv(cfg, serveModel);
   // Write the PID so `hipfire stop` / `hipfire ps` / `hipfire run` can find us.
   // Cleanup on normal exit; stale PID on crash is tolerated (isPidAlive catches it).
   // HIPFIRE_NO_PID_FILE=1 suppresses the write — used by `hipfire chat` when it
@@ -3435,11 +3471,29 @@ async function serve(port: number, host: string) {
         //    tool-call format contracts (observed verbatim in
         //    /tmp/hipfire-prompt-*.txt). Skip for V4F.
         if (tools.length > 0 && currentArch !== "deepseek4") {
+          // qwen3.5/3.6 (arch qwen3_5 / qwen3_5_moe) are Qwen-XML-native
+          // (`<function=NAME><parameter=ARG>`). When the Hermes JSON grammar is
+          // OFF for them (the default for non-Hermes qwen — see resolveToolGrammar),
+          // show the model its NATIVE XML call format instead of the legacy
+          // Hermes JSON example. A JSON example fights the model's training and
+          // induces XML-tag drift / dropped braces mid-call. Keyed on the actual
+          // grammar env so the example always matches what the model will emit:
+          // grammar ON (Hermes-format models like carnice, or a user override)
+          // keeps the JSON example; non-qwen35 arches (cohere, etc.) are
+          // untouched. The <tools> schema block stays JSON either way — that is
+          // the function DEFINITION list, which Qwen's native template also
+          // renders as JSON; only the emitted CALL format differs.
+          const isQwen35 = currentArch === "qwen3_5" || currentArch === "qwen3_5_moe";
+          const grammarOn = process.env.HIPFIRE_QWEN35_GRAMMAR !== "0";
+          const useXmlToolFormat = isQwen35 && !grammarOn;
+          const exampleCall = useXmlToolFormat
+            ? "<tool_call>\n<function=example_function>\n<parameter=param>\nvalue\n</parameter>\n</function>\n</tool_call>"
+            : '<tool_call>\n{"name": "example_function", "arguments": {"param": "value"}}\n</tool_call>';
           const toolsBlock = "# Tools\n\nYou have access to the following functions:\n\n<tools>\n"
             + tools.map((t: any) => JSON.stringify(t)).join("\n")
             + "\n</tools>\n\n"
             + 'If you choose to call a function ONLY reply in the following format with NO suffix:\n\n'
-            + '<tool_call>\n{"name": "example_function", "arguments": {"param": "value"}}\n</tool_call>';
+            + exampleCall;
           systemPrompt = systemPrompt ? systemPrompt + "\n\n" + toolsBlock : toolsBlock;
         }
 

--- a/cli/registry.json
+++ b/cli/registry.json
@@ -315,28 +315,32 @@
       "file": "carnice-9b.mq4",
       "size_gb": 5.0,
       "min_vram_gb": 6,
-      "desc": "Hermes tool-use, MQ4"
+      "desc": "Hermes tool-use, MQ4",
+      "default_tool_format": "hermes"
     },
     "carnice:27b": {
       "repo": "schuttdev/hipfire-carnice-27b",
       "file": "carnice-27b.mq4",
       "size_gb": 15.0,
       "min_vram_gb": 16,
-      "desc": "Hermes 27B tool-use, MQ4"
+      "desc": "Hermes 27B tool-use, MQ4",
+      "default_tool_format": "hermes"
     },
     "carnice:9b-mq6": {
       "repo": "schuttdev/hipfire-carnice-9b",
       "file": "carnice-9b.mq6",
       "size_gb": 7.3,
       "min_vram_gb": 8,
-      "desc": "Hermes tool-use, MQ6 higher quality"
+      "desc": "Hermes tool-use, MQ6 higher quality",
+      "default_tool_format": "hermes"
     },
     "carnice:27b-mq6": {
       "repo": "schuttdev/hipfire-carnice-27b",
       "file": "carnice-27b.mq6",
       "size_gb": 21.4,
       "min_vram_gb": 24,
-      "desc": "Hermes 27B, MQ6 higher quality"
+      "desc": "Hermes 27B, MQ6 higher quality",
+      "default_tool_format": "hermes"
     },
     "qwopus:9b": {
       "repo": "schuttdev/hipfire-qwopus-9b",

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -3630,6 +3630,22 @@ struct PromptCachePlan {
     resume_from: Option<usize>,
 }
 
+/// Format for re-rendering a historical assistant `tool_call` on a cache
+/// MISS in the non-jinja ChatScaffold path (`HIPFIRE_JINJA_CHAT=0`).
+/// Mirrors the CLI's per-model grammar gating: grammar OFF (the default
+/// for native-XML Qwen3.5/3.6) => native XML; grammar ON (Hermes-format
+/// models like carnice, or a user override) => Hermes JSON. Both
+/// `build_cached_history` call sites (LCP planning in `plan_prompt_cache`
+/// and the actual prompt render) read this so their token streams stay
+/// byte-consistent — a mismatch would break the LCP forward-extension.
+fn qwen_history_tool_render() -> hipfire_runtime::prompt_frame::ToolCallRender {
+    if std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref() == Some("0") {
+        hipfire_runtime::prompt_frame::ToolCallRender::QwenXml
+    } else {
+        hipfire_runtime::prompt_frame::ToolCallRender::HermesJson
+    }
+}
+
 /// Pure LCP prompt-cache decision shared in spirit with the AR `generate`
 /// path's inline block — but side-effect-free (touches no GPU/seq_pos state),
 /// so the DFlash path can use it too. Renders the canonical conversation via
@@ -3666,6 +3682,7 @@ fn plan_prompt_cache(
         messages_history,
         &q_tokens,
         assistant_prefix,
+        qwen_history_tool_render(),
         |msg| {
             let stripped = strip_think_for_fingerprint(&msg.content);
             let normalized =
@@ -6745,8 +6762,10 @@ fn generate(
                       // flags) — same predicate the arch_id=7 path uses above. The τ-adaptive
                       // block controller makes temp>0 DSpark beat AR + CACTUS adds more; this
                       // was hardcoded greedy-only (temp>0 → AR).
-        let spec_temp_ok =
-            temp <= 1e-6 || m.speculator.as_ref().map_or(false, |s| !s.requires_greedy());
+        let spec_temp_ok = temp <= 1e-6
+            || m.speculator
+                .as_ref()
+                .map_or(false, |s| !s.requires_greedy());
         let spec_mode = deepseek4_spec_requested(m) && spec_temp_ok;
         if spec_mode && m.speculator.is_some() {
             generate_deepseek4_spec(
@@ -7776,6 +7795,7 @@ fn generate(
                 history,
                 &q_tokens,
                 assistant_prefix,
+                qwen_history_tool_render(),
                 |msg| {
                     // Match the store side's stripping. The store applies
                     // `strip_think_for_fingerprint` then `maybe_normalize_prompt`

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -3638,12 +3638,11 @@ struct PromptCachePlan {
 /// `build_cached_history` call sites (LCP planning in `plan_prompt_cache`
 /// and the actual prompt render) read this so their token streams stay
 /// byte-consistent — a mismatch would break the LCP forward-extension.
-fn qwen_history_tool_render() -> hipfire_runtime::prompt_frame::ToolCallRender {
-    if std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref() == Some("0") {
-        hipfire_runtime::prompt_frame::ToolCallRender::QwenXml
-    } else {
-        hipfire_runtime::prompt_frame::ToolCallRender::HermesJson
-    }
+fn qwen_history_tool_render(model_path: &str) -> hipfire_runtime::prompt_frame::ToolCallRender {
+    hipfire_runtime::prompt_frame::qwen35_history_render(
+        std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref(),
+        model_path,
+    )
 }
 
 /// Pure LCP prompt-cache decision shared in spirit with the AR `generate`
@@ -3667,6 +3666,7 @@ fn plan_prompt_cache(
     system_prompt: Option<&str>,
     prompt: &str,
     assistant_prefix: hipfire_runtime::prompt_frame::AssistantPrefix,
+    tool_render: hipfire_runtime::prompt_frame::ToolCallRender,
     messages_history: &[hipfire_runtime::prompt_frame::Message],
     cache_disabled: bool,
     // Ascending DeltaNet checkpoint positions (from `m.dflash_checkpoints`) and
@@ -3682,7 +3682,7 @@ fn plan_prompt_cache(
         messages_history,
         &q_tokens,
         assistant_prefix,
-        qwen_history_tool_render(),
+        tool_render,
         |msg| {
             let stripped = strip_think_for_fingerprint(&msg.content);
             let normalized =
@@ -4084,6 +4084,7 @@ fn generate_dflash(
                 system_prompt,
                 prompt,
                 assistant_prefix,
+                qwen_history_tool_render(&m.model_path),
                 hist,
                 cache_disabled,
                 &dflash_ckpt_positions,
@@ -4123,7 +4124,10 @@ fn generate_dflash(
     // list from the raw tool JSON inside `make_spec_emitter`. This wrapper only
     // honors the `HIPFIRE_QWEN35_GRAMMAR=0` kill-switch by withholding `tools`
     // (⇒ empty schema ⇒ grammar inactive).
-    let grammar_enabled = std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref() != Some("0");
+    let grammar_enabled = hipfire_runtime::prompt_frame::qwen35_grammar_on(
+        std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref(),
+        &m.model_path,
+    );
     let emit_tools: Option<Vec<serde_json::Value>> = if grammar_enabled {
         tools.map(|t| t.to_vec())
     } else {
@@ -5913,7 +5917,10 @@ fn generate_multi(
     // vocab is built into a request-local Vec rather than cached on `m`
     // (m.decoded_vocab) because `m` is already mutably borrowed here (kv/dn/gpus)
     // — pp>1 + tools is uncommon, so the per-request decode is acceptable.
-    let grammar_enabled = std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref() != Some("0");
+    let grammar_enabled = hipfire_runtime::prompt_frame::qwen35_grammar_on(
+        std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref(),
+        &m.model_path,
+    );
     let tool_schemas_qwen: Vec<hipfire_arch_qwen35::grammar::ToolSchema> = if grammar_enabled {
         tools
             .map(|arr| {
@@ -7795,7 +7802,7 @@ fn generate(
                 history,
                 &q_tokens,
                 assistant_prefix,
-                qwen_history_tool_render(),
+                qwen_history_tool_render(&m.model_path),
                 |msg| {
                     // Match the store side's stripping. The store applies
                     // `strip_think_for_fingerprint` then `maybe_normalize_prompt`
@@ -8453,7 +8460,10 @@ fn generate(
         // structurally-similar DSML grammar.
         //
         // Disable with `HIPFIRE_QWEN35_GRAMMAR=0` for A/B comparison.
-        let grammar_enabled = std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref() != Some("0");
+        let grammar_enabled = hipfire_runtime::prompt_frame::qwen35_grammar_on(
+            std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref(),
+            &m.model_path,
+        );
         let tool_schemas_qwen: Vec<hipfire_arch_qwen35::grammar::ToolSchema> = if grammar_enabled {
             tools
                 .map(|arr| {

--- a/crates/hipfire-runtime/src/prompt_frame.rs
+++ b/crates/hipfire-runtime/src/prompt_frame.rs
@@ -360,6 +360,47 @@ impl<'a> ChatScaffold<'a> {
     }
 }
 
+/// How a historical assistant turn's `tool_calls` are re-rendered on a
+/// cache MISS in [`build_cached_history`] — the hand-rolled ChatScaffold
+/// path used only when `HIPFIRE_JINJA_CHAT=0`. (The default jinja path
+/// renders history through the model's trained chat_template instead, via
+/// `build_cached_history_jinja`, and is unaffected by this enum.)
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum ToolCallRender {
+    /// Legacy Hermes JSON: `\n<tool_call>\n{"name":..,"arguments":..}\n</tool_call>`.
+    /// Correct for Hermes-native models (carnice) and grammar-forced JSON.
+    HermesJson,
+    /// Qwen native XML: `\n<tool_call>\n<function=NAME>\n<parameter=ARG>\nVALUE\n</parameter>\n…\n</function>\n</tool_call>`.
+    /// Matches what grammar-off Qwen3.5/3.6 actually emit (and their
+    /// upstream chat_template), so a cache-miss history replay shows the
+    /// model its own format instead of fighting it with JSON.
+    QwenXml,
+}
+
+/// Render one tool call in Qwen3.5/3.6 native XML, matching the shape the
+/// model emits and its upstream chat_template produces. A string argument
+/// is emitted verbatim; any other JSON value is compact-serialized
+/// (mirrors the template's `value | string if string else value | tojson`).
+fn render_tool_call_qwen_xml(tc: &ToolCall) -> String {
+    let mut s = String::from("\n<tool_call>\n<function=");
+    s.push_str(&tc.name);
+    s.push_str(">\n");
+    if let Some(obj) = tc.arguments.as_object() {
+        for (k, v) in obj {
+            s.push_str("<parameter=");
+            s.push_str(k);
+            s.push_str(">\n");
+            match v {
+                serde_json::Value::String(sv) => s.push_str(sv),
+                other => s.push_str(&serde_json::to_string(other).unwrap_or_default()),
+            }
+            s.push_str("\n</parameter>\n");
+        }
+    }
+    s.push_str("</function>\n</tool_call>");
+    s
+}
+
 /// Build a multi-turn token stream from structured history, splicing
 /// cached verbatim token sequences for any historical assistant turn
 /// that `cache_lookup` returns `Some` for. Used by the daemon's Qwen
@@ -387,6 +428,7 @@ pub fn build_cached_history(
     history: &[Message],
     live_user_tokens: &[u32],
     assistant_prefix: AssistantPrefix,
+    tool_render: ToolCallRender,
     mut cache_lookup: impl FnMut(&Message) -> Option<Vec<u32>>,
 ) -> Vec<u32> {
     let scaffold = ChatScaffold::for_tokenizer(tokenizer);
@@ -444,14 +486,19 @@ pub fn build_cached_history(
                         out.extend(tokenizer.encode(&msg.content));
                     }
                     for tc in &msg.tool_calls {
-                        let payload = serde_json::json!({
-                            "name": tc.name,
-                            "arguments": tc.arguments,
-                        });
-                        let rendered = format!(
-                            "\n<tool_call>\n{}\n</tool_call>",
-                            serde_json::to_string(&payload).unwrap_or_default(),
-                        );
+                        let rendered = match tool_render {
+                            ToolCallRender::HermesJson => {
+                                let payload = serde_json::json!({
+                                    "name": tc.name,
+                                    "arguments": tc.arguments,
+                                });
+                                format!(
+                                    "\n<tool_call>\n{}\n</tool_call>",
+                                    serde_json::to_string(&payload).unwrap_or_default(),
+                                )
+                            }
+                            ToolCallRender::QwenXml => render_tool_call_qwen_xml(tc),
+                        };
                         out.extend(tokenizer.encode(&rendered));
                     }
                 }
@@ -1647,6 +1694,94 @@ mod tests {
         assert!(
             out.contains("tool:72F[id=call_1];"),
             "tool response w/ tool_call_id rendered: {out:?}",
+        );
+    }
+
+    #[test]
+    fn cache_miss_history_tool_call_renders_native_xml_for_qwen() {
+        // Non-jinja ChatScaffold replay: on a cache MISS the historical
+        // assistant tool_call must re-render in the model's OWN format.
+        // For grammar-off Qwen3.5/3.6 that is native XML
+        // (`<function=NAME><parameter=ARG>`), NOT Hermes JSON — otherwise a
+        // post-eviction replay shows the model JSON and nudges it off its
+        // trained tool-call distribution.
+        let t = make_tokenizer();
+        let history = vec![
+            Message {
+                role: Role::User,
+                content: "weather?".to_string(),
+                tool_calls: Vec::new(),
+                tool_call_id: None,
+                tool_plan: String::new(),
+            },
+            Message {
+                role: Role::Assistant,
+                content: String::new(),
+                tool_calls: vec![ToolCall {
+                    name: "get_weather".to_string(),
+                    arguments: serde_json::json!({"city": "SF"}),
+                }],
+                tool_call_id: None,
+                tool_plan: String::new(),
+            },
+        ];
+        // cache_lookup returns None => MISS => the miss-branch render runs.
+        let toks = build_cached_history(
+            &t,
+            None,
+            &history,
+            &[],
+            AssistantPrefix::Plain,
+            ToolCallRender::QwenXml,
+            |_| None,
+        );
+        let text = t.decode(&toks);
+        assert!(
+            text.contains("<function=get_weather>"),
+            "expected native XML function tag, got: {text:?}"
+        );
+        assert!(
+            text.contains("<parameter=city>"),
+            "expected native XML parameter tag, got: {text:?}"
+        );
+        assert!(
+            !text.contains("{\"name\""),
+            "must NOT emit Hermes JSON payload, got: {text:?}"
+        );
+    }
+
+    #[test]
+    fn cache_miss_history_tool_call_renders_hermes_json_when_selected() {
+        // Hermes-native models (carnice / grammar-forced JSON) must keep
+        // the legacy `{"name":..,"arguments":..}` payload on replay.
+        let t = make_tokenizer();
+        let history = vec![Message {
+            role: Role::Assistant,
+            content: String::new(),
+            tool_calls: vec![ToolCall {
+                name: "get_weather".to_string(),
+                arguments: serde_json::json!({"city": "SF"}),
+            }],
+            tool_call_id: None,
+            tool_plan: String::new(),
+        }];
+        let toks = build_cached_history(
+            &t,
+            None,
+            &history,
+            &[],
+            AssistantPrefix::Plain,
+            ToolCallRender::HermesJson,
+            |_| None,
+        );
+        let text = t.decode(&toks);
+        assert!(
+            text.contains("{\"name\":\"get_weather\""),
+            "expected Hermes JSON payload, got: {text:?}"
+        );
+        assert!(
+            !text.contains("<function="),
+            "must NOT emit XML function tag, got: {text:?}"
         );
     }
 

--- a/crates/hipfire-runtime/src/prompt_frame.rs
+++ b/crates/hipfire-runtime/src/prompt_frame.rs
@@ -382,6 +382,18 @@ pub enum ToolCallRender {
 /// is emitted verbatim; any other JSON value is compact-serialized
 /// (mirrors the template's `value | string if string else value | tojson`).
 fn render_tool_call_qwen_xml(tc: &ToolCall) -> String {
+    // Invariant: tool-call arguments are a JSON object (per the tool schema).
+    // A non-object degrades to an empty `<function=…></function>` below; assert
+    // in debug so a violation surfaces in tests, degrade gracefully in release.
+    // NOTE: parameter values are NOT XML-escaped — a value literally containing
+    // `</parameter>`/`</function>` would desync the replayed token stream, but
+    // that only turns a cache-hit into a cache-miss (LCP divergence forces a
+    // re-prefill), and mirrors the model's own upstream chat_template.
+    debug_assert!(
+        tc.arguments.is_object(),
+        "tool-call arguments should be a JSON object, got {:?}",
+        tc.arguments
+    );
     let mut s = String::from("\n<tool_call>\n<function=");
     s.push_str(&tc.name);
     s.push_str(">\n");
@@ -399,6 +411,36 @@ fn render_tool_call_qwen_xml(tc: &ToolCall) -> String {
     }
     s.push_str("</function>\n</tool_call>");
     s
+}
+
+/// Whether the Hermes-JSON tool-call grammar (and history render) should be ON
+/// for a Qwen3.5/3.6-family model, given the `HIPFIRE_QWEN35_GRAMMAR` env value
+/// (`None` if unset) and the loaded model path. Lives in the lib — not only in
+/// the CLI's `resolveToolGrammar` — so the DAEMON defaults correctly when
+/// launched DIRECTLY: the GPU behavior gate and `coherence-gate.sh` /
+/// `agentic-gate.sh` spawn `examples/daemon` without the CLI's `applyConfigEnv`,
+/// so without this they fall back to Hermes and never exercise the native-XML
+/// path. Precedence: explicit env wins (`"0"` = off kill-switch, any other set
+/// value = on); otherwise carnice (Hermes-native) => ON, plain Qwen3.5/3.6
+/// (XML-native) => OFF. Keyed on `carnice` in the model file name (all carnice
+/// cards ship as `carnice-*.mq{4,6}`), the only Hermes family in this arch.
+pub fn qwen35_grammar_on(env: Option<&str>, model_path: &str) -> bool {
+    match env {
+        Some("0") => false,
+        Some(_) => true,
+        None => model_path.to_ascii_lowercase().contains("carnice"),
+    }
+}
+
+/// Cache-miss history re-render format (non-jinja `HIPFIRE_JINJA_CHAT=0` path)
+/// for the same inputs as [`qwen35_grammar_on`]: grammar ON => Hermes JSON,
+/// grammar OFF => Qwen native XML.
+pub fn qwen35_history_render(env: Option<&str>, model_path: &str) -> ToolCallRender {
+    if qwen35_grammar_on(env, model_path) {
+        ToolCallRender::HermesJson
+    } else {
+        ToolCallRender::QwenXml
+    }
 }
 
 /// Build a multi-turn token stream from structured history, splicing
@@ -1782,6 +1824,55 @@ mod tests {
         assert!(
             !text.contains("<function="),
             "must NOT emit XML function tag, got: {text:?}"
+        );
+    }
+
+    // ── Model-aware tool-call format default ────────────────────────────
+    // The DAEMON (not just the CLI) must default the tool-call format by
+    // model, so a daemon-direct launch (GPU behavior gate, coherence-gate.sh,
+    // agentic-gate.sh) gets native XML for plain Qwen3.5/3.6 — not Hermes.
+
+    #[test]
+    fn grammar_default_off_for_plain_qwen() {
+        // No env => plain (non-carnice) Qwen3.5/3.6 defaults grammar OFF (XML).
+        assert!(!qwen35_grammar_on(None, "/models/qwen3.6-27b.mq4"));
+        assert!(!qwen35_grammar_on(None, "/models/qwen3.5-4b.mq4"));
+    }
+
+    #[test]
+    fn grammar_default_on_for_carnice() {
+        // No env => carnice (Hermes-native) defaults grammar ON (JSON).
+        assert!(qwen35_grammar_on(None, "/models/carnice-27b.mq4"));
+        assert!(qwen35_grammar_on(None, "/MODELS/Carnice-9b.mq6")); // case-insensitive
+    }
+
+    #[test]
+    fn grammar_env_zero_is_killswitch_even_for_carnice() {
+        assert!(!qwen35_grammar_on(Some("0"), "/models/carnice-27b.mq4"));
+    }
+
+    #[test]
+    fn grammar_env_set_forces_on_even_for_plain_qwen() {
+        assert!(qwen35_grammar_on(Some("1"), "/models/qwen3.6-27b.mq4"));
+    }
+
+    #[test]
+    fn history_render_follows_model_default_and_env() {
+        assert_eq!(
+            qwen35_history_render(None, "/m/qwen3.6-27b.mq4"),
+            ToolCallRender::QwenXml
+        );
+        assert_eq!(
+            qwen35_history_render(None, "/m/carnice-27b.mq4"),
+            ToolCallRender::HermesJson
+        );
+        assert_eq!(
+            qwen35_history_render(Some("1"), "/m/qwen3.6-27b.mq4"),
+            ToolCallRender::HermesJson
+        );
+        assert_eq!(
+            qwen35_history_render(Some("0"), "/m/carnice-27b.mq4"),
+            ToolCallRender::QwenXml
         );
     }
 


### PR DESCRIPTION
Follow-on to #508 (the dropped-outer-brace grammar fix). That PR made the Hermes-JSON grammar correct; this PR stops forcing qwen3.5/3.6 into Hermes JSON at all, since those models are **XML-native** (`<function=NAME><parameter=ARG>`). Emitting a JSON example / re-rendering history as JSON fights the model's training and is what induced the drift in the first place.

## Changes

1. **Per-model grammar gating** (`cli/index.ts`, `registry.json`): `resolveToolGrammar()` picks the tool format from the registry `default_tool_format` (added `"hermes"` to the 4 carnice cards) or a hermes/carnice heuristic. Non-Hermes qwen defaults the Hermes JSON grammar **OFF** → the model emits its native XML; Hermes-format models (carnice) keep it **ON**. Applied in `serve()` too.
2. **CLI tools-block example → native XML** (Part A): for `qwen3_5`/`qwen3_5_moe` with the grammar off, the injected example is `<tool_call><function=><parameter=>` instead of the Hermes JSON one. Keyed on the live grammar env so the example always matches what the model will actually emit.
3. **Cache-miss history re-render → native XML** (Part B): `build_cached_history`'s ChatScaffold miss branch (the `HIPFIRE_JINJA_CHAT=0` hand-rolled fallback) gains a `ToolCallRender` param; grammar-off qwen re-renders a historical `tool_call` as native XML via `render_tool_call_qwen_xml()`. Both call sites (LCP planning in `plan_prompt_cache` + the actual render) read the same env-derived format so their token streams stay byte-consistent.

## Note on scope

On the **default** path qwen3.6 already renders through its bundled `chat_template` (`jinja_active` is on by default), which is native XML for both the tools-block and history — so the real forcing signal was the grammar (now off for non-Hermes qwen). Parts A/B additionally harden the `HIPFIRE_JINJA_CHAT=0` hand-rolled fallback so it's consistent too.

## Testing

- `prompt_frame` red→green tests for both XML and Hermes-JSON history render; full `hipfire-runtime` lib (315) + `hipfire-arch-qwen35` grammar (75) green.
- Live on qwen3.6-27b.mq4: single-turn 5/5 angle-bracket-heavy writes clean (heredoc `<<`, `#include <stdio.h>`, `<vector>`, HTML, `a < b`); multi-turn (history tool_call + tool result → new call) clean; the `HIPFIRE_JINJA_CHAT=0` cache path exercised (`eligible=true`, Assistant tool_call miss → XML render, `lcp=256` forward extension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
