### PR TITLE
fix(gate): bound unavailable runner probes

### DIFF
--- a/autoresearch/ar/gate/run.py
+++ b/autoresearch/ar/gate/run.py
@@ -223,6 +223,13 @@ def collect_cell_data(arch, files, base, head, repo, cfg, *, dev=None, models=No
             except RuntimeError as e:
                 cell[role] = None
                 cell.setdefault("errors", {})[role] = str(e)
+                # A runner/daemon probe failure is not improved by multiplying it
+                # across every remaining model. Preserve the failed cell as data
+                # and let the deterministic grader reject this arch immediately.
+                cells.append(cell)
+                out["cells"] = cells
+                out["probe_error"] = str(e)
+                return out
         cells.append(cell)
     out["cells"] = cells
     return out
@@ -244,6 +251,10 @@ def grade_collected(collected, *, cfg) -> dict:
         return {"arch": arch, "verdict": "REJECT", "reasons": ["device_unavailable"],
                 "bod": None, "rows": [], "tok_delta_pct": 0.0,
                 "detail": collected["device_error"]}
+    if collected.get("probe_error"):
+        return {"arch": arch, "verdict": "REJECT", "reasons": ["probe_unavailable"],
+                "bod": None, "rows": [], "tok_delta_pct": 0.0,
+                "detail": collected["probe_error"]}
 
     rows, deltas = [], []
     for c in collected.get("cells", []):

--- a/autoresearch/ar/gate/serve_probe.py
+++ b/autoresearch/ar/gate/serve_probe.py
@@ -27,7 +27,7 @@ from ..certify import verdict as V
 
 
 def run_serve_harness(daemon_bin, model_path, dev, *, repo, kv="q8", max_tokens=128,
-                      port=11540, timeout=1200, run=None) -> list:
+                      port=11540, timeout=300, run=None) -> list:
     """Run one greedy serve_harness battery against ``daemon_bin`` and return its
     per-turn rows (parsed from ``--out``). Raises ``RuntimeError`` on a spawn/parse
     failure so the caller can map it to an ERROR verdict (never a silent empty pass)."""
@@ -39,7 +39,13 @@ def run_serve_harness(daemon_bin, model_path, dev, *, repo, kv="q8", max_tokens=
             "--out", out, "--port", str(port)]
     env = dict(os.environ, HIPFIRE_DAEMON_BIN=daemon_bin, HIP_VISIBLE_DEVICES=str(dev))
     runner = run or (lambda a, e, t: subprocess.run(a, env=e, timeout=t, capture_output=True, text=True))
-    proc = runner(argv, env, timeout)
+    try:
+        proc = runner(argv, env, timeout)
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(
+            f"serve_harness timeout after {timeout}s for {os.path.basename(daemon_bin)}/"
+            f"{os.path.basename(model_path)}"
+        ) from e
     rc = getattr(proc, "returncode", 1)
     if rc != 0:
         tail = (getattr(proc, "stderr", "") or "")[-1500:]

--- a/autoresearch/ar/tests/test_gate_run.py
+++ b/autoresearch/ar/tests/test_gate_run.py
@@ -128,6 +128,31 @@ def test_collect_fails_device_discovery_before_build_or_gpu_work(monkeypatch):
     assert result["cells"] == []
 
 
+def test_collect_aborts_remaining_models_after_first_probe_failure(monkeypatch):
+    from autoresearch.ar.gate import build, device, serve_probe
+    from autoresearch.ar.gate.run import collect_cell_data, grade_collected
+
+    monkeypatch.setattr(device, "resolve_device", lambda *a, **kw: 0)
+    monkeypatch.setattr(build, "build_daemon", lambda ref, repo: f"/tmp/{ref}-daemon")
+    calls = []
+
+    def unavailable(*args, **kwargs):
+        calls.append(args)
+        raise RuntimeError("serve_harness timeout after 300s")
+
+    monkeypatch.setattr(serve_probe, "run_serve_harness", unavailable)
+    collected = collect_cell_data(
+        "gfx1100", ["crates/hipfire-runtime/src/x.rs"], "base", "head", "/r", _cfg(),
+        models=["qwen3.6-27b", "qwen3.6-a3b"],
+    )
+    assert len(calls) == 1
+    assert len(collected["cells"]) == 1
+    assert "timeout" in collected["probe_error"]
+    graded = grade_collected(collected, cfg=_cfg())
+    assert graded["verdict"] == "REJECT"
+    assert graded["reasons"] == ["probe_unavailable"]
+
+
 def test_run_pr_gate_docs_only_is_trivial_and_tags_non_kaden():
     g = _git(name_only="docs/x.md\n", numstat="3\t0\tdocs/x.md\n")
     r = run_pr_gate(base="m", head="pr", repo="/r", author="fivetide", is_draft=False,

--- a/autoresearch/ar/tests/test_gate_serve_probe.py
+++ b/autoresearch/ar/tests/test_gate_serve_probe.py
@@ -1,7 +1,11 @@
 # Copyright (c) Kaden Schutt
 """serve_harness-driven cell grading -> a ledger ROW (verdict.make_row schema, gate
 verdict vocabulary) + per-(model,arch) BOD blockers. Pure grading, no GPU/serve."""
-from autoresearch.ar.gate.serve_probe import cell_blocker, grade_cell
+import subprocess
+
+import pytest
+
+from autoresearch.ar.gate.serve_probe import cell_blocker, grade_cell, run_serve_harness
 
 
 def _row(content, tok_s=130.0, wall=1.0, attractor=False):
@@ -78,3 +82,14 @@ def test_perf_blocker_detail_includes_delta():
                [_row("x", tok_s=150.0, wall=1.4) for _ in range(4)])
     b = cell_blocker(r)
     assert b["kind"] == "perf_regression" and "% tok/s" in b["detail"]
+
+
+def test_serve_probe_timeout_becomes_structured_runtime_error():
+    def timeout_runner(argv, env, timeout):
+        raise subprocess.TimeoutExpired(argv, timeout)
+
+    with pytest.raises(RuntimeError, match="serve_harness timeout after 7s"):
+        run_serve_harness(
+            "/tmp/daemon", "/tmp/model", 0, repo="/repo", timeout=7,
+            run=timeout_runner,
+        )

--- a/docs/specs/2026-07-10-agentic-pr-merge-gate-design.md
+++ b/docs/specs/2026-07-10-agentic-pr-merge-gate-design.md
@@ -511,6 +511,9 @@ codex/grok auth on-box.
 - **Runner device discovery failure** (`rocminfo` timeout/no agents or the
   assigned arch missing) → fail that arch immediately as `device_unavailable`;
   never guess device 0 or spend the battery timeout retrying a lost GPU.
+- **Runner probe timeout/failure** → cap one `serve_harness` invocation at five
+  minutes, fail the arch as `probe_unavailable`, and skip its remaining model
+  cells instead of multiplying an unavailable GPU across the matrix.
 - **Codex behavior failure** (nonzero exit, timeout, missing/malformed verdict)
   → record that assigned behavior as failed; never substitute a green result.
 - **Claude interpretation failure** → post/merge does not run. A deterministic


### PR DESCRIPTION
## What changed
- cap each gate `serve_harness` process at five minutes instead of twenty
- translate `TimeoutExpired` into structured gate evidence
- abort remaining model cells after the first runner probe failure
- emit a clear `probe_unavailable` REJECT instead of multiplying an outage across the matrix

## Validation
- `uv run --with pytest --with numpy python -m pytest tests scripts/test_astrea.py autoresearch/ar/tests -q` (381 passed)
- `git diff --check`

Live backlog run 29158782680 passed strict device discovery, then hipx lost the gfx1100 eGPU from the PCIe bus during the first battery. The old 20-minute outer timeout and per-model continuation would turn one hardware outage into hours of retries.