### PR TITLE
fix(serve): restore sampled think-cap continuation (cherry-pick f03b494dc — completes #523)

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -655,6 +655,22 @@ function savePerModelConfigs(all: PerModelConfigs) {
 // possibly-undefined check.
 type ResolvedConfig = HipfireConfig & { max_think_tokens: number; max_think_explicit: boolean };
 
+// Pure serve-layer cap resolution, exported so the default-medium behavior is
+// regression-tested without starting a daemon. `undefined` means uncapped.
+export function resolveServeThinkCap(
+  thinking: HipfireConfig["thinking"],
+  maxThinkTokens: number,
+  enableThinking: boolean | undefined,
+  reasoningEffort: number | null,
+): number | undefined {
+  let cap = thinking === "off"
+    ? 1
+    : (maxThinkTokens > 0 ? maxThinkTokens : undefined);
+  if (enableThinking === false) cap = 1;
+  if (reasoningEffort !== null) cap = reasoningEffort === 0 ? undefined : reasoningEffort;
+  return cap;
+}
+
 function resolveModelConfig(tag: string | null | undefined): ResolvedConfig {
   const base = loadConfig();
   if (!tag) { resolveThinkingBudget(base); return base as ResolvedConfig; }
@@ -3669,37 +3685,19 @@ async function serve(port: number, host: string) {
           if (typeof sendView.min_p === "number") genParams.min_p = sendView.min_p;
         }
         void oaiPenalty; void oaiPenaltySet; // superseded by native presence/frequency
-        // Serve API is UNCAPPED by default (OpenAI/o1 convention — the client
-        // bounds length via max_tokens). The CLI-chat think-budget preset is a
-        // chat convenience, NOT an API default: forwarding the bare "med" preset
-        // here made the daemon route EVERY thinking request to AR (its
-        // `budgeted_thinking_needs_ar` gate), which DISABLED DFlash/MTP through
-        // the serve — they can't continue past a *forced* </think> so a budget
-        // sends them to AR. So forward a budget only when the operator set one
-        // EXPLICITLY (raw max_think_tokens or a non-default thinking_budget);
-        // `reasoning_effort` still caps per-request below and thinking=off
-        // hard-suppresses. (#74 trade-off accepted per design: an uncapped
-        // thinking model on a SMALL max_tokens can return empty content, so
-        // clients should size max_tokens for the reasoning they ask for, or pass
-        // reasoning_effort. The `hipfire run`/chat paths keep the preset budget.)
-        if (effective.thinking === "off") {
-          genParams.max_think_tokens = 1;
-        } else if (effective.max_think_tokens > 0 && effective.max_think_explicit) {
-          genParams.max_think_tokens = effective.max_think_tokens;
-        }
-        // chat_template_kwargs.enable_thinking=false hard-caps thinking to 1
-        // token (model emits <think> then is forced to close). Overrides
-        // per-model max_think_tokens because the request semantics are more
-        // specific than the static config.
-        if (enableThinking === false) genParams.max_think_tokens = 1;
-        // reasoning.effort wins over both per-model and enable_thinking
-        // when present (it's the most explicit per-request signal). xhigh
-        // (0 = uncapped) only applies when set; we don't unconditionally
-        // clobber a per-model max_think_tokens with 0.
-        if (reasoningEffort !== null) {
-          if (reasoningEffort === 0) delete genParams.max_think_tokens;
-          else genParams.max_think_tokens = reasoningEffort;
-        }
+        // Forward the resolved think budget by default ("med" = 2048). Sampled
+        // thinking models can otherwise reason to the max_tokens wall without
+        // closing </think>, yielding no visible answer. The daemon's AR and
+        // spec-decode paths force-close at the cap and continue into the answer.
+        // reasoning_effort remains the per-request override; xhigh removes the
+        // cap, and thinking=off still hard-suppresses reasoning.
+        const serveThinkCap = resolveServeThinkCap(
+          effective.thinking,
+          effective.max_think_tokens,
+          enableThinking,
+          reasoningEffort,
+        );
+        if (serveThinkCap !== undefined) genParams.max_think_tokens = serveThinkCap;
         // Wire thinking control for both legacy assistant_prefix
         // (ChatFrame::ClosedThink) and the new Jinja template path.
         // The Jinja path uses max_think_tokens==1 as the signal for

--- a/cli/serve_think_cap.test.ts
+++ b/cli/serve_think_cap.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { resolveServeThinkCap } from "./index.ts";
+
+describe("serve think-cap resolution", () => {
+  test("forwards the resolved default medium cap", () => {
+    expect(resolveServeThinkCap("on", 2048, undefined, null)).toBe(2048);
+  });
+
+  test("preserves uncapped and explicit request precedence", () => {
+    expect(resolveServeThinkCap("on", 0, undefined, null)).toBeUndefined();
+    expect(resolveServeThinkCap("off", 2048, undefined, null)).toBe(1);
+    expect(resolveServeThinkCap("on", 2048, false, null)).toBe(1);
+    expect(resolveServeThinkCap("off", 2048, false, 0)).toBeUndefined();
+    expect(resolveServeThinkCap("on", 2048, undefined, 4096)).toBe(4096);
+  });
+});

--- a/crates/hipfire-arch-qwen35/src/spec_emit.rs
+++ b/crates/hipfire-arch-qwen35/src/spec_emit.rs
@@ -40,9 +40,19 @@ pub struct Qwen35Emit<'a> {
     open_think_prefix: bool,
     think_count: usize,
     prev_in_think: bool,
+    /// Think-budget force-close continuation drained by `take_forced` so the
+    /// target advances over `</think>` and continues into visible output.
+    forced: Vec<u32>,
+    /// Prevent an endlessly re-opened reasoning span from being force-closed
+    /// repeatedly. A second cap hit hard-stops through `ThinkCap`.
+    think_force_closed: bool,
     /// `generated` counter at the point of the most recent `observe` — only used
     /// for the attractor-detect log message (byte-for-byte stderr parity).
     generated_hint: usize,
+}
+
+fn think_continuation_text() -> String {
+    std::env::var("HIPFIRE_THINK_CONTINUATION").unwrap_or_else(|_| "</think>\n\n".to_string())
 }
 
 impl<'a> Qwen35Emit<'a> {
@@ -97,6 +107,8 @@ impl<'a> Qwen35Emit<'a> {
             open_think_prefix: matches!(ctx.assistant_prefix, AssistantPrefix::OpenThink),
             think_count: 0,
             prev_in_think: false,
+            forced: Vec::new(),
+            think_force_closed: false,
             generated_hint: 0,
         })
     }
@@ -216,9 +228,12 @@ impl<'a> SpecEmit for Qwen35Emit<'a> {
             self.prev_in_think = in_think;
 
             if in_think && self.think_count >= self.max_think_tokens {
-                // Force-close: stream `</think>\n` and stop. The inline path
-                // wrote this literal token frame directly (not through the
-                // filter, not into streamed_tokens) — preserve that exactly.
+                if !self.think_force_closed {
+                    self.forced = self.tokenizer.encode(&think_continuation_text());
+                    self.think_force_closed = true;
+                    return EmitOutcome { events, stop: None };
+                }
+                // A pathological re-open after the injected close hard-stops.
                 events.push(ClientEvent::Token("</think>\n".to_string()));
                 return EmitOutcome {
                     events,
@@ -270,5 +285,9 @@ impl<'a> SpecEmit for Qwen35Emit<'a> {
     /// attractor-detect log message reports the same number it did inline.
     fn set_generated_hint(&mut self, generated: usize) {
         self.generated_hint = generated;
+    }
+
+    fn take_forced(&mut self) -> Vec<u32> {
+        std::mem::take(&mut self.forced)
     }
 }

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -5258,6 +5258,10 @@ fn generate_qwen35_mtp(
     let mut accepted_total = 0usize;
     let mut think_count: usize = 0;
     let mut prev_in_think = false;
+    // Once the cap closes the first reasoning span, stop counting and continue
+    // into the visible answer. The close is applied at a spec-block boundary so
+    // the emitted stream and trunk/MTP caches remain aligned.
+    let mut think_closed = false;
 
     // Emit the seed token first (TTFT = prefill).
     streamed_tokens.push(seed_token);
@@ -5318,7 +5322,6 @@ fn generate_qwen35_mtp(
         accepted_total += result.accept_count;
 
         let mut hit_eos = false;
-        let mut think_cap_hit = false;
         for &tok in &result.committed {
             if generated >= max_tokens {
                 break;
@@ -5358,7 +5361,7 @@ fn generate_qwen35_mtp(
                     break;
                 }
             }
-            if max_think_tokens > 0 {
+            if max_think_tokens > 0 && !think_closed {
                 let raw_so_far = tokenizer.decode_bytes(&streamed_tokens);
                 let raw_str = std::str::from_utf8(&raw_so_far).unwrap_or("");
                 let in_think = currently_in_think(
@@ -5375,16 +5378,10 @@ fn generate_qwen35_mtp(
                     think_count += 1;
                 }
                 prev_in_think = in_think;
-                if in_think && think_count >= max_think_tokens {
-                    let _ = writeln!(
-                        stdout,
-                        r#"{{"type":"token","id":"{}","text":"</think>\n"}}"#,
-                        id
-                    );
-                    let _ = stdout.flush();
-                    think_cap_hit = true;
-                    break;
-                }
+                // Apply the close after this committed block. `spec_step`
+                // already advanced the trunk across the whole block, so
+                // stopping midway here would desynchronize visible tokens and
+                // model state.
             }
         }
         last_committed = match result.committed.last() {
@@ -5392,8 +5389,66 @@ fn generate_qwen35_mtp(
             None => break, // defensive: spec_step always commits ≥ 1
         };
         cur_pos += result.advance;
-        if result.hit_eos || hit_eos || think_cap_hit {
+        if result.hit_eos || hit_eos {
             break;
+        }
+
+        if max_think_tokens > 0 && !think_closed && prev_in_think && think_count >= max_think_tokens
+        {
+            let close_ids = tokenizer.encode(&think_continuation());
+            if !close_ids.is_empty() {
+                for &ct in &close_ids {
+                    if generated >= max_tokens {
+                        break;
+                    }
+                    emitted.push(ct);
+                    streamed_tokens.push(ct);
+                    emit_committed_event(
+                        stdout,
+                        id,
+                        ct,
+                        streamed_tokens.len() - 1,
+                        t0.elapsed().as_millis() as u64,
+                    );
+                    let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
+                    let new_bytes = &all_bytes[bytes_fed_to_filter..];
+                    bytes_fed_to_filter = all_bytes.len();
+                    if let FilterAction::Emit(text_bytes) = filter.observe(new_bytes) {
+                        if let Ok(text) = std::str::from_utf8(&text_bytes) {
+                            let _ = writeln!(
+                                stdout,
+                                r#"{{"type":"token","id":"{}","text":{}}}"#,
+                                id,
+                                serde_json::to_string(&text).unwrap_or_default()
+                            );
+                            let _ = stdout.flush();
+                        }
+                    }
+                    generated += 1;
+                }
+
+                // Match the MTP loop's deferred-token invariant: advance the
+                // trunk and head cache over the prior deferred token plus every
+                // close token except the new deferred tail.
+                let mut advance_toks = Vec::with_capacity(close_ids.len());
+                advance_toks.push(last_committed);
+                advance_toks.extend_from_slice(&close_ids[..close_ids.len() - 1]);
+                if let Err(e) = mtp_spec::prefill_trunk_and_mtp_cache(
+                    gpu,
+                    &mut target,
+                    head,
+                    &mut state,
+                    &advance_toks,
+                    cur_pos,
+                ) {
+                    step_error = Some(format!("think force-close: {e:?}"));
+                    break;
+                }
+                cur_pos += advance_toks.len();
+                last_committed = *close_ids.last().unwrap();
+                think_closed = true;
+                prev_in_think = false;
+            }
         }
     }
 
@@ -7021,16 +7076,9 @@ fn generate(
     // rejection invariant) — a temp>0 request carrying a non-default top_p gets
     // temp-only sampling and a one-time warn below.
     //
-    // Exception: thinking-on + max_think_tokens currently needs the AR path.
-    // DFlash's budget cap can close/strip the think span but does not yet
-    // continue into visible answer text after the forced close. AR already
-    // splices </think> through KV and continues generation, so route budgeted
-    // thinking requests there until DFlash continuation is implemented.
-    let budgeted_thinking_needs_ar = max_think_tokens > 0
-        && !matches!(
-            assistant_prefix,
-            hipfire_runtime::prompt_frame::AssistantPrefix::ClosedThink
-        );
+    // Budgeted thinking remains on the selected decode path. AR splices the
+    // continuation directly, DFlash uses SpecEmit::take_forced, and native MTP
+    // applies the same close at a committed-block boundary.
 
     // ── Qwen3.5/3.6 native-MTP serve path (opt-in) ─────────────────────
     //
@@ -7039,9 +7087,9 @@ fn generate(
     // compressed-serial). Gated tightly so the DEFAULT path (DFlash/AR) is
     // unchanged: requires the env opt-in `HIPFIRE_QWEN_MTP=1`, a loaded MTP
     // head (`m.qwen35_mtp_head`), greedy (temp≈0; MTP serve v1 is greedy/
-    // argmax-match), a qwen3.5/3.6 trunk (arch 5/6), single-GPU, and no
-    // budgeted-thinking (which needs the AR </think> splice). Anything not
-    // satisfying ALL of these falls through to the existing DFlash/AR routing.
+    // argmax-match), a qwen3.5/3.6 trunk (arch 5/6), and single-GPU. Budgeted
+    // thinking stays on MTP and uses the block-boundary continuation above.
+    // Anything not satisfying these gates falls through to DFlash/AR.
     //
     // SAMPLED (temp>0) MTP is now distribution-preserving and reachable here,
     // but gated behind an opt-in env flag until the temp>0 coherence battery
@@ -7073,7 +7121,6 @@ fn generate(
         && m.qwen35_mtp_head.is_some()
         && (temp <= 1e-6 || mtp_sampled_on)
         && (m.arch_id == 5 || m.arch_id == 6)
-        && !budgeted_thinking_needs_ar
     {
         generate_qwen35_mtp(
             m,
@@ -7183,7 +7230,6 @@ fn generate(
         && (m.arch_id == 5 || m.arch_id == 6 || m.arch_id == 0 || m.arch_id == 1)
         && !qwen_dflash_route
         && !llama_dflash_route
-        && !budgeted_thinking_needs_ar
         && !force_ar_chat
     {
         let reason = if temp_spec_env_off {
@@ -7202,7 +7248,6 @@ fn generate(
         );
     }
     if m.speculator.is_some()
-        && !budgeted_thinking_needs_ar
         && !force_ar_chat
         && (qwen_dflash_route || llama_dflash_route)
     {

--- a/crates/hipfire-runtime/src/config.rs
+++ b/crates/hipfire-runtime/src/config.rs
@@ -91,13 +91,11 @@ impl RuntimeConfig {
                 .ok()
                 .as_deref()
                 .map(|v| v != "0" && !v.eq_ignore_ascii_case("false")),
-            // Default OFF (0 = disabled). The 4-gram×8 loop guard false-positives
-            // on legitimate enumeration-heavy reasoning at temp>0 — a repeating
-            // markdown bullet scaffold (`\n - **`) trips it INSIDE `<think>`,
-            // force-EOSing mid-think and emptying the answer channel (surfaced by
-            // the qwen3.6 temp=1.0 registry default). Runaway thinking is handled
-            // by the think-budget force-close instead. Opt back in with
-            // `HIPFIRE_NGRAM_LOOP_THRESHOLD=N` (was: default 8).
+            // Default OFF (0 = disabled). The content-blind 4-gram guard can
+            // false-positive on repeated markdown/list scaffolding inside
+            // sampled reasoning and force-EOS before a visible answer. The
+            // think-budget force-close handles runaway reasoning instead;
+            // operators can opt this guard back in with an explicit threshold.
             ngram_loop_threshold: std::env::var("HIPFIRE_NGRAM_LOOP_THRESHOLD")
                 .ok()
                 .and_then(|v| v.parse().ok())
@@ -129,6 +127,21 @@ mod tests {
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn ngram_loop_guard_is_off_by_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let prev = std::env::var("HIPFIRE_NGRAM_LOOP_THRESHOLD").ok();
+        std::env::remove_var("HIPFIRE_NGRAM_LOOP_THRESHOLD");
+
+        let cfg = RuntimeConfig::from_env();
+        assert_eq!(cfg.ngram_loop_threshold, 0);
+
+        match prev {
+            Some(value) => std::env::set_var("HIPFIRE_NGRAM_LOOP_THRESHOLD", value),
+            None => std::env::remove_var("HIPFIRE_NGRAM_LOOP_THRESHOLD"),
+        }
+    }
 
     #[test]
     fn normalize_prompt_accepts_no_as_false() {

--- a/crates/hipfire-runtime/src/loop_guard.rs
+++ b/crates/hipfire-runtime/src/loop_guard.rs
@@ -15,9 +15,8 @@
 //!
 //! Behavior is byte-identical to the inline detector previously in
 //! `crates/hipfire-runtime/examples/daemon.rs`. The defaults are read from
-//! `HIPFIRE_NGRAM_LOOP_THRESHOLD` (**default 0 = disabled**; the content-blind
-//! 4-gram×N counter false-positives on enumeration-heavy reasoning at temp>0)
-//! and `HIPFIRE_NGRAM_WINDOW` (default 256). The threshold is `>=`, not `>`.
+//! `HIPFIRE_NGRAM_LOOP_THRESHOLD` (default 0 = disabled) and
+//! `HIPFIRE_NGRAM_WINDOW` (default 256). The threshold is `>=`, not `>`.
 
 use std::collections::HashMap;
 
@@ -43,9 +42,9 @@ pub struct LoopGuard {
 impl LoopGuard {
     /// Construct a guard from environment variables.
     ///
-    /// - `HIPFIRE_NGRAM_LOOP_THRESHOLD` (**default 0 = disabled**): a 4-gram
-    ///   count of this value or higher inside the window triggers the guard.
-    ///   Off by default; set to N>0 to opt the guard in.
+    /// - `HIPFIRE_NGRAM_LOOP_THRESHOLD` (default 0 = disabled): a 4-gram count
+    ///   of this value or higher inside the window triggers the guard. Set an
+    ///   explicit positive value to opt in.
     /// - `HIPFIRE_NGRAM_WINDOW` (default 256): how many trailing tokens to
     ///   inspect on each `check` call.
     pub fn from_config(config: &crate::config::RuntimeConfig) -> Self {


### PR DESCRIPTION
Cherry-picks **`f03b494dc`** from `redline` (`-x` trailer preserved) — the complete, hiptrx-validated fix for the runaway-thinking pairing.

**Why:** #523 restored only the n-gram half (guard default 8→0). But master also gated the med think-cap behind `max_think_explicit`, so with the default config (`thinking_budget: "med"`, no override) the 2048 cap **wasn't forwarded** — leaving master with *neither* runaway guard by default after #523. This restores the whole 7eac3c876 correctness unit:
- disable the content-blind 4-gram loop guard by default (already on master via #523; resolved to f03b494dc's wording),
- **forward the resolved medium think budget through the serve API** (`resolveServeThinkCap()` replaces the `&& max_think_explicit` gate),
- continue AR/DFlash/native-MTP generation after the forced `</think>` close.

**Validated (from the commit):** fixed-seed A3B sampled battery on hiptrx now produces visible coherent output for all 5 prompts; controlled repeat 158.24 tok/s capped vs 156.94 uncapped (perf-neutral; the earlier 153.02 was transient run-state variance). Adds `serve_think_cap.test.ts` + guard-default tests.

**Scope:** deliberately excludes the unrelated MTP prefix-cache from 7eac3c876. Verified here: `cargo check -p hipfire-runtime -p hipfire-arch-qwen35` green; `bun test serve_think_cap.test.ts` 2/2 pass.