### PR TITLE
fix(bench): report real cohere2moe prefill (pp table + generate metrics)

### DIFF
--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -2549,9 +2549,13 @@ fn main() {
                     }
                     ok
                 } else if m.arch_id == 12 {
-                    // Cohere2-MoE warm-pass: per-token decode_step over the
-                    // synthetic prompt. This primes attention + MoE dispatch
-                    // without mutating qwen/minimax-specific state.
+                    // Cohere2-MoE: measure the REAL production prefill — the
+                    // batched `forward_batch` (256-chunk) that `generate_cohere2moe`
+                    // uses — so the pp table reflects true prefill throughput
+                    // (~6x decode) instead of a per-token decode_step warm-pass
+                    // (which measures decode speed and mislabels it prefill).
+                    // Tiers with no indexed-MoE kernel (bf16 oracle / Q8 experts)
+                    // fall back to per-token, mirroring `forward_batch_supported`.
                     let b = m
                         .cohere2moe_mut()
                         .expect("arch_id=12 requires cohere2moe bundle");
@@ -2559,14 +2563,37 @@ fn main() {
                     let weights = &b.weights;
                     let state = &mut b.state;
                     let mut ok = true;
-                    for (i, &tok) in synthetic.iter().enumerate() {
-                        if cohere2moe::forward::decode_step(
-                            config, weights, state, &mut gpu, tok, i as u32,
-                        )
-                        .is_err()
-                        {
-                            ok = false;
-                            break;
+                    if cohere2moe::forward::forward_batch_supported(weights) && synthetic.len() > 1
+                    {
+                        let mut i = 0;
+                        while i < synthetic.len() {
+                            let end = (i + 256).min(synthetic.len());
+                            let start_pos = state.n_tokens;
+                            if cohere2moe::forward::forward_batch(
+                                config,
+                                weights,
+                                state,
+                                &mut gpu,
+                                &synthetic[i..end],
+                                start_pos,
+                            )
+                            .is_err()
+                            {
+                                ok = false;
+                                break;
+                            }
+                            i = end;
+                        }
+                    } else {
+                        for (i, &tok) in synthetic.iter().enumerate() {
+                            if cohere2moe::forward::decode_step(
+                                config, weights, state, &mut gpu, tok, i as u32,
+                            )
+                            .is_err()
+                            {
+                                ok = false;
+                                break;
+                            }
                         }
                     }
                     ok
@@ -12082,7 +12109,15 @@ fn generate_cohere2moe(
     let _ = writeln!(
         stdout,
         r#"{{"type":"done","id":"{}","tokens":{},"tok_s":{:.2},"prefill_tokens":{},"prefill_ms":{},"prefill_tok_s":{:.1},"decode_tok_s":{:.2},"ttft_ms":{},"total_ms":{}}}"#,
-        id, generated_count, tok_s, prefill_tokens, prefill_ms, prefill_tok_s, tok_s, prefill_ms, total_ms,
+        id,
+        generated_count,
+        tok_s,
+        prefill_tokens,
+        prefill_ms,
+        prefill_tok_s,
+        tok_s,
+        prefill_ms,
+        total_ms,
     );
     let _ = stdout.flush();
 }

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -12068,10 +12068,21 @@ fn generate_cohere2moe(
     } else {
         0.0
     };
+    // Prefill metrics so the CLI bench measures the REAL production prefill
+    // (batched `forward_batch`) straight off the generate response — mirrors
+    // the qwen35 `done` fields (`ttft_ms` ≈ prefill_ms, `decode_tok_s` = tok_s).
+    // Prior to this, cohere2moe omitted these, so `hipfire bench` fell back to
+    // the synthetic per-token `bench_prefill` path and under-reported prefill ~6×.
+    let prefill_tokens = prefill_ids.len();
+    let prefill_tok_s = if prefill_ms > 0 {
+        (prefill_tokens as f64 * 1000.0) / prefill_ms as f64
+    } else {
+        0.0
+    };
     let _ = writeln!(
         stdout,
-        r#"{{"type":"done","id":"{}","tokens":{},"tok_s":{:.2},"prefill_ms":{},"total_ms":{}}}"#,
-        id, generated_count, tok_s, prefill_ms, total_ms,
+        r#"{{"type":"done","id":"{}","tokens":{},"tok_s":{:.2},"prefill_tokens":{},"prefill_ms":{},"prefill_tok_s":{:.1},"decode_tok_s":{:.2},"ttft_ms":{},"total_ms":{}}}"#,
+        id, generated_count, tok_s, prefill_tokens, prefill_ms, prefill_tok_s, tok_s, prefill_ms, total_ms,
     );
     let _ = stdout.flush();
 }


### PR DESCRIPTION
## Problem
`hipfire bench` reports a misleadingly low prefill number for cohere2moe (North-Mini-Code): ~58 tok/s, roughly equal to *decode* speed.

Two causes:
1. The CLI's `benchRun` reads `prefill_tok_s`/`prefill_tokens` off the daemon's `generate` `done` message. `generate_cohere2moe` never emitted those (only `prefill_ms` + a combined `tok_s`), unlike `generate_qwen35` which emits the full set.
2. With no prefill number from `generate`, the bench's `pp` table comes from the synthetic `bench_prefill` command — whose `arch_id == 12` branch runs a per-token `decode_step` warm-pass, **not** the batched `forward_batch`. So it measures decode speed and labels it prefill.

Net: the bench under-reports cohere2moe prefill ~6× (real batched prefill is ~330 tok/s on gfx1151, ~6× the ~50 tok/s decode).

## Fix
Emit the same `done` metrics from `generate_cohere2moe` as `generate_qwen35` (`prefill_tokens`, `prefill_tok_s`, `decode_tok_s`, `ttft_ms`; `ttft_ms ≈ prefill_ms`, `decode_tok_s = tok_s`). The bench now measures prefill through the real production `generate` → `forward_batch` path — an integration measurement by construction, so it can't silently diverge from production.

## Verification (gfx1151, HIP 7.2)
`hipfire bench north-mini-code "<1843-token prompt>"`:
- **before:** `pp --` per run; only the synthetic `pp` table (~58 tok/s, decode-rate)
- **after:** `Prefill tok/s ~330 (user prompt, 1843 tok)` off the real generate path

Coherent output confirmed; decode unchanged.

## Notes
- The same gap exists for the deepseek4/minimax/lfm2moe `done` messages + the `bench_prefill` per-arch ladder; this PR scopes to cohere2moe. A follow-up could route both `generate_*` and `bench_prefill` through one shared prefill entry point so the bench is structurally an integration test for every arch.
- Separately investigated a prefill speedup (larger prefill chunk / flash sub-batch); a clean end-to-end A/B showed it inert (~327 vs ~332 tok/s — the apparent win was a profiling-sync artifact), so nothing perf-related is included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
