### PR TITLE
fix(serve): restore n-gram loop-guard DEFAULT OFF (master regressed to 8 → lobotomizes reasoning)

### DIFF
--- a/crates/hipfire-runtime/src/config.rs
+++ b/crates/hipfire-runtime/src/config.rs
@@ -91,10 +91,17 @@ impl RuntimeConfig {
                 .ok()
                 .as_deref()
                 .map(|v| v != "0" && !v.eq_ignore_ascii_case("false")),
+            // Default OFF (0 = disabled). The 4-gram×8 loop guard false-positives
+            // on legitimate enumeration-heavy reasoning at temp>0 — a repeating
+            // markdown bullet scaffold (`\n - **`) trips it INSIDE `<think>`,
+            // force-EOSing mid-think and emptying the answer channel (surfaced by
+            // the qwen3.6 temp=1.0 registry default). Runaway thinking is handled
+            // by the think-budget force-close instead. Opt back in with
+            // `HIPFIRE_NGRAM_LOOP_THRESHOLD=N` (was: default 8).
             ngram_loop_threshold: std::env::var("HIPFIRE_NGRAM_LOOP_THRESHOLD")
                 .ok()
                 .and_then(|v| v.parse().ok())
-                .unwrap_or(8),
+                .unwrap_or(0),
             ngram_window: std::env::var("HIPFIRE_NGRAM_WINDOW")
                 .ok()
                 .and_then(|v| v.parse().ok())

--- a/crates/hipfire-runtime/src/loop_guard.rs
+++ b/crates/hipfire-runtime/src/loop_guard.rs
@@ -15,8 +15,9 @@
 //!
 //! Behavior is byte-identical to the inline detector previously in
 //! `crates/hipfire-runtime/examples/daemon.rs`. The defaults are read from
-//! `HIPFIRE_NGRAM_LOOP_THRESHOLD` (default 8, 0 = disabled) and
-//! `HIPFIRE_NGRAM_WINDOW` (default 256). The threshold is `>=`, not `>`.
+//! `HIPFIRE_NGRAM_LOOP_THRESHOLD` (**default 0 = disabled**; the content-blind
+//! 4-gram×N counter false-positives on enumeration-heavy reasoning at temp>0)
+//! and `HIPFIRE_NGRAM_WINDOW` (default 256). The threshold is `>=`, not `>`.
 
 use std::collections::HashMap;
 
@@ -42,9 +43,9 @@ pub struct LoopGuard {
 impl LoopGuard {
     /// Construct a guard from environment variables.
     ///
-    /// - `HIPFIRE_NGRAM_LOOP_THRESHOLD` (default 8): a 4-gram count of this
-    ///   value or higher inside the window triggers the guard. Set to 0 to
-    ///   disable the guard entirely.
+    /// - `HIPFIRE_NGRAM_LOOP_THRESHOLD` (**default 0 = disabled**): a 4-gram
+    ///   count of this value or higher inside the window triggers the guard.
+    ///   Off by default; set to N>0 to opt the guard in.
     /// - `HIPFIRE_NGRAM_WINDOW` (default 256): how many trailing tokens to
     ///   inspect on each `check` call.
     pub fn from_config(config: &crate::config::RuntimeConfig) -> Self {


### PR DESCRIPTION
**Coherence regression restore.** Master's `HIPFIRE_NGRAM_LOOP_THRESHOLD` is back at default **8** — the content-blind 4-gram×8 loop guard false-positives on legitimate enumeration-heavy reasoning at temp>0: a repeating `\n - **` markdown-bullet scaffold trips it **inside `<think>`**, force-EOSes mid-think, and empties the answer channel (the qwen3.6 temp=1.0 registry default hits this). Restores the validated 7eac3c876 behavior: **default 8 → 0 (OFF)**; runaway thinking is handled by the think-budget force-close instead. Opt back in with `HIPFIRE_NGRAM_LOOP_THRESHOLD=N`. Exactly the n-gram hunk (config.rs default+comment + loop_guard.rs doc), 3-way-merged onto current master — no other 7eac3c876 changes. Compiles (`cargo check -p hipfire-runtime`).