### PR TITLE
fix(gate): explain box model fit contract

### DIFF
--- a/.github/workflows/gpu-gates.yml
+++ b/.github/workflows/gpu-gates.yml
@@ -168,7 +168,7 @@ jobs:
                    "hipx": {
                      "run": true | false,
                      "archs": ["gfx1100", "gfx1151"],
-                     "models": ["model filenames from autoresearch/config/pr_gate.toml"],
+                     "models": ["dispatch_context model names fitting EVERY selected hipx arch"],
                      "behavior_tests": [
                        {"id":"stable-id", "what":"behavior", "prompt":"exact test",
                         "expect":"machine-checkable outcome"}
@@ -177,7 +177,7 @@ jobs:
                    "hiptrx": {
                      "run": true | false,
                      "archs": ["gfx1201"],
-                     "models": ["model filenames from autoresearch/config/pr_gate.toml"],
+                     "models": ["dispatch_context model names fitting EVERY selected hiptrx arch"],
                      "behavior_tests": []
                    }
                  }
@@ -190,6 +190,12 @@ jobs:
             the diff is truly trivial. decision="skip" is only for docs/workflow-only
             changes with no runtime behavior to test. Never omit an affected arch merely to
             save time: the validator will reject the plan and start zero runners.
+
+            IMPORTANT: a box's `models` list is run unchanged on EACH arch selected for that
+            box. Every listed model must therefore fit EVERY listed arch, using
+            dispatch_context.models as the authority. In particular, `deepseek4` fits only
+            gfx1151 and is INVALID when hipx selects both gfx1100 and gfx1151; omit it in that
+            case. Do not take the union of per-arch model support.
 
             The runner executes `ar gate --collect` then `--grade` mechanically for every
             selected arch. Use behavior_tests only for exact checks the deterministic GPU

--- a/autoresearch/ar/tests/test_gpu_gate_workflow.py
+++ b/autoresearch/ar/tests/test_gpu_gate_workflow.py
@@ -43,6 +43,14 @@ def test_claude_can_write_outputs_and_validator_owns_release_signal():
     assert "--validate-plan dispatch_plan.json" in dispatch
 
 
+def test_dispatch_prompt_explains_box_model_fit_is_an_intersection():
+    text = _text()
+    dispatch = text.split("\n  dispatch:\n", 1)[1].split("\n  no_runner:\n", 1)[0]
+    assert "Every listed model must therefore fit EVERY listed arch" in dispatch
+    assert "`deepseek4` fits only" in dispatch
+    assert "Do not take the union of per-arch model support" in dispatch
+
+
 def test_selected_runner_uses_mechanical_collect_and_grade_not_agent_verdict():
     text = _text()
     gate = text.split("\n  gate:\n", 1)[1].split("\n  interpret:\n", 1)[0]

--- a/docs/specs/2026-07-10-agentic-pr-merge-gate-design.md
+++ b/docs/specs/2026-07-10-agentic-pr-merge-gate-design.md
@@ -104,6 +104,12 @@ gate runs only fitting cells.
 | `qwen3.6-a3b` (MoE) | ✅ | ✅ | ✅ | canonical |
 | `deepseek4` (EP) | ✗ | ✅ | (EP-4 multi) | example: DS4 change → gfx1151 only |
 
+The dispatch schema assigns one `models` list per box, and the runner applies
+that same list to every arch selected on the box. The list must therefore be the
+intersection of model support across the selected archs, never the union. For
+example, `deepseek4` is invalid in a hipx assignment containing both gfx1100 and
+gfx1151; it is valid only when that assignment selects gfx1151 alone.
+
 The **canonical battery** (`qwen3.6-27b` + `qwen3.6-a3b`) always runs on every
 arch it fits; a change that touches a specific model/arch **adds** that cell
 (Claude selects it — §8). Auto-merge requires clean + non-clobber on the


### PR DESCRIPTION
## What changed
- make the box-level model/arch intersection contract explicit in Claude dispatch instructions
- state that each box model is run on every selected arch
- call out the concrete `deepseek4`/gfx1100 invalid combination that the backlog run exposed
- pin the contract in the spec and workflow tests

## Validation
- `uv run --with pytest python -m pytest autoresearch/ar/tests/test_gpu_gate_workflow.py autoresearch/ar/tests/test_gate_dispatch.py -q` (28 passed)
- `git diff --check`

Live backlog run 29157855551 failed closed with zero runners because Claude selected a union of per-arch model support (`deepseek4` alongside gfx1100+gfx1151) while the runner matrix applies one model list to every box arch.