### PR TITLE
fix(qwen35): prevent gated-norm MQ rotation scratch overflow

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -4699,8 +4699,9 @@ pub struct Qwen35Scratch {
     pub repeat_buf: GpuTensor, // [repeat_window]
 
     // MagnumQuant rotation scratch: FWHT(x) shared across Q/K/V (or gate/up, etc).
-    // Sized to max(dim, hidden_dim) — one rotation per batch replaces one per GEMV.
-    pub x_rot: GpuTensor, // [max(dim, hidden_dim)]
+    // DeltaNet's output projection consumes v_dim values, which can exceed both
+    // dim and the unused dense hidden_dim on MoE checkpoints.
+    pub x_rot: GpuTensor, // [max(dim, hidden_dim, v_dim)]
 
     // Flash attention partials buffer for tile+reduce 2-kernel path.
     // Size: n_heads * max_tiles * (2 + head_dim) floats.
@@ -4743,6 +4744,10 @@ pub struct Qwen35Scratch {
     // Optional long-prefill scratch. Default is None to preserve VRAM
     // footprint; set HIPFIRE_PREFILL_REUSE_PBS=1 to allocate and reuse it.
     pub prefill_batch: Option<PrefillBatchScratch>,
+}
+
+fn qwen35_x_rot_len(dim: usize, hidden_dim: usize, v_dim: usize) -> usize {
+    dim.max(hidden_dim).max(v_dim)
 }
 
 impl Qwen35Scratch {
@@ -4798,7 +4803,10 @@ impl Qwen35Scratch {
             logits: gpu.alloc_tensor(&[config.vocab_size], DType::F32)?,
             sample_buf: gpu.alloc_tensor(&[2], DType::F32)?,
             repeat_buf: gpu.alloc_tensor(&[repeat_window], DType::F32)?,
-            x_rot: gpu.alloc_tensor(&[dim.max(config.hidden_dim)], DType::F32)?,
+            x_rot: gpu.alloc_tensor(
+                &[qwen35_x_rot_len(dim, config.hidden_dim, v_dim)],
+                DType::F32,
+            )?,
 
             // Flash attention partials: enough for the smallest tile used by
             // Q8 decode experiments and the fixed tile_size=128 paths.
@@ -16860,6 +16868,12 @@ pub fn forward_with_embedding(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn x_rot_covers_deltanet_value_width_for_moe_configs() {
+        assert_eq!(qwen35_x_rot_len(2048, 0, 4096), 4096);
+        assert_eq!(qwen35_x_rot_len(2048, 8192, 4096), 8192);
+    }
 
     // ── SP2 — per-expert mixed-tier table builder (CPU-pure) ──────────────
     // `mixed_tier_table` is the testable core of `per_expert_tier_tables`:

--- a/crates/rdna-compute/src/gemv.rs
+++ b/crates/rdna-compute/src/gemv.rs
@@ -3211,6 +3211,29 @@ impl Gpu {
         eps: f32,
     ) -> HipResult<()> {
         self.bind_thread()?;
+        let k = n_heads.checked_mul(head_dim).ok_or_else(|| {
+            hip_bridge::HipError::new(1, "gated_norm_rotate_mq_gfx1100: size overflow")
+        })?;
+        if n_heads != 32 || head_dim != 128 {
+            return Err(hip_bridge::HipError::new(
+                1,
+                "gated_norm_rotate_mq_gfx1100: expected 32 heads with head_dim=128",
+            ));
+        }
+        if x.numel() < k || z.numel() < k || weight.numel() < head_dim || x_rot.numel() < k {
+            return Err(hip_bridge::HipError::new(
+                1,
+                &format!(
+                    "gated_norm_rotate_mq_gfx1100: undersized tensor (x={}, z={}, weight={}, x_rot={}, required x/z/x_rot={}, weight={})",
+                    x.numel(),
+                    z.numel(),
+                    weight.numel(),
+                    x_rot.numel(),
+                    k,
+                    head_dim,
+                ),
+            ));
+        }
         self.ensure_mq_signs()?;
         let (module, src, kernel) = if self.arch_caps.is_gfx1151() {
             (
@@ -3247,7 +3270,6 @@ impl Gpu {
             &hd as *const _ as *mut c_void,
             &ep as *const _ as *mut c_void,
         ];
-        let k = n_heads * head_dim;
         let bytes = crate::profile::gated_norm_bytes(k) + crate::profile::mq_rotate_bytes(k);
         let timer = crate::profile::begin_timer(&self.hip, "fused", kernel, bytes);
         let result = self.launch_maybe_blob(


### PR DESCRIPTION
## Summary

Fix a deterministic gfx1100 Qwen3.6-35B-A3B failure at the long-prefill-to-first-decode boundary by sizing `Qwen35Scratch::x_rot` for the DeltaNet value width and validating the fused gated-norm/MQ-rotation launch contract before dispatch.

## Root cause

For Qwen3.6-35B-A3B, `dim=2048`, `hidden_dim=0`, and `v_dim=32*128=4096`. `Qwen35Scratch::x_rot` was allocated as `max(dim, hidden_dim)`, or 2048 F32 elements, while `gated_norm_mq_rotate_gfx1100` writes 4096 F32 elements. The resulting out-of-bounds write is 8192 bytes.

The latent allocation bug became deterministic after `12a9842c` enabled the gated-norm MQ rotation fusion by default. The stable trigger was an 8192-token prefill followed by the first single-token decode.

This change:

1. Allocates `x_rot` as `max(dim, hidden_dim, v_dim)`.
2. Adds overflow, exact-shape, and tensor-capacity validation before launching the fusion.
3. Adds a unit test covering the Qwen3.6-35B-A3B MoE dimensions.

The additional allocation for this model is 2048 F32 elements, or 8 KiB per scratch instance.

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [x] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [x] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template - touch only when refining the new-arch reference)
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [ ] docs / CI / scripts

## Test plan

- [x] `./scripts/no-gpu-ci.sh` passes
  - Bun: 288 passed, 0 failed
- [x] `cargo build --release --locked --workspace --features deltanet`
- [x] `cargo test --locked --lib --workspace --features deltanet`
- [x] `./target/release/examples/test_kernels`
  - 16 passed, 0 failed, 0 skipped on Radeon Pro W7900 / gfx1100
- [x] Exact Qwen3.6-35B-A3B regression path
  - 8192-token prefill, 2-token warmup, and 8-token decode completed without HIP 700 or a hang
  - decode: 145.9 tok/s
- [x] Fusion on/off produced identical token IDs in the diagnostic parity run
- [ ] If perf-relevant: `./scripts/speed-gate.sh` within the shared gfx1100 floor

The complete speed gate was run on Radeon Pro W7900. It reported 7 passed, 7 below the shared RX 7900 XTX-oriented gfx1100 floor, and 1 row without a committed baseline. This is the existing hardware-baseline mismatch on this host rather than evidence of a change-specific regression since W7900 is with a 18Gbps bandwidth compared to 20 on 7900XTX.

| Metric | Baseline | W7900 observed | Delta |
|---|---:|---:|---:|
| 0.8B pp32 prefill | 2007.9 | 2437.7 | +21.4% |
| 0.8B pp128 prefill | 4672.5 | 6067.5 | +29.9% |
| 0.8B decode | 365.6 | 337.8 | -7.6% |
| 4B pp32 prefill | 1014.0 | 1422.1 | +40.2% |
| 4B pp128 prefill | 2004.3 | 2319.1 | +15.7% |
| 4B decode | 178.0 | 139.6 | -21.6% |
| 9B pp32 prefill | 1240.0 | 1084.2 | -12.6% |
| 9B pp128 prefill | 1672.0 | 1704.7 | +2.0% |
| 9B decode | 114.8 | 100.9 | -12.1% |
| 27B pp32 prefill | 406.1 | 358.1 | -11.8% |
| 27B pp128 prefill | 491.1 | 602.1 | +22.6% |
| 27B decode | 46.5 | 35.8 | -23.0% |
| 27B DFlash merge-sort | 250.0 | 212.0 | -15.2% |
| 9B DFlash merge-sort | 575.0 | 551.1 | -4.2% |
| 27B DFlash LRU | no baseline | 148.51, tau=9.0 | N/A |

The current `CONTRIBUTING.md` retires the fixed `coherence-gate*.sh` batteries as acceptance evidence. The actual affected model path and the current `test_kernels` gate were run instead.

Two unrelated beta harness issues were observed and were not modified here:

- `redline_daemon_harness.py` loads the model but expects a missing `redline_capture` response field.
- `serve_harness.py` hardcodes `/home/kaden/.bun/bin/bun`.

## Architecture-trait change?

No. This does not change the `Architecture` trait surface.
