### PR TITLE
fix(gate): expose box-local Codex to runners

### DIFF
--- a/.github/workflows/gpu-gates.yml
+++ b/.github/workflows/gpu-gates.yml
@@ -344,6 +344,9 @@ jobs:
           BOX: ${{ matrix.box }}
         run: |
           set -eu
+          # The runner service is non-login and does not inherit ~/.local/bin,
+          # while both boxes install their authenticated codex binary there.
+          export PATH="$HOME/.local/bin:$PATH"
           source scripts/gpu-lock.sh
           gpu_acquire "gpu-gate-behavior-${BOX}"
           trap gpu_release EXIT

--- a/autoresearch/ar/gate/dispatch.py
+++ b/autoresearch/ar/gate/dispatch.py
@@ -347,18 +347,26 @@ def run_behavior_test(bt, *, agent_exec_fn, cwd, verdict_path) -> dict:
         + f" serve_harness). When done, write your verdict as JSON to {verdict_path}:"
         + ' {"passed": <true|false>, "detail": "<one-line reason>"}.'
     )
-    rc = agent_exec_fn(
-        harness=bt.get("harness", "codex"), model=bt.get("model"),
-        effort=bt.get("effort", "high"), prompt=prompt, cwd=cwd,
-    )
-    passed, detail = False, f"no verdict written (exec rc={rc})"
+    exec_error = None
+    try:
+        rc = agent_exec_fn(
+            harness=bt.get("harness", "codex"), model=bt.get("model"),
+            effort=bt.get("effort", "high"), prompt=prompt, cwd=cwd,
+        )
+    except Exception as e:
+        # Executor discovery/auth/process errors are structured behavior failures,
+        # not uncaught tracebacks that leave an empty, unjoinable artifact.
+        rc = 127
+        exec_error = f"executor error: {type(e).__name__}: {e}"
+    passed, detail = False, exec_error or f"no verdict written (exec rc={rc})"
     try:
         with open(verdict_path) as fh:
             v = json.load(fh)
         passed = bool(v.get("passed"))
         detail = str(v.get("detail", ""))
     except Exception as e:  # missing / malformed verdict -> FAIL, do not silently pass
-        detail = f"verdict unreadable ({e}); exec rc={rc}"
+        if exec_error is None:
+            detail = f"verdict unreadable ({e}); exec rc={rc}"
     return {"id": bt.get("id"), "what": bt.get("what", "behavior"), "passed": passed,
             "harness": bt.get("harness", "codex"), "model": bt.get("model"), "detail": detail}
 

--- a/autoresearch/ar/tests/test_gate_dispatch.py
+++ b/autoresearch/ar/tests/test_gate_dispatch.py
@@ -85,6 +85,20 @@ def test_behavior_test_missing_verdict_is_fail_not_silent_pass(tmp_path):
     assert r["passed"] is False and "verdict unreadable" in r["detail"]
 
 
+def test_behavior_test_executor_exception_is_structured_fail(tmp_path):
+    def missing_executor(**kwargs):
+        raise FileNotFoundError("codex")
+
+    r = run_behavior_test(
+        {"id": "x", "what": "x", "prompt": "p"},
+        agent_exec_fn=missing_executor, cwd="/r",
+        verdict_path=str(tmp_path / "missing.json"),
+    )
+    assert r["passed"] is False
+    assert r["id"] == "x"
+    assert "executor error: FileNotFoundError: codex" in r["detail"]
+
+
 def test_run_behavior_tests_all(tmp_path):
     tests = [{"what": "a", "prompt": "pa"}, {"what": "b", "prompt": "pb"}]
     res = run_behavior_tests(tests, agent_exec_fn=_writer(True), cwd="/r",

--- a/autoresearch/ar/tests/test_gpu_gate_workflow.py
+++ b/autoresearch/ar/tests/test_gpu_gate_workflow.py
@@ -53,6 +53,13 @@ def test_selected_runner_uses_mechanical_collect_and_grade_not_agent_verdict():
     assert "codex exec" not in collect
 
 
+def test_box_behavior_executor_adds_authenticated_local_binary_path():
+    text = _text()
+    behavior = text.split("- name: Run assigned bespoke behavior tests", 1)[1]
+    behavior = behavior.split("- name: Upload box evidence", 1)[0]
+    assert 'export PATH="$HOME/.local/bin:$PATH"' in behavior
+
+
 def test_interpret_requires_dispatch_and_downloaded_runner_evidence():
     text = _text()
     interpret = text.split("\n  interpret:\n", 1)[1]


### PR DESCRIPTION
## Root cause

The live #513 dispatch and deterministic gfx1201 battery succeeded, but bespoke behavior execution failed before testing because the non-login Actions runner PATH did not include `~/.local/bin`. Both hipx and hiptrx have their authenticated Codex binary at `/home/kaden/.local/bin/codex`.

## Fix

- prepend `$HOME/.local/bin` only in the bespoke behavior step
- convert executor discovery/auth/process exceptions into structured failed behavior results instead of tracebacks and empty artifacts

## Validation

- actionlint clean
- 281/281 autoresearch gate tests pass
- read-only host check confirms `/home/kaden/.local/bin/codex` on both hipx and hiptrx
- run 29156600624 proved Claude dispatch, dynamic two-box scheduling, and gfx1201 deterministic PASS before the PATH failure

After merge I will rerun #513 to validate the behavior executors and final join.