### PR TITLE
fix: remove noisy RDNA2 GEMV variant eprintln

### DIFF
--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -2346,7 +2346,7 @@ pub fn gemv_hfq4g256_for_arch(
                 "cache-aggressive",
             ];
             let name = names.get(variant as usize).unwrap_or(&"baseline-rdna2");
-            eprintln!("  RDNA2 GEMV variant: v{variant} ({name})");
+            // eprintln!("  RDNA2 GEMV variant: v{variant} ({name})");
             match variant {
                 2 => (GEMV_HFQ4G256_GFX1030_V2_SRC, "gemv_hfq4g256_rdna2v2"),
                 3 => (GEMV_HFQ4G256_GFX1030_V3_SRC, "gemv_hfq4g256_rdna2v3"),


### PR DESCRIPTION
## Summary

Removes the `eprintln!("  RDNA2 GEMV variant: v{variant} ({name})")` call in `gemv_hfq4g256_for_arch` (`crates/rdna-compute/src/kernels.rs`).

## Problem

On RDNA2 (gfx1030/gfx1031), every GEMV kernel selection prints this line to stderr:

```
RDNA2 GEMV variant: v1 (baseline-rdna2)
```

Since a single decode step involves many GEMV calls, this produces hundreds of identical spam lines in `serve.log` and `hipfire bench` output. The variant information is not actionable for users — it's only useful for kernel developers who can check the variant via `HIPFIRE_RDNA2_VARIANT` env var or the pre-compiled cache directory name.

## Testing

- Verified the `eprintln!` string no longer appears in the compiled binary via `strings`
- Tested `hipfire bench qwen3.6-35b-a3b.mq2` — no more RDNA2 GEMV variant spam in output

Closes #531