### PR TITLE
fix(gate): fail closed when runner GPU is unavailable

### DIFF
--- a/autoresearch/ar/gate/device.py
+++ b/autoresearch/ar/gate/device.py
@@ -16,7 +16,8 @@ import subprocess
 
 def _rocminfo() -> str:
     try:
-        return subprocess.run(["rocminfo"], capture_output=True, text=True, timeout=30).stdout or ""
+        proc = subprocess.run(["rocminfo"], capture_output=True, text=True, timeout=15)
+        return proc.stdout if proc.returncode == 0 else ""
     except Exception:
         return ""
 
@@ -50,12 +51,21 @@ def gpu_gfx_order(rocminfo_text: str) -> list[str]:
     return order
 
 
-def resolve_device(arch, *, rocminfo_text=None, default=0) -> int:
+def resolve_device(arch, *, rocminfo_text=None, default=0, strict=False) -> int:
     """HIP device index for ``arch`` on this box (``default`` if rocminfo is unusable
-    or the arch isn't found — a single-GPU box then correctly uses 0)."""
+    or the arch isn't found — a single-GPU box then correctly uses 0).
+
+    ``strict=True`` is the merge-gate contract: an unavailable/hung ``rocminfo`` or
+    a missing arch raises instead of silently guessing device 0. Explicit local
+    callers retain the legacy fallback unless they opt into strict discovery.
+    """
     text = _rocminfo() if rocminfo_text is None else rocminfo_text
     order = gpu_gfx_order(text)
     for i, name in enumerate(order):
         if name == arch:
             return i
+    if strict:
+        if not order:
+            raise RuntimeError("rocminfo unavailable, timed out, or reported no GPU agents")
+        raise RuntimeError(f"required arch {arch} absent from rocminfo GPU order {order}")
     return default

--- a/autoresearch/ar/gate/run.py
+++ b/autoresearch/ar/gate/run.py
@@ -185,10 +185,21 @@ def collect_cell_data(arch, files, base, head, repo, cfg, *, dev=None, models=No
     bleed = [f for f in kernel_files if deferred_archs
              and cross_arch.check_cross_arch(f, arch, deferred_archs, repo, base_sha=base)]
 
-    dev = resolve_device(arch, default=dev if dev is not None else 0)
     kv = getattr(cfg, "kv_mode", None) or "q8"
     models_dir = os.path.expanduser(os.environ.get("HIPFIRE_MODELS_DIR", "~/.hipfire/models"))
     out = {"arch": arch, "deferred": False, "dev": dev, "cross_arch_bleed": bleed}
+
+    try:
+        # CI must never guess device 0 when rocminfo hangs or an eGPU disappears.
+        # An explicit local --dev remains an operator override for bring-up work.
+        dev = resolve_device(
+            arch, default=dev if dev is not None else 0, strict=dev is None,
+        )
+        out["dev"] = dev
+    except RuntimeError as e:
+        out["device_error"] = str(e)
+        out["cells"] = []
+        return out
 
     try:
         out["base_bin"] = build_daemon(base, repo)
@@ -229,6 +240,10 @@ def grade_collected(collected, *, cfg) -> dict:
     if collected.get("build_error"):
         return {"arch": arch, "verdict": "REJECT", "reasons": ["build_fail"], "bod": None,
                 "rows": [], "tok_delta_pct": 0.0, "detail": collected["build_error"]}
+    if collected.get("device_error"):
+        return {"arch": arch, "verdict": "REJECT", "reasons": ["device_unavailable"],
+                "bod": None, "rows": [], "tok_delta_pct": 0.0,
+                "detail": collected["device_error"]}
 
     rows, deltas = [], []
     for c in collected.get("cells", []):

--- a/autoresearch/ar/tests/test_gate_build_device.py
+++ b/autoresearch/ar/tests/test_gate_build_device.py
@@ -40,6 +40,13 @@ def test_resolve_device_absent_arch_falls_back_to_default():
     assert resolve_device("gfx999", rocminfo_text="", default=3) == 3
 
 
+def test_strict_device_resolution_never_guesses_on_missing_or_empty_rocminfo():
+    with pytest.raises(RuntimeError, match="required arch gfx1201 absent"):
+        resolve_device("gfx1201", rocminfo_text=ROCMINFO, strict=True)
+    with pytest.raises(RuntimeError, match="rocminfo unavailable"):
+        resolve_device("gfx1100", rocminfo_text="", strict=True)
+
+
 # ---- arch->box deferral ----
 
 class _Cfg:

--- a/autoresearch/ar/tests/test_gate_run.py
+++ b/autoresearch/ar/tests/test_gate_run.py
@@ -97,6 +97,37 @@ def test_interpret_folds_failed_behavior_as_bod(tmp_path):
     assert any("behavior:cli --foo" in str(b) for b in res["outcome"]["bod"]["blockers"])
 
 
+def test_grade_collected_maps_device_discovery_failure_to_clear_reject():
+    from autoresearch.ar.gate.run import grade_collected
+
+    result = grade_collected(
+        {"arch": "gfx1100", "device_error": "rocminfo unavailable", "cells": []},
+        cfg=_cfg(),
+    )
+    assert result["verdict"] == "REJECT"
+    assert result["reasons"] == ["device_unavailable"]
+    assert result["detail"] == "rocminfo unavailable"
+
+
+def test_collect_fails_device_discovery_before_build_or_gpu_work(monkeypatch):
+    from autoresearch.ar.gate import build, device
+    from autoresearch.ar.gate.run import collect_cell_data
+
+    def unavailable(*args, **kwargs):
+        raise RuntimeError("required arch gfx1100 absent")
+
+    def must_not_build(*args, **kwargs):
+        raise AssertionError("device preflight must precede build")
+
+    monkeypatch.setattr(device, "resolve_device", unavailable)
+    monkeypatch.setattr(build, "build_daemon", must_not_build)
+    result = collect_cell_data(
+        "gfx1100", ["crates/hipfire-runtime/src/x.rs"], "base", "head", "/r", _cfg(),
+    )
+    assert result["device_error"] == "required arch gfx1100 absent"
+    assert result["cells"] == []
+
+
 def test_run_pr_gate_docs_only_is_trivial_and_tags_non_kaden():
     g = _git(name_only="docs/x.md\n", numstat="3\t0\tdocs/x.md\n")
     r = run_pr_gate(base="m", head="pr", repo="/r", author="fivetide", is_draft=False,

--- a/docs/specs/2026-07-10-agentic-pr-merge-gate-design.md
+++ b/docs/specs/2026-07-10-agentic-pr-merge-gate-design.md
@@ -508,6 +508,9 @@ codex/grok auth on-box.
   broke that arch's daemon build; Tier 1 only covers the generic workspace).
 - **Claude dispatch failure** (missing files, timeout, invalid or incomplete
   plan) → fail the dispatch job and create zero self-hosted runner jobs.
+- **Runner device discovery failure** (`rocminfo` timeout/no agents or the
+  assigned arch missing) → fail that arch immediately as `device_unavailable`;
+  never guess device 0 or spend the battery timeout retrying a lost GPU.
 - **Codex behavior failure** (nonzero exit, timeout, missing/malformed verdict)
   → record that assigned behavior as failed; never substitute a green result.
 - **Claude interpretation failure** → post/merge does not run. A deterministic


### PR DESCRIPTION
## What changed
- make live merge-gate device discovery strict instead of silently falling back to HIP device 0
- cap `rocminfo` discovery at 15 seconds
- emit structured `device_unavailable` REJECT evidence before building or launching a daemon
- preserve explicit local `--dev` as an operator override

## Validation
- `uv run --with pytest --with numpy python -m pytest tests scripts/test_astrea.py autoresearch/ar/tests -q` (379 passed)
- `git diff --check`

Live backlog run 29158141451 found hipx AMDGPU `device lost from bus`; `rocminfo` hung and the old resolver guessed index 0, causing repeated daemon warm-up hangs. hiptrx completed PASS. This makes that runner failure immediate, explicit, and joinable instead of retrying a physically absent device.