### PR TITLE
fix(gate): bound box-local Codex probes

### DIFF
--- a/autoresearch/ar/gate/agent.py
+++ b/autoresearch/ar/gate/agent.py
@@ -1,0 +1,115 @@
+# Copyright (c) Kaden Schutt
+"""Bounded, gate-local Codex executor for bespoke behavior probes.
+
+The autoresearch loop intentionally lets an agent keep exploring until the agent
+exits. A merge gate has a different contract: once a valid structured verdict
+exists, further exploration only holds a scarce GPU runner. This executor stops
+the whole probe process group at that boundary and fails closed on a wall timeout.
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+
+DEFAULT_TIMEOUT_SECONDS = 900.0
+DEFAULT_POLL_SECONDS = 0.25
+
+
+def _valid_verdict(path: str) -> bool:
+    try:
+        with open(path) as fh:
+            verdict = json.load(fh)
+        return (
+            isinstance(verdict.get("passed"), bool)
+            and isinstance(verdict.get("detail"), str)
+            and bool(verdict["detail"].strip())
+        )
+    except (OSError, ValueError, AttributeError):
+        return False
+
+
+def _stop_process_group(proc: subprocess.Popen, *, grace_seconds: float = 5.0) -> None:
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        proc.wait()
+        return
+    try:
+        proc.wait(timeout=grace_seconds)
+    except subprocess.TimeoutExpired:
+        pass
+    # The Codex parent can exit before a spawned daemon. Kill any remaining
+    # members even when wait() already reaped the parent.
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    if proc.poll() is None:
+        try:
+            proc.wait()
+        except ChildProcessError:
+            pass
+
+
+def run_codex_probe(
+    *,
+    harness: str,
+    model: str,
+    effort: str,
+    prompt: str,
+    cwd: str,
+    verdict_path: str,
+    timeout_seconds: float | None = None,
+    poll_seconds: float = DEFAULT_POLL_SECONDS,
+) -> int:
+    """Run one Codex behavior probe and return 0 once its verdict is complete.
+
+    The child gets its own process group so any daemon/build children are cleaned
+    up with Codex. Missing/malformed verdicts remain failures in ``dispatch.py``;
+    a timeout returns 124. This deliberately has no autoresearch retry/fallback
+    policy: merge-gate evidence must come from the exact dispatched harness/model.
+    """
+    if (harness or "codex").lower() != "codex":
+        raise ValueError("GPU gate behavior probes require harness='codex'")
+    try:
+        os.unlink(verdict_path)
+    except FileNotFoundError:
+        pass
+    timeout = float(
+        timeout_seconds
+        if timeout_seconds is not None
+        else os.environ.get("GATE_CODEX_TIMEOUT_SECS", DEFAULT_TIMEOUT_SECONDS)
+    )
+    argv = [
+        "codex", "exec", "--dangerously-bypass-approvals-and-sandbox",
+        "--skip-git-repo-check", "-m", model,
+        "-c", f'model_reasoning_effort="{effort}"', "-C", cwd, "-",
+    ]
+    proc = subprocess.Popen(
+        argv, cwd=cwd, stdin=subprocess.PIPE, stdout=sys.stderr, stderr=sys.stderr,
+        text=True, start_new_session=True,
+    )
+    try:
+        assert proc.stdin is not None
+        proc.stdin.write(prompt)
+        proc.stdin.close()
+        deadline = time.monotonic() + timeout
+        while True:
+            if _valid_verdict(verdict_path):
+                _stop_process_group(proc)
+                return 0
+            rc = proc.poll()
+            if rc is not None:
+                _stop_process_group(proc)
+                return rc
+            if time.monotonic() >= deadline:
+                _stop_process_group(proc)
+                return 124
+            time.sleep(poll_seconds)
+    except BaseException:
+        _stop_process_group(proc)
+        raise

--- a/autoresearch/ar/gate/dispatch.py
+++ b/autoresearch/ar/gate/dispatch.py
@@ -8,8 +8,8 @@ This module is the deterministic glue around that plan:
   * parse_plan   — parse Claude's plan and apply the classify_pr FLOOR to its risk
                    (escalate-only: Claude can go higher than the path floor, never
                    lower — a kernel PR can't be de-classified to trivial).
-  * run_behavior_test(s) — execute each bespoke test via the injected codex seam
-                   (agent_exec), reading a structured verdict codex writes. This is
+  * run_behavior_test(s) — execute each bespoke test via the injected bounded
+                   gate-local Codex seam, reading a structured verdict Codex writes. This is
                    the "codex tests beyond serve_harness" piece — codex runs the
                    test GENERALLY on-box (build / run the new path / verify), not
                    bound to serve_harness.
@@ -18,7 +18,7 @@ This module is the deterministic glue around that plan:
                    behavior test passed.
 
 Everything here is pure/no-GPU with an injected agent_exec_fn; the only real GPU/
-codex touch is agent_exec itself in production.
+Codex touch is the gate-local executor itself in production.
 """
 from __future__ import annotations
 
@@ -337,7 +337,7 @@ def verify_evidence(plan: dict, *, results_dir, behavior_dir, pr, base_sha, head
 
 def run_behavior_test(bt, *, agent_exec_fn, cwd, verdict_path) -> dict:
     """Run ONE bespoke behavior test via codex. ``agent_exec_fn(harness, model, effort,
-    prompt, cwd) -> int`` is the injected seam (agent_exec.run_round in prod). codex is
+    prompt, cwd, verdict_path) -> int`` is the injected seam. codex is
     told to write a structured verdict to ``verdict_path``; a missing/unreadable verdict
     is a FAIL (never a silent pass). Returns {what, passed, harness, model, detail}."""
     prompt = (
@@ -345,13 +345,14 @@ def run_behavior_test(bt, *, agent_exec_fn, cwd, verdict_path) -> dict:
         + f"\n\nExpected: {bt.get('expect', 'the behavior works correctly')}."
         + f"\nBuild/run whatever is needed to verify this on-box (you are NOT limited to"
         + f" serve_harness). When done, write your verdict as JSON to {verdict_path}:"
-        + ' {"passed": <true|false>, "detail": "<one-line reason>"}.'
+        + ' {"passed": <true|false>, "detail": "<one-line reason>"}. Then STOP immediately.'
     )
     exec_error = None
     try:
         rc = agent_exec_fn(
             harness=bt.get("harness", "codex"), model=bt.get("model"),
             effort=bt.get("effort", "high"), prompt=prompt, cwd=cwd,
+            verdict_path=verdict_path,
         )
     except Exception as e:
         # Executor discovery/auth/process errors are structured behavior failures,

--- a/autoresearch/ar/gate/run.py
+++ b/autoresearch/ar/gate/run.py
@@ -78,18 +78,16 @@ def run_pr_gate(*, base, head, repo, author, is_draft, helpful, cfg: GateConfig,
 
 def run_behavior_plan(plan_path, *, repo, verdict_dir, base, head, run_git=None) -> dict:
     """Load Claude's dispatch plan.json, floor its risk (classify_pr), and run every
-    bespoke behavior test via codex (agent_exec) GENERALLY on-box — the piece that
+    bespoke behavior test via the bounded gate-local Codex executor on-box — the piece that
     tests behaviors serve_harness cannot reach. Returns {plan, behavior_results}."""
-    from ..agent_exec import run_round_resilient  # lazy: codex shell-out (+grok fallback), prod only
+    from .agent import run_codex_probe
     from . import dispatch
 
     with open(plan_path) as fh:
         raw = json.load(fh)
     plan = dispatch.parse_plan(raw, changed_files(base, head, repo, run_git=run_git))
-    # run_round_resilient: on a codex usage-limit, luna/terra tests fall back to grok;
-    # sol tests wait for codex to reset (no silent downgrade). Drop-in for run_round.
     results = dispatch.run_behavior_tests(
-        plan["behavior_tests"], agent_exec_fn=run_round_resilient, cwd=repo, verdict_dir=verdict_dir)
+        plan["behavior_tests"], agent_exec_fn=run_codex_probe, cwd=repo, verdict_dir=verdict_dir)
     return {"plan": plan, "behavior_results": results}
 
 

--- a/autoresearch/ar/tests/test_gate_agent.py
+++ b/autoresearch/ar/tests/test_gate_agent.py
@@ -1,0 +1,95 @@
+# Copyright (c) Kaden Schutt
+import json
+import sys
+import time
+
+from autoresearch.ar.gate import agent
+
+
+def test_probe_stops_process_group_as_soon_as_verdict_is_written(tmp_path, monkeypatch):
+    verdict = tmp_path / "verdict.json"
+    child = (
+        "import json,time; "
+        f"json.dump({{'passed': True, 'detail': 'done'}}, open({str(verdict)!r}, 'w')); "
+        "time.sleep(60)"
+    )
+    real_popen = agent.subprocess.Popen
+
+    def popen(_argv, **kwargs):
+        return real_popen([sys.executable, "-c", child], **kwargs)
+
+    monkeypatch.setattr(agent.subprocess, "Popen", popen)
+    started = time.monotonic()
+    rc = agent.run_codex_probe(
+        harness="codex", model="test", effort="high", prompt="probe", cwd=str(tmp_path),
+        verdict_path=str(verdict), timeout_seconds=5, poll_seconds=0.01,
+    )
+    assert rc == 0
+    assert time.monotonic() - started < 2
+    assert json.loads(verdict.read_text())["passed"] is True
+
+
+def test_probe_routes_agent_output_away_from_machine_stdout(tmp_path, monkeypatch):
+    verdict = tmp_path / "verdict.json"
+    child = (
+        "import json; print('agent chatter'); "
+        f"json.dump({{'passed': True, 'detail': 'done'}}, open({str(verdict)!r}, 'w'))"
+    )
+    real_popen = agent.subprocess.Popen
+    seen = {}
+
+    def popen(_argv, **kwargs):
+        seen.update(kwargs)
+        return real_popen([sys.executable, "-c", child], **kwargs)
+
+    monkeypatch.setattr(agent.subprocess, "Popen", popen)
+    rc = agent.run_codex_probe(
+        harness="codex", model="test", effort="high", prompt="probe", cwd=str(tmp_path),
+        verdict_path=str(verdict), timeout_seconds=5, poll_seconds=0.01,
+    )
+    assert rc == 0
+    assert seen["stdout"] is sys.stderr
+    assert seen["stderr"] is sys.stderr
+
+
+def test_probe_timeout_kills_process_and_returns_124(tmp_path, monkeypatch):
+    real_popen = agent.subprocess.Popen
+
+    def popen(_argv, **kwargs):
+        return real_popen([sys.executable, "-c", "import time; time.sleep(60)"], **kwargs)
+
+    monkeypatch.setattr(agent.subprocess, "Popen", popen)
+    rc = agent.run_codex_probe(
+        harness="codex", model="test", effort="high", prompt="probe", cwd=str(tmp_path),
+        verdict_path=str(tmp_path / "missing.json"), timeout_seconds=0.05, poll_seconds=0.01,
+    )
+    assert rc == 124
+
+
+def test_probe_removes_stale_verdict_before_starting(tmp_path, monkeypatch):
+    verdict = tmp_path / "verdict.json"
+    verdict.write_text('{"passed": true, "detail": "stale"}')
+    real_popen = agent.subprocess.Popen
+
+    def popen(_argv, **kwargs):
+        return real_popen([sys.executable, "-c", "import time; time.sleep(60)"], **kwargs)
+
+    monkeypatch.setattr(agent.subprocess, "Popen", popen)
+    rc = agent.run_codex_probe(
+        harness="codex", model="test", effort="high", prompt="probe", cwd=str(tmp_path),
+        verdict_path=str(verdict), timeout_seconds=0.05, poll_seconds=0.01,
+    )
+    assert rc == 124
+    assert not verdict.exists()
+
+
+def test_probe_rejects_non_codex_harness(tmp_path):
+    try:
+        agent.run_codex_probe(
+            harness="grok", model="test", effort="high", prompt="probe", cwd=str(tmp_path),
+            verdict_path=str(tmp_path / "verdict.json"), timeout_seconds=1,
+        )
+    except ValueError as exc:
+        assert "require harness='codex'" in str(exc)
+    else:
+        raise AssertionError("non-Codex gate probe must fail closed")

--- a/autoresearch/ar/tests/test_gate_dispatch.py
+++ b/autoresearch/ar/tests/test_gate_dispatch.py
@@ -51,7 +51,7 @@ def test_parse_plan_accepts_json_string_and_keeps_claude_escalation():
 def _writer(passed, detail="ok"):
     """A mock agent_exec_fn that writes a codex-style verdict file, returns rc 0.
     The verdict_path is embedded in the prompt; parse it out and honor it."""
-    def fn(*, harness, model, effort, prompt, cwd):
+    def fn(*, harness, model, effort, prompt, cwd, verdict_path):
         # extract the verdict path the runner asked codex to write to
         path = prompt.split("write your verdict as JSON to ")[1].split(":")[0].strip()
         with open(path, "w") as fh:
@@ -78,7 +78,7 @@ def test_behavior_test_fail_reports_detail(tmp_path):
 
 def test_behavior_test_missing_verdict_is_fail_not_silent_pass(tmp_path):
     # codex ran (rc 0) but wrote NO verdict -> must FAIL, never silently pass.
-    def no_verdict(*, harness, model, effort, prompt, cwd):
+    def no_verdict(*, harness, model, effort, prompt, cwd, verdict_path):
         return 0
     r = run_behavior_test({"what": "x", "prompt": "p"}, agent_exec_fn=no_verdict, cwd="/r",
                           verdict_path=str(tmp_path / "missing.json"))

--- a/docs/specs/2026-07-10-agentic-pr-merge-gate-design.md
+++ b/docs/specs/2026-07-10-agentic-pr-merge-gate-design.md
@@ -216,7 +216,7 @@ same PR/base/head before interpretation is allowed.
 ### 8.1 Executor routing (Claude tiers codex by the risk it read)
 
 Having classified the diff semantically, Claude sets `(harness, model, effort)`
-for each bespoke behavior test's on-box executor via `agent_exec`. The
+for each bespoke behavior test's bounded, gate-local on-box executor. The
 `classify_pr` floor pins the **minimum** tier; Claude escalates from there. The
 table lives in `pr_gate.toml`, re-tuned from the ledger's per-tier
 false-pass/false-reject rates:
@@ -231,25 +231,15 @@ false-pass/false-reject rates:
 codex authenticates **box-local** on hipx/hiptrx (not a GitHub secret). pi.dev
 slots in as a fourth harness when added (§Phase 6).
 
-**Codex usage-limit resilience.** codex exec can refuse a round when the box's
-codex account is out of usage. `agent_exec.run_round_resilient` (the seam every
-gate codex round runs through — behavior tests §8 *and* the Gate-4 merge-fix §11)
-distinguishes that refusal (nonzero exit **plus** a usage-limit marker in codex's
-output) from a genuine task failure and reacts by tier:
-
-- **non-sol** (luna/terra) round → **fall back to grok** immediately with the
-  identical prompt (grok is a fine substitute at these tiers; `$GATE_GROK_MODEL`,
-  default `grok-4.5`). grok exists on hiptrx; on a box without grok the fallback
-  round simply fails and the PR punts — never a false pass.
-- **sol** (`gpt-5.6-sol`, high-risk / merge-conflict) round → the top
-  intelligence tier is *required*, so we do **not** degrade to grok. We **wait**
-  `CODEX_RESET_POLL_SECS` (default 900s) and retry codex, up to `CODEX_MAX_WAITS`
-  (default 8) times, until codex resets. Exhausting the wait budget returns
-  codex's failing rc (the PR punts) — a sol requirement is never silently
-  downgraded to a lower tier.
-
-A genuine codex error (nonzero exit **without** a usage marker) is returned as-is
-and never masked by a model swap.
+**Bounded behavior executor.** The merge gate does not call autoresearch's
+open-ended `agent_exec` or substitute another model on usage failure. It starts
+the exact dispatched Codex model in its own process group, polls the assigned
+structured-verdict file, and stops Codex plus any daemon/build children as soon
+as a valid verdict exists. `GATE_CODEX_TIMEOUT_SECS` sets the hard per-probe wall
+timeout (900 seconds by default). Timeout, usage refusal, nonzero exit, and
+missing/malformed verdict all fail closed as behavior evidence; none are retried
+or silently downgraded. Gate-4's later merge-fix research remains a separate
+workflow and may use the autoresearch resilience policy described in §11.
 
 ## 9. Offender location → contributor recommendation
 


### PR DESCRIPTION
## What changed
- separate merge-gate behavior probes from the open-ended autoresearch executor
- stop the Codex process group as soon as a valid structured verdict exists
- fail closed after a 900s wall timeout and reject non-Codex substitution
- keep agent logs on stderr so stdout remains valid JSON evidence
- remove stale verdict files before every probe and clean daemon/build children

## Validation
- `uv run --with pytest --with numpy python -m pytest tests scripts/test_astrea.py autoresearch/ar/tests -q` (375 passed)
- `bun test && bun run typecheck` in `cli/` (281 passed; typecheck clean)
- `python3 scripts/check-env-docs.py`
- `git diff --check`

Live backlog run 29157002892 exposed both issues: Codex wrote the correct verdict but continued researching, and the old autoresearch executor echoed its logs into the redirected JSON evidence stream.