### PR TITLE
fix(rocm): centralise ROCm discovery + reproduction package for fixture disputes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,7 @@ name = "hsa-bridge"
 version = "0.3.0"
 dependencies = [
  "hip-bridge",
+ "hipfire-config",
  "libloading",
  "thiserror 2.0.18",
 ]

--- a/crates/hip-bridge/src/ffi.rs
+++ b/crates/hip-bridge/src/ffi.rs
@@ -276,24 +276,50 @@ impl HipRuntime {
 
         #[cfg(not(target_os = "windows"))]
         let lib = unsafe {
-            // Try unversioned first (canonical with rocm-hip-devel symlink),
-            // then versioned SONAMEs. Fedora's `rocm-hip` package ships only
+            // Unversioned first (canonical with rocm-hip-devel symlink), then
+            // versioned SONAMEs. Fedora's `rocm-hip` package ships only
             // `libamdhip64.so.6` — the unversioned `.so` symlink is in the
             // `-devel` package which most users don't have. Reported in #64.
-            Library::new("libamdhip64.so")
-                .or_else(|_| Library::new("libamdhip64.so.7"))
-                .or_else(|_| Library::new("libamdhip64.so.6"))
-                .or_else(|_| Library::new("libamdhip64.so.5"))
-                .map_err(|e| {
-                    HipError::new(
+            //
+            // Resolution used to be loader-only here, which silently required
+            // LD_LIBRARY_PATH/ldconfig to already point at ROCm and broke on
+            // side-by-side and /opt/rocm/core-<ver> layouts. hipfire_config::rocm
+            // prepends explicitly resolved roots and keeps the bare sonames last
+            // so a correctly configured loader path still wins nothing away.
+            let candidates = hipfire_config::rocm::library_candidates(&[
+                "libamdhip64.so",
+                "libamdhip64.so.7",
+                "libamdhip64.so.6",
+                "libamdhip64.so.5",
+            ]);
+            let mut loaded = None;
+            let mut last_err = None;
+            for candidate in &candidates {
+                match Library::new(candidate) {
+                    Ok(l) => {
+                        loaded = Some(l);
+                        break;
+                    }
+                    Err(e) => last_err = Some(e),
+                }
+            }
+            match loaded {
+                Some(l) => l,
+                None => {
+                    return Err(HipError::new(
                         0,
                         &format!(
-                            "failed to dlopen libamdhip64.so: {e}. \
-                             Tried: libamdhip64.so, libamdhip64.so.7, .so.6, .so.5. \
-                             Is ROCm installed?"
+                            "failed to dlopen libamdhip64.so: {}. Tried: {}. \
+                             Is ROCm installed? Set HIPFIRE_ROCM_PATH or ROCM_PATH \
+                             if it lives outside /opt/rocm.",
+                            last_err
+                                .map(|e| e.to_string())
+                                .unwrap_or_else(|| "no candidates".into()),
+                            candidates.join(", ")
                         ),
-                    )
-                })?
+                    ));
+                }
+            }
         };
 
         let runtime = unsafe {
@@ -842,8 +868,12 @@ impl HipRuntime {
         let elapsed = t.elapsed().as_nanos() as u64;
         crate::ffi::launch_counters::memcpy_dtoh::record_bytes(elapsed, dst.len() as u64);
         static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let dump =
-            *DUMP.get_or_init(|| hipfire_config::developer_var("HIPFIRE_DTOH_DUMP").ok().as_deref() == Some("1"));
+        let dump = *DUMP.get_or_init(|| {
+            hipfire_config::developer_var("HIPFIRE_DTOH_DUMP")
+                .ok()
+                .as_deref()
+                == Some("1")
+        });
         if dump {
             eprintln!(
                 "dtoh bytes={} us={} at {}:{}",
@@ -886,8 +916,12 @@ impl HipRuntime {
         let elapsed = t.elapsed().as_nanos() as u64;
         crate::ffi::launch_counters::memcpy_dtoh::record_bytes(elapsed, dst.len() as u64);
         static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let dump =
-            *DUMP.get_or_init(|| hipfire_config::developer_var("HIPFIRE_DTOH_DUMP").ok().as_deref() == Some("1"));
+        let dump = *DUMP.get_or_init(|| {
+            hipfire_config::developer_var("HIPFIRE_DTOH_DUMP")
+                .ok()
+                .as_deref()
+                == Some("1")
+        });
         if dump {
             eprintln!(
                 "dtoh_at bytes={} us={} at {}:{}",
@@ -929,8 +963,12 @@ impl HipRuntime {
         let elapsed = t.elapsed().as_nanos() as u64;
         crate::ffi::launch_counters::memset::record_bytes(elapsed, size as u64);
         static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let dump =
-            *DUMP.get_or_init(|| hipfire_config::developer_var("HIPFIRE_MEMSET_DUMP").ok().as_deref() == Some("1"));
+        let dump = *DUMP.get_or_init(|| {
+            hipfire_config::developer_var("HIPFIRE_MEMSET_DUMP")
+                .ok()
+                .as_deref()
+                == Some("1")
+        });
         if dump {
             eprintln!(
                 "memset bytes={} us={} at {}:{}",
@@ -960,8 +998,12 @@ impl HipRuntime {
         let elapsed = t.elapsed().as_nanos() as u64;
         crate::ffi::launch_counters::memset::record_bytes(elapsed, size as u64);
         static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let dump =
-            *DUMP.get_or_init(|| hipfire_config::developer_var("HIPFIRE_MEMSET_DUMP").ok().as_deref() == Some("1"));
+        let dump = *DUMP.get_or_init(|| {
+            hipfire_config::developer_var("HIPFIRE_MEMSET_DUMP")
+                .ok()
+                .as_deref()
+                == Some("1")
+        });
         if dump {
             eprintln!(
                 "memset_async bytes={} us={} at {}:{}",

--- a/crates/hip-bridge/src/rccl.rs
+++ b/crates/hip-bridge/src/rccl.rs
@@ -102,10 +102,16 @@ impl RcclComms {
     /// `ncclCommInitAll`. Each comm[i] binds to `device_ids[i]`.
     pub fn init_all(device_ids: &[i32]) -> RcclResult<Self> {
         let lib = unsafe {
-            let candidates = ["librccl.so", "librccl.so.1", "librccl.so.1.0"];
+            // Resolved ROCm roots first, bare sonames last, so RCCL is found on
+            // side-by-side and /opt/rocm/core-<ver> installs too.
+            let candidates = hipfire_config::rocm::library_candidates(&[
+                "librccl.so",
+                "librccl.so.1",
+                "librccl.so.1.0",
+            ]);
             let mut loaded = None;
             for name in &candidates {
-                if let Ok(l) = Library::new(*name) {
+                if let Ok(l) = Library::new(name) {
                     loaded = Some(l);
                     break;
                 }

--- a/crates/hip-bridge/src/rocblas.rs
+++ b/crates/hip-bridge/src/rocblas.rs
@@ -106,22 +106,23 @@ impl Rocblas {
     /// On failure (library missing / symbol missing), returns an error that the
     /// caller can treat as "rocBLAS unavailable, fall back to hand-rolled kernels".
     pub fn load() -> RocblasResult<Self> {
-        let candidates = [
+        // Resolved ROCm roots first, bare sonames last. Replaces a hardcoded
+        // /opt/rocm/lib list that missed side-by-side and core-<ver> layouts.
+        let candidates = hipfire_config::rocm::library_candidates(&[
             "librocblas.so",
             "librocblas.so.7",
             "librocblas.so.6",
             "librocblas.so.5",
-            "/opt/rocm/lib/librocblas.so",
-            "/opt/rocm/lib/librocblas.so.7",
-            "/opt/rocm/lib/librocblas.so.6",
-            "/opt/rocm/lib/librocblas.so.5",
-        ];
+        ]);
         let lib = candidates
             .iter()
-            .find_map(|name| unsafe { Library::new(*name).ok() })
+            .find_map(|name| unsafe { Library::new(name).ok() })
             .ok_or_else(|| RocblasError {
                 status: 0,
-                context: "dlopen librocblas.so (tried several names) failed".into(),
+                context: format!(
+                    "dlopen librocblas.so failed. Tried: {}",
+                    candidates.join(", ")
+                ),
             })?;
 
         unsafe {

--- a/crates/hipfire-config/src/lib.rs
+++ b/crates/hipfire-config/src/lib.rs
@@ -9,6 +9,8 @@
 //! persistence, validation, and field-level provenance. Runtime crates consume
 //! resolved values; they do not parse user configuration in hot paths.
 
+pub mod rocm;
+
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/crates/hipfire-config/src/rocm.rs
+++ b/crates/hipfire-config/src/rocm.rs
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! ROCm installation discovery.
+//!
+//! hipfire dlopens the HIP/HSA runtimes rather than linking them, so it has to
+//! find them at run time. Historically each call site did that differently:
+//!
+//!   * `hip-bridge` (Linux) asked the dynamic loader for a bare
+//!     `libamdhip64.so` and did no root resolution at all — it worked only
+//!     when `LD_LIBRARY_PATH`/ldconfig already pointed at ROCm.
+//!   * `hsa-bridge`, `rocblas` and `rccl` hardcoded `/opt/rocm/lib`.
+//!   * The kernel compiler invoked a bare `hipcc` off `PATH`.
+//!
+//! That breaks on any install that is not literally `/opt/rocm`: side-by-side
+//! installs (`/opt/rocm-6.4`), the `/opt/rocm/core-<ver>` layout used when a
+//! host ROCm is overmounted into a container, and Windows' `HIP_PATH`.
+//!
+//! This module centralises the policy. Resolution order, most authoritative
+//! first:
+//!
+//!   1. `HIPFIRE_ROCM_PATH` — our explicit override, always wins.
+//!   2. `ROCM_PATH`         — the ROCm-standard variable.
+//!   3. `HIP_PATH`          — HIP SDK variable; a trailing `hip` component is
+//!                            stripped so `/opt/rocm/hip` resolves to `/opt/rocm`.
+//!   4. The parent of a resolved device compiler on `PATH` (`hipcc`,
+//!      `amdclang++`, …), which is how a `module load`-style environment
+//!      identifies itself.
+//!   5. `/opt/rocm`.
+//!   6. Versioned siblings — `/opt/rocm-*` and `/opt/rocm/core-*` — newest
+//!      first, so `core-7.14` beats `core-7`.
+//!
+//! Nothing here touches the GPU; it is pure path policy and is unit-tested
+//! against a synthetic tree.
+
+use std::path::{Path, PathBuf};
+
+/// Device compilers, most specific first. `hipcc` is being wound down upstream
+/// in favour of invoking the LLVM driver directly, and on ROCm 7.14 `hipcc` is
+/// already a thin wrapper around `amdclang++`, so both are probed.
+pub const DEVICE_COMPILERS: &[&str] = &["hipcc", "amdclang++", "amdclang", "clang++"];
+
+/// Split a directory name into numeric components for version ordering.
+/// `core-7.14` -> [7, 14]; names without digits sort last.
+fn version_key(name: &str) -> Vec<u64> {
+    let mut out = Vec::new();
+    let mut cur = String::new();
+    for ch in name.chars() {
+        if ch.is_ascii_digit() {
+            cur.push(ch);
+        } else if !cur.is_empty() {
+            out.push(cur.parse().unwrap_or(0));
+            cur.clear();
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur.parse().unwrap_or(0));
+    }
+    out
+}
+
+/// Versioned ROCm siblings under `base`, newest first.
+fn versioned_siblings(base: &Path, prefix: &str) -> Vec<PathBuf> {
+    let mut found: Vec<(Vec<u64>, PathBuf)> = Vec::new();
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return Vec::new();
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        if !name.starts_with(prefix) || !entry.path().is_dir() {
+            continue;
+        }
+        let key = version_key(name);
+        if key.is_empty() {
+            continue;
+        }
+        found.push((key, entry.path()));
+    }
+    // Descending by numeric key so 7.14 precedes 7.
+    found.sort_by(|a, b| b.0.cmp(&a.0));
+    found.into_iter().map(|(_, p)| p).collect()
+}
+
+/// A `HIP_PATH` may point at `<root>/hip`; normalise to `<root>`.
+fn normalize_hip_path(p: &Path) -> PathBuf {
+    if p.file_name().map(|f| f == "hip").unwrap_or(false) {
+        if let Some(parent) = p.parent() {
+            return parent.to_path_buf();
+        }
+    }
+    p.to_path_buf()
+}
+
+/// Locate a tool on `PATH` and derive the ROCm root from it (`<root>/bin/tool`).
+fn root_from_path_tools() -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        for tool in DEVICE_COMPILERS {
+            let candidate = dir.join(tool);
+            if !candidate.exists() {
+                continue;
+            }
+            let resolved = std::fs::canonicalize(&candidate).unwrap_or(candidate);
+            // <root>/bin/<tool> -> <root>
+            if let Some(root) = resolved.parent().and_then(|b| b.parent()) {
+                return Some(root.to_path_buf());
+            }
+        }
+    }
+    None
+}
+
+/// Ordered candidate ROCm roots. Entries are deduplicated but NOT filtered for
+/// existence — callers that need existence should use [`root`].
+pub fn roots() -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let mut push = |p: PathBuf| {
+        if !out.contains(&p) {
+            out.push(p);
+        }
+    };
+
+    for var in ["HIPFIRE_ROCM_PATH", "ROCM_PATH"] {
+        if let Some(v) = std::env::var_os(var) {
+            if !v.is_empty() {
+                push(PathBuf::from(v));
+            }
+        }
+    }
+    if let Some(v) = std::env::var_os("HIP_PATH") {
+        if !v.is_empty() {
+            push(normalize_hip_path(Path::new(&v)));
+        }
+    }
+    if let Some(p) = root_from_path_tools() {
+        push(p);
+    }
+    push(PathBuf::from("/opt/rocm"));
+    for p in versioned_siblings(Path::new("/opt/rocm"), "core-") {
+        push(p);
+    }
+    for p in versioned_siblings(Path::new("/opt"), "rocm-") {
+        push(p);
+    }
+    out
+}
+
+/// The first candidate root that exists on disk.
+pub fn root() -> Option<PathBuf> {
+    roots().into_iter().find(|p| p.is_dir())
+}
+
+/// ROCm version string from `<root>/.info/version`, if readable.
+pub fn version() -> Option<String> {
+    for r in roots() {
+        let f = r.join(".info").join("version");
+        if let Ok(s) = std::fs::read_to_string(&f) {
+            let s = s.trim();
+            if !s.is_empty() {
+                return Some(s.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Candidate load paths for a library, resolved roots first and the bare
+/// sonames last so the dynamic loader still gets its turn (that is what makes
+/// a correctly-configured `LD_LIBRARY_PATH` keep working).
+///
+/// `sonames` should be ordered most-preferred first, e.g.
+/// `["libamdhip64.so", "libamdhip64.so.7"]`.
+pub fn library_candidates(sonames: &[&str]) -> Vec<String> {
+    let mut out = Vec::new();
+    for r in roots() {
+        for libdir in ["lib", "lib64"] {
+            for soname in sonames {
+                let p = r.join(libdir).join(soname);
+                if p.exists() {
+                    out.push(p.to_string_lossy().into_owned());
+                }
+            }
+        }
+    }
+    for soname in sonames {
+        out.push((*soname).to_string());
+    }
+    out
+}
+
+/// Locate a ROCm tool (`hipcc`, `amdclang++`, `rocminfo`, …) under a resolved
+/// root, falling back to bare `PATH` lookup.
+pub fn tool(name: &str) -> Option<PathBuf> {
+    for r in roots() {
+        let p = r.join("bin").join(name);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|d| d.join(name))
+        .find(|p| p.exists())
+}
+
+/// The device compiler this installation should use, most specific first.
+pub fn device_compiler() -> Option<PathBuf> {
+    DEVICE_COMPILERS.iter().find_map(|c| tool(c))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_key_orders_core_dirs_newest_first() {
+        assert_eq!(version_key("core-7.14"), vec![7, 14]);
+        assert_eq!(version_key("core-7"), vec![7]);
+        assert_eq!(version_key("rocm-6.4.1"), vec![6, 4, 1]);
+        assert!(version_key("core-7.14") > version_key("core-7"));
+        assert!(version_key("core-7.14") > version_key("core-7.9"));
+        assert!(version_key("nodigits").is_empty());
+    }
+
+    #[test]
+    fn hip_path_with_trailing_hip_component_normalizes_to_root() {
+        assert_eq!(
+            normalize_hip_path(Path::new("/opt/rocm/hip")),
+            PathBuf::from("/opt/rocm")
+        );
+        // A root that merely lives under a directory called hip is untouched.
+        assert_eq!(
+            normalize_hip_path(Path::new("/opt/rocm")),
+            PathBuf::from("/opt/rocm")
+        );
+    }
+
+    #[test]
+    fn versioned_siblings_sorts_newest_first_and_skips_files() {
+        let tmp = std::env::temp_dir().join(format!("hipfire-rocm-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        for d in ["core-7", "core-7.14", "core-6.4", "unrelated"] {
+            std::fs::create_dir_all(tmp.join(d)).unwrap();
+        }
+        // A regular file matching the prefix must not be treated as a root.
+        std::fs::write(tmp.join("core-9-notadir"), b"x").unwrap();
+
+        let got = versioned_siblings(&tmp, "core-");
+        let names: Vec<String> = got
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["core-7.14", "core-7", "core-6.4"]);
+
+        std::fs::remove_dir_all(&tmp).unwrap();
+    }
+
+    #[test]
+    fn library_candidates_always_end_with_bare_sonames() {
+        let c = library_candidates(&["libamdhip64.so", "libamdhip64.so.7"]);
+        assert!(c.len() >= 2);
+        // The loader fallback must be last so an explicit root wins over it.
+        assert_eq!(
+            &c[c.len() - 2..],
+            &["libamdhip64.so".to_string(), "libamdhip64.so.7".to_string()]
+        );
+    }
+
+    #[test]
+    fn roots_are_deduplicated_and_include_opt_rocm() {
+        let r = roots();
+        let mut seen = std::collections::HashSet::new();
+        for p in &r {
+            assert!(seen.insert(p.clone()), "duplicate root: {p:?}");
+        }
+        assert!(r.contains(&PathBuf::from("/opt/rocm")));
+    }
+}

--- a/crates/hsa-bridge/Cargo.toml
+++ b/crates/hsa-bridge/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 description = "Thin Rust FFI to AMD HSA/ROCr runtime via dlopen — bypasses HIP launch overhead"
 
 [dependencies]
+hipfire-config = { path = "../hipfire-config" }
 libloading.workspace = true
 thiserror = "2"
 

--- a/crates/hsa-bridge/src/ffi.rs
+++ b/crates/hsa-bridge/src/ffi.rs
@@ -130,8 +130,7 @@ pub struct HsaLib {
         callback: unsafe extern "C" fn(HsaAgentHandle, *mut c_void) -> HsaStatus,
         data: *mut c_void,
     ) -> HsaStatus,
-    pub fn_agent_get_info:
-        unsafe extern "C" fn(HsaAgentHandle, u32, *mut c_void) -> HsaStatus,
+    pub fn_agent_get_info: unsafe extern "C" fn(HsaAgentHandle, u32, *mut c_void) -> HsaStatus,
 
     // Queues
     pub fn_queue_create: unsafe extern "C" fn(
@@ -145,8 +144,7 @@ pub struct HsaLib {
         queue: *mut *mut HsaQueue,
     ) -> HsaStatus,
     pub fn_queue_destroy: unsafe extern "C" fn(queue: *mut HsaQueue) -> HsaStatus,
-    pub fn_queue_load_write_index_relaxed:
-        unsafe extern "C" fn(queue: *const HsaQueue) -> u64,
+    pub fn_queue_load_write_index_relaxed: unsafe extern "C" fn(queue: *const HsaQueue) -> u64,
     pub fn_queue_store_write_index_release:
         unsafe extern "C" fn(queue: *const HsaQueue, value: u64),
 
@@ -159,8 +157,7 @@ pub struct HsaLib {
     ) -> HsaStatus,
     pub fn_signal_destroy: unsafe extern "C" fn(signal: HsaSignalHandle) -> HsaStatus,
     pub fn_signal_store_relaxed: unsafe extern "C" fn(signal: HsaSignalHandle, value: i64),
-    pub fn_signal_store_screlease:
-        unsafe extern "C" fn(signal: HsaSignalHandle, value: i64),
+    pub fn_signal_store_screlease: unsafe extern "C" fn(signal: HsaSignalHandle, value: i64),
     pub fn_signal_load_relaxed: unsafe extern "C" fn(signal: HsaSignalHandle) -> i64,
     pub fn_signal_wait_scacquire: unsafe extern "C" fn(
         signal: HsaSignalHandle,
@@ -216,12 +213,9 @@ pub struct HsaLib {
         options: *const c_char,
         loaded_code_object: *mut u64,
     ) -> HsaStatus,
-    pub fn_executable_freeze: unsafe extern "C" fn(
-        executable: HsaExecutableHandle,
-        options: *const c_char,
-    ) -> HsaStatus,
-    pub fn_executable_destroy:
-        unsafe extern "C" fn(executable: HsaExecutableHandle) -> HsaStatus,
+    pub fn_executable_freeze:
+        unsafe extern "C" fn(executable: HsaExecutableHandle, options: *const c_char) -> HsaStatus,
+    pub fn_executable_destroy: unsafe extern "C" fn(executable: HsaExecutableHandle) -> HsaStatus,
     pub fn_executable_get_symbol_by_name: unsafe extern "C" fn(
         executable: HsaExecutableHandle,
         symbol_name: *const c_char,
@@ -242,10 +236,7 @@ unsafe impl Sync for HsaLib {}
 macro_rules! load_fn {
     ($lib:expr, $name:expr, $ty:ty) => {{
         let sym: Symbol<'_, $ty> = $lib.get($name.as_bytes()).map_err(|e| {
-            crate::error::HsaError::new(
-                0,
-                &format!("failed to load symbol {}: {e}", $name),
-            )
+            crate::error::HsaError::new(0, &format!("failed to load symbol {}: {e}", $name))
         })?;
         *sym.into_raw()
     }};
@@ -253,31 +244,53 @@ macro_rules! load_fn {
 
 impl HsaLib {
     /// Dlopen libhsa-runtime64.so and resolve all function pointers.
-    /// Searches /opt/rocm/lib then the default loader path.
+    ///
+    /// Candidates come from `hipfire_config::rocm`, which honours
+    /// `HIPFIRE_ROCM_PATH` / `ROCM_PATH` / `HIP_PATH`, derives the root from a
+    /// device compiler on `PATH`, and understands versioned layouts such as
+    /// `/opt/rocm/core-7.14`. Bare sonames are tried last so a correctly
+    /// configured `LD_LIBRARY_PATH` still works. This previously hardcoded
+    /// `/opt/rocm/lib`, which fails on every non-default install.
     pub fn load() -> crate::error::HsaResult<Self> {
+        let candidates = hipfire_config::rocm::library_candidates(&[
+            "libhsa-runtime64.so.1",
+            "libhsa-runtime64.so",
+        ]);
         let lib = unsafe {
-            Library::new("/opt/rocm/lib/libhsa-runtime64.so.1")
-                .or_else(|_| Library::new("/opt/rocm/lib/libhsa-runtime64.so"))
-                .or_else(|_| Library::new("libhsa-runtime64.so.1"))
-                .or_else(|_| Library::new("libhsa-runtime64.so"))
-                .map_err(|e| {
-                    crate::error::HsaError::new(
+            let mut loaded = None;
+            let mut last_err = None;
+            for candidate in &candidates {
+                match Library::new(candidate) {
+                    Ok(l) => {
+                        loaded = Some(l);
+                        break;
+                    }
+                    Err(e) => last_err = Some(e),
+                }
+            }
+            match loaded {
+                Some(l) => l,
+                None => {
+                    return Err(crate::error::HsaError::new(
                         0,
                         &format!(
-                            "failed to dlopen libhsa-runtime64.so: {e}. Is ROCm installed?"
+                            "failed to dlopen libhsa-runtime64.so: {}. Tried: {}. \
+                             Is ROCm installed? Set HIPFIRE_ROCM_PATH or ROCM_PATH \
+                             if it lives outside /opt/rocm.",
+                            last_err
+                                .map(|e| e.to_string())
+                                .unwrap_or_else(|| "no candidates".into()),
+                            candidates.join(", ")
                         ),
-                    )
-                })?
+                    ));
+                }
+            }
         };
 
         unsafe {
             Ok(Self {
                 fn_init: load_fn!(lib, "hsa_init", unsafe extern "C" fn() -> HsaStatus),
-                fn_shut_down: load_fn!(
-                    lib,
-                    "hsa_shut_down",
-                    unsafe extern "C" fn() -> HsaStatus
-                ),
+                fn_shut_down: load_fn!(lib, "hsa_shut_down", unsafe extern "C" fn() -> HsaStatus),
 
                 fn_iterate_agents: load_fn!(
                     lib,
@@ -457,11 +470,7 @@ impl HsaLib {
                 fn_executable_symbol_get_info: load_fn!(
                     lib,
                     "hsa_executable_symbol_get_info",
-                    unsafe extern "C" fn(
-                        HsaExecutableSymbolHandle,
-                        u32,
-                        *mut c_void,
-                    ) -> HsaStatus
+                    unsafe extern "C" fn(HsaExecutableSymbolHandle, u32, *mut c_void) -> HsaStatus
                 ),
                 _lib: lib,
             })

--- a/crates/rdna-compute/src/compiler.rs
+++ b/crates/rdna-compute/src/compiler.rs
@@ -98,6 +98,9 @@ pub struct KernelCompiler {
     /// hash so blobs built by a different compiler/ROCm don't get reused across
     /// builds sharing one `.hipfire_kernels` dir (the "invalid device image" trap).
     toolchain_id: String,
+    /// Resolved device-compiler binary. Bare "hipcc" when PATH provides it;
+    /// otherwise an absolute path discovered under a resolved ROCm root.
+    hipcc_bin: std::path::PathBuf,
 }
 
 impl KernelCompiler {
@@ -190,7 +193,23 @@ impl KernelCompiler {
 
         // Probe for hipcc once at init, not per-kernel. Capture its version line
         // as a toolchain fingerprint for the cache hash (Fix #1).
-        let hipcc_out = Command::new("hipcc").arg("--version").output().ok();
+        //
+        // PATH stays authoritative so an explicit `module load` / PATH choice
+        // still wins. The resolved-root fallback is strictly additive: it only
+        // engages when PATH has no hipcc at all, which is the common
+        // "ROCm installed under /opt/rocm/core-<ver> but not on PATH" case that
+        // previously degraded silently to has_hipcc=false.
+        let hipcc_bin: std::path::PathBuf = if Command::new("hipcc")
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            "hipcc".into()
+        } else {
+            hipfire_config::rocm::tool("hipcc").unwrap_or_else(|| "hipcc".into())
+        };
+        let hipcc_out = Command::new(&hipcc_bin).arg("--version").output().ok();
         let has_hipcc = hipcc_out
             .as_ref()
             .map(|o| o.status.success())
@@ -230,6 +249,7 @@ impl KernelCompiler {
             compiled: HashMap::new(),
             precompiled_dir,
             has_hipcc,
+            hipcc_bin,
             extra_flags,
             gfx1151_cumode_modules,
             toolchain_id,
@@ -328,6 +348,7 @@ impl KernelCompiler {
 
         if !cache_valid {
             Self::hipcc_compile(
+                &self.hipcc_bin,
                 &self.arch,
                 &src_path,
                 &obj_path,
@@ -446,6 +467,7 @@ impl KernelCompiler {
 
     /// Run hipcc for a single kernel. Shared by compile() and compile_batch().
     fn hipcc_compile(
+        hipcc_bin: &Path,
         arch: &str,
         src_path: &Path,
         obj_path: &Path,
@@ -509,7 +531,7 @@ impl KernelCompiler {
         args.push(obj_path.to_str().unwrap().into());
         args.push(src_path.to_str().unwrap().into());
 
-        let output = Command::new("hipcc")
+        let output = Command::new(hipcc_bin)
             .args(&args)
             .output()
             .map_err(|e| hip_bridge::HipError::new(0, &format!("failed to run hipcc: {e}")))?;
@@ -612,6 +634,7 @@ impl KernelCompiler {
         eprintln!("  compiling {n} kernels in parallel...");
         let arch = self.arch.clone();
         let precompiled_dir = self.precompiled_dir.clone();
+        let hipcc_bin = self.hipcc_bin.clone();
 
         // Shared counter so parallel threads can report "[i/N] name" as each one
         // completes. Ordering follows completion (not launch) — matches the pace
@@ -625,10 +648,12 @@ impl KernelCompiler {
                 |(name, source, src_hash, src_path, obj_path, hash_path, module_flags)| {
                     let arch = arch.clone();
                     let precompiled_dir = precompiled_dir.clone();
+                    let hipcc_bin = hipcc_bin.clone();
                     let extra_flags = self.extra_flags.clone();
                     let done = std::sync::Arc::clone(&done);
                     let handle = thread::spawn(move || {
                         let result = Self::hipcc_compile(
+                            &hipcc_bin,
                             &arch,
                             &src_path,
                             &obj_path,
@@ -690,6 +715,7 @@ mod tests {
             extra_flags: extra_flags.to_string(),
             gfx1151_cumode_modules: HashSet::new(),
             toolchain_id: toolchain_id.to_string(),
+            hipcc_bin: PathBuf::from("hipcc"),
         }
     }
 

--- a/docs/GOLDEN-REDLINE.md
+++ b/docs/GOLDEN-REDLINE.md
@@ -66,6 +66,46 @@ The stationarity ceiling is 120 TG128 rows. This preserves the existing slope,
 spread, confirmation, and median-drift criteria while allowing slow cold-start
 clock convergence. It does not relax the acceptance gates.
 
+## Reproducing on a box that disagrees
+
+`golden-redline.py` pins the model, sampling profile, benchmark contract, PM4
+policy and route identity — but not the compiled code objects or the host
+toolchain. When a contributor reports the same route identity (same dispatch
+count, kernel count and sequence hash) with different throughput, the
+divergence is below the tape and none of the above will catch it.
+
+`scripts/redline-repro-package.sh` closes that gap.
+
+```bash
+# On a box where the fixture passes, right after a successful golden run:
+scripts/redline-repro-package.sh capture --arch gfx1201
+
+# On the box that cannot reproduce:
+scripts/redline-repro-package.sh verify --package repro-gfx1201-*.tar.gz
+scripts/redline-repro-package.sh run    --package repro-gfx1201-*.tar.gz --pin-kernels
+```
+
+The package is ~156 KB and carries the 46 compiled code objects with a manifest
+hash, the ROCm and code-generator versions, GPU state, the PM4 policy, the
+acceptance floors, the required tape, and the reference attestation.
+
+`verify` classifies every difference as BLOCKING (arch, model SHA-256, PM4
+policy) or ADVISORY (source commit, daemon hash, ROCm version, code-generator
+version, code-object manifest) and exits 2 on a blocking mismatch. `--force`
+proceeds anyway.
+
+`--pin-kernels` installs the packaged code objects into
+`kernels/compiled/<arch>/` and shadows the device compilers with failing stubs,
+so the engine takes its "pre-compiled blob, no compiler available" branch and
+runs *our* binaries rather than rebuilding with the local toolchain. The engine
+prints `Output may be incorrect` in that state; under `--pin-kernels` that
+warning is expected and is the confirmation the pinning took effect. A pinned
+run recompiles nothing, which shows up as a much shorter warm-up.
+
+Note the stubs shadow only the compiler *names* — `rocminfo`, `rocm-smi` and
+the rest of `PATH` stay reachable. Removing whole `PATH` directories instead
+would strip device detection along with the compilers and hang the bench.
+
 ## What counts as a pass
 
 Identity is exact. Performance is an evidence-bound floor rather than a demand

--- a/scripts/redline-repro-package.sh
+++ b/scripts/redline-repro-package.sh
@@ -1,0 +1,466 @@
+#!/usr/bin/env bash
+# Redline golden-fixture reproduction package.
+#
+# WHY THIS EXISTS
+#
+# scripts/golden-redline.py pins the model, sampling profile, benchmark
+# contract, PM4 policy and route identity — but NOT the compiled code objects
+# or the host toolchain. Contributors reproducing the gfx1201 fixture have
+# reported PM4 slower than HIP on the same source commit, the same model
+# SHA-256 and the same ROCm version, while that commit passes elsewhere. When
+# the route identity matches byte-for-byte (same dispatch count, kernel count
+# and sequence hash) but throughput does not, the divergence lives BELOW the
+# tape: code objects, toolchain, or machine state.
+#
+# This script captures what the golden run does not, diffs it against a box
+# that cannot reproduce, and can force our exact code objects to be used.
+#
+# HOW KERNEL PINNING WORKS  (crates/rdna-compute/src/compiler.rs)
+#
+#   precompiled kernels/compiled/<arch>/<name>.hsaco exists?
+#     .hash sidecar matches src_hash        -> use it
+#     no valid hash AND no device compiler  -> use it, engine warns
+#     no valid hash AND compiler present    -> RECOMPILE (pinning defeated)
+#
+# src_hash folds in `toolchain_id`, so a different toolchain invalidates our
+# sidecars by design. `run --pin-kernels` therefore installs the blobs AND
+# hides the device compiler from the daemon's PATH, taking the middle branch so
+# our exact code objects execute. The engine prints its own "Output may be
+# incorrect" warning in that state; under --pin-kernels that warning is
+# EXPECTED and is precisely the confirmation that our blobs are in use.
+#
+# TOOLCHAIN NOTE
+#
+# The engine currently probes `hipcc` only. hipcc is being wound down upstream
+# in favour of invoking amdclang++/clang++ directly, and on ROCm 7.14 hipcc is
+# already just an ELF wrapper around amdclang++. This script therefore treats
+# the device compiler as a SET (see DEVICE_COMPILERS) rather than assuming
+# hipcc, so pinning keeps working after the engine moves off hipcc.
+#
+# USAGE
+#
+#   # On a box where the fixture passes, after a successful golden run:
+#   scripts/redline-repro-package.sh capture --arch gfx1201
+#
+#   # On a box that cannot reproduce:
+#   scripts/redline-repro-package.sh verify --package repro-gfx1201-*.tar.gz
+#   scripts/redline-repro-package.sh run    --package repro-gfx1201-*.tar.gz
+#   scripts/redline-repro-package.sh run    --package ... --pin-kernels
+#   scripts/redline-repro-package.sh run    --package ... --force
+#
+# Exit codes: 0 ok, 1 usage/IO error, 2 blocking mismatch (overridden by --force).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SCHEMA_VERSION=1
+PY=python3
+
+# Device compilers, most-specific first. hipcc is listed for today's engine;
+# the amdclang/clang entries keep --pin-kernels correct once the engine invokes
+# the LLVM driver directly.
+DEVICE_COMPILERS=(hipcc amdclang++ amdclang clang++ clang)
+
+die() { echo "error: $*" >&2; exit 1; }
+command -v "$PY" >/dev/null || die "python3 required (this repo deliberately does not depend on jq)"
+
+# `cmd | head -1 || echo fallback` concatenates BOTH outputs under pipefail:
+# head closes the pipe, the pipeline reports failure, and the fallback still
+# runs. Capture the whole output first, slice afterwards.
+first_line() {
+  local out
+  out="$("$@" 2>/dev/null || true)"
+  [ -n "$out" ] || { echo "unavailable"; return; }
+  printf '%s\n' "${out%%$'\n'*}"
+}
+
+nth_line() {
+  local n="$1"; shift
+  local out
+  out="$("$@" 2>/dev/null || true)"
+  printf '%s\n' "$out" | sed -n "${n}p"
+}
+
+# The code-generator identity. amdclang++ reports it on line 1; hipcc reports
+# the HIP runtime version on line 1 and the AMD clang version on line 2. The
+# engine currently fingerprints hipcc line 1, which is the weaker of the two.
+codegen_version() {
+  if command -v amdclang++ >/dev/null 2>&1; then
+    first_line amdclang++ --version
+  elif command -v hipcc >/dev/null 2>&1; then
+    nth_line 2 hipcc --version
+  else
+    echo unknown
+  fi
+}
+
+detect_arch() {
+  local device="${1:-0}"
+  command -v rocminfo >/dev/null || die "rocminfo not found; pass --arch explicitly"
+  rocminfo 2>/dev/null | grep -oE 'gfx[0-9]+' | sed -n "$((device + 1))p"
+}
+
+# ROCm installs are not always at /opt/rocm — this fleet uses
+# /opt/rocm/core-<ver>. Derive the root from the resolved compiler first, then
+# fall back to $ROCM_PATH and a glob, so side-by-side installs report the
+# version actually in use rather than whichever one is symlinked.
+rocm_version() {
+  local cc root
+  for cc in "${DEVICE_COMPILERS[@]}"; do
+    if command -v "$cc" >/dev/null 2>&1; then
+      root="$(cd "$(dirname "$(readlink -f "$(command -v "$cc")")")/.." && pwd)"
+      [ -f "$root/.info/version" ] && { cat "$root/.info/version"; return; }
+    fi
+  done
+  [ -n "${ROCM_PATH:-}" ] && [ -f "$ROCM_PATH/.info/version" ] && { cat "$ROCM_PATH/.info/version"; return; }
+  local f
+  for f in /opt/rocm/.info/version /opt/rocm*/.info/version /opt/rocm/core-*/.info/version; do
+    [ -f "$f" ] && { cat "$f"; return; }
+  done
+  echo unknown
+}
+
+usage() { sed -n '2,53p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+# ── capture ──────────────────────────────────────────────────────────────────
+
+cmd_capture() {
+  local arch="" device=0 out_dir="." attestation=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --arch) arch="$2"; shift 2 ;;
+      --device) device="$2"; shift 2 ;;
+      --out) out_dir="$2"; shift 2 ;;
+      --attestation) attestation="$2"; shift 2 ;;
+      -h|--help) usage 0 ;;
+      *) die "unknown capture flag: $1" ;;
+    esac
+  done
+  [ -n "$arch" ] || arch="$(detect_arch "$device")"
+  [ -n "$arch" ] || die "could not detect arch; pass --arch"
+
+  local stamp; stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  local stage; stage="$(mktemp -d)"
+  trap 'rm -rf "$stage"' RETURN
+  mkdir -p "$stage/hsaco/$arch"
+
+  local cache="${HIPFIRE_KERNEL_CACHE:-.hipfire_kernels}/$arch"
+  [ -d "$cache" ] || die "no kernel cache at $cache — run the golden fixture first so code objects exist"
+  cp "$cache"/*.hsaco "$stage/hsaco/$arch/" 2>/dev/null || die "no .hsaco found in $cache"
+  # .hash sidecars let a same-toolchain box use these without --pin-kernels.
+  cp "$cache"/*.hash "$stage/hsaco/$arch/" 2>/dev/null || true
+
+  if [ -z "$attestation" ]; then
+    attestation="$(ls -1t .redline-work/golden/*"$arch"*.golden.json 2>/dev/null | head -1 || true)"
+  fi
+  if [ -n "$attestation" ] && [ -f "$attestation" ]; then
+    cp "$attestation" "$stage/attestation.json"
+    local report="${attestation%.golden.json}.json"
+    [ -f "$report" ] && cp "$report" "$stage/product-report.json" || true
+  else
+    echo "warning: no golden attestation for $arch — package carries no reference result" >&2
+  fi
+
+  cp registry/redline-golden-v1.json "$stage/fixture-registry.json"
+
+  {
+    echo "captured_at_utc=$stamp"
+    echo "host=$(hostname)"
+    echo "kernel=$(uname -r)"
+    echo "rocm_version=$(rocm_version)"
+    # Record every device compiler on PATH. The engine fingerprints only the
+    # first line of `hipcc --version`, which on ROCm 7.14 is the HIP runtime
+    # version rather than the code generator — so capture both explicitly.
+    for cc in "${DEVICE_COMPILERS[@]}"; do
+      if command -v "$cc" >/dev/null 2>&1; then
+        echo "compiler_${cc//+/p}_path=$(command -v "$cc")"
+        echo "compiler_${cc//+/p}_version=$("$cc" --version 2>/dev/null | head -1)"
+      fi
+    done
+    echo "hipcc_version=$(first_line hipcc --version)"
+    echo "codegen_version=$(codegen_version)"
+  } > "$stage/env.txt"
+
+  rocm-smi --showallinfo > "$stage/gpu.txt" 2>&1 || amd-smi static > "$stage/gpu.txt" 2>&1 || echo unavailable > "$stage/gpu.txt"
+
+  "$PY" - "$stage" "$arch" "$stamp" "target/release/examples/daemon" "$SCHEMA_VERSION" <<'PYCAP'
+import hashlib, json, pathlib, subprocess, sys
+
+stage, arch, stamp, daemon, schema = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], int(sys.argv[5])
+stage = pathlib.Path(stage)
+
+def sha_file(p):
+    p = pathlib.Path(p)
+    if not p.exists():
+        return None
+    h = hashlib.sha256()
+    with p.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+blob_dir = stage / "hsaco" / arch
+blobs = sorted(blob_dir.glob("*.hsaco"))
+files = {b.name: sha_file(b) for b in blobs}
+mh = hashlib.sha256()
+for name in sorted(files):
+    mh.update(name.encode()); mh.update(bytes.fromhex(files[name]))
+
+reg = json.loads((stage / "fixture-registry.json").read_text())
+fixture = next((f for f in reg["fixtures"] if f["architecture"] == arch), None)
+att = stage / "attestation.json"
+env = dict(l.split("=", 1) for l in (stage / "env.txt").read_text().splitlines() if "=" in l)
+commit = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True, text=True).stdout.strip()
+
+manifest = {
+    "schema_version": schema,
+    "captured_at_utc": stamp,
+    "architecture": arch,
+    "source_commit": commit or None,
+    "daemon_sha256": sha_file(daemon),
+    "env": env,
+    "model": reg["model"],
+    "pm4_policy": reg["pm4_policy"],
+    "benchmark": (fixture or {}).get("benchmark"),
+    "acceptance": (fixture or {}).get("acceptance"),
+    "route": (fixture or {}).get("route"),
+    "hsaco": {
+        "count": len(files),
+        "total_bytes": sum(b.stat().st_size for b in blobs),
+        "manifest_sha256": mh.hexdigest(),
+        "have_hash_sidecars": bool(list(blob_dir.glob("*.hash"))),
+        "files": files,
+    },
+    "observed": json.loads(att.read_text()) if att.exists() else None,
+}
+(stage / "manifest.json").write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+print(f"  arch             {arch}")
+print(f"  source commit    {manifest['source_commit']}")
+print(f"  daemon sha256    {manifest['daemon_sha256']}")
+print(f"  code objects     {len(files)} files, {manifest['hsaco']['total_bytes']:,} bytes")
+print(f"  hsaco manifest   {mh.hexdigest()}")
+print(f"  rocm             {env.get('rocm_version','unknown')}")
+print(f"  codegen          {env.get('codegen_version','unknown')}")
+PYCAP
+
+  mkdir -p "$out_dir"
+  local tarball="$out_dir/repro-$arch-$stamp.tar.gz"
+  tar -czf "$tarball" -C "$stage" .
+  echo "package: $tarball ($(du -h "$tarball" | cut -f1))"
+}
+
+# ── verify ───────────────────────────────────────────────────────────────────
+
+unpack() {
+  local pkg="$1"
+  [ -f "$pkg" ] || die "package not found: $pkg"
+  local dir; dir="$(mktemp -d)"
+  tar -xzf "$pkg" -C "$dir"
+  [ -f "$dir/manifest.json" ] || die "no manifest.json in package: $pkg"
+  echo "$dir"
+}
+
+do_verify() {
+  local dir="$1" device="$2"
+  local local_arch; local_arch="$(detect_arch "$device" 2>/dev/null || echo unknown)"
+  local local_rocm; local_rocm="$(rocm_version)"
+  local local_hipcc; local_hipcc="$(first_line hipcc --version)"
+  local local_codegen; local_codegen="$(codegen_version)"
+  local local_commit; local_commit="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+
+  "$PY" - "$dir" "$local_arch" "$local_rocm" "$local_hipcc" "$local_codegen" \
+        "$local_commit" "target/release/examples/daemon" \
+        "${HIPFIRE_KERNEL_CACHE:-.hipfire_kernels}" <<'PYVER'
+import hashlib, json, os, pathlib, sys
+
+dir_, arch, rocm, hipcc, codegen, commit, daemon, cache = sys.argv[1:9]
+m = json.loads((pathlib.Path(dir_) / "manifest.json").read_text())
+
+def sha_file(p):
+    p = pathlib.Path(p)
+    if not p.exists():
+        return None
+    h = hashlib.sha256()
+    with p.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+rows = []
+blocking = 0
+
+def check(label, expected, actual, severity, note="", ok_note=""):
+    # note is shown only on mismatch; ok_note only when the check passes.
+    global blocking
+    if expected != actual and severity == "BLOCKING":
+        blocking += 1
+    rows.append((label, "ok" if expected == actual else severity, expected, actual, note, ok_note))
+
+check("gpu arch", m["architecture"], arch, "BLOCKING", "a different arch cannot reproduce this fixture")
+
+model = m["model"]
+model_path = pathlib.Path.home() / ".hipfire" / "models" / model["file"]
+check("model sha256", model["sha256"], sha_file(model_path), "BLOCKING", f"expected at {model_path}")
+
+# An unset PM4 var means the committed default applies, which IS the policy.
+for key, want in sorted(m.get("pm4_policy", {}).items()):
+    got = os.environ.get(key)
+    check(f"env {key}", str(want), str(want) if got is None else got, "BLOCKING",
+          note="explicitly overridden in your shell — unset it or you measure a different route",
+          ok_note="unset = committed default" if got is None else "matches policy")
+
+check("source commit", m["source_commit"], commit, "ADVISORY",
+      "differs -> route-compatible-reproduction, not exact-reference-binary")
+check("daemon sha256", m["daemon_sha256"], sha_file(daemon), "ADVISORY", "rebuild differences are expected")
+check("rocm version", m["env"].get("rocm_version"), rocm, "ADVISORY", "folded into the kernel cache hash")
+check("hipcc version", m["env"].get("hipcc_version"), hipcc, "ADVISORY",
+      "NOTE: this line is the HIP runtime version, not the code generator")
+check("codegen version", m["env"].get("codegen_version"), codegen, "ADVISORY",
+      "THIS is what actually determines the code objects; differs -> use --pin-kernels")
+
+local_dir = pathlib.Path(cache) / arch
+local_blobs = sorted(local_dir.glob("*.hsaco")) if local_dir.is_dir() else []
+local_manifest = None
+if local_blobs:
+    mh = hashlib.sha256()
+    for b in local_blobs:
+        mh.update(b.name.encode()); mh.update(bytes.fromhex(sha_file(b)))
+    local_manifest = mh.hexdigest()
+check("hsaco manifest", m["hsaco"]["manifest_sha256"], local_manifest, "ADVISORY",
+      f"{len(local_blobs)} local vs {m['hsaco']['count']} packaged code objects")
+
+w = max(len(r[0]) for r in rows)
+print()
+for label, status, expected, actual, note, ok_note in rows:
+    print(f"  {label.ljust(w)}  {status.ljust(9)}  ", end="")
+    if status == "ok":
+        print(ok_note)
+    else:
+        print(f"expected {expected!r}")
+        print(f"  {' '.ljust(w)}             actual   {actual!r}")
+        if note:
+            print(f"  {' '.ljust(w)}             note     {note}")
+
+obs = ((m.get("observed") or {}).get("validation")) or {}
+print()
+if obs:
+    print(f"  reference result:  {obs.get('classification', 'unknown')} (valid={obs.get('valid')})")
+    print(f"  reference perf:    HIP {obs['hip_median_tok_s']:.3f} -> PM4 "
+          f"{obs['pm4_median_tok_s']:.3f} tok/s ({obs['speedup']:.4f}x)")
+else:
+    print("  reference result:  none recorded")
+if m.get("acceptance"):
+    a = m["acceptance"]
+    print(f"  acceptance floors: pm4 >= {a.get('minimum_pm4_tok_s')} tok/s, speedup >= {a.get('minimum_speedup')}x")
+if m.get("route"):
+    r = m["route"]
+    print(f"  required tape:     {r.get('dispatches')} dispatches / {r.get('unique_kernels')} kernels / {r.get('sequence_hash')}")
+print()
+if blocking:
+    print(f"  {blocking} BLOCKING mismatch(es) — pass --force to proceed anyway.")
+sys.exit(2 if blocking else 0)
+PYVER
+}
+
+cmd_verify() {
+  local pkg="" device=0 force=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --package) pkg="$2"; shift 2 ;;
+      --device) device="$2"; shift 2 ;;
+      --force) force=1; shift ;;
+      -h|--help) usage 0 ;;
+      *) die "unknown verify flag: $1" ;;
+    esac
+  done
+  [ -n "$pkg" ] || die "verify requires --package"
+  local dir; dir="$(unpack "$pkg")"
+  trap 'rm -rf "$dir"' RETURN
+  local rc=0
+  do_verify "$dir" "$device" || rc=$?
+  if [ "$rc" -eq 2 ] && [ "$force" -eq 1 ]; then
+    echo "  --force: continuing despite blocking mismatches"
+    return 0
+  fi
+  return "$rc"
+}
+
+# ── run ──────────────────────────────────────────────────────────────────────
+
+cmd_run() {
+  local pkg="" device=0 force=0 pin=0
+  local -a passthrough=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --package) pkg="$2"; shift 2 ;;
+      --device) device="$2"; shift 2 ;;
+      --force) force=1; shift ;;
+      --pin-kernels) pin=1; shift ;;
+      -h|--help) usage 0 ;;
+      *) passthrough+=("$1"); shift ;;
+    esac
+  done
+  [ -n "$pkg" ] || die "run requires --package"
+  local dir; dir="$(unpack "$pkg")"
+  local SHIM_DIR=""
+  trap 'rm -rf "$dir" "${SHIM_DIR:-/nonexistent}"' RETURN
+
+  local arch
+  arch="$("$PY" -c "import json,sys;print(json.load(open(sys.argv[1]))['architecture'])" "$dir/manifest.json")"
+
+  local rc=0
+  do_verify "$dir" "$device" || rc=$?
+  if [ "$rc" -eq 2 ]; then
+    [ "$force" -eq 1 ] || { echo "  refusing to run with blocking mismatches; pass --force to override" >&2; return 2; }
+    echo "  --force: running despite blocking mismatches"
+  fi
+
+  local -a env_prefix=()
+  if [ "$pin" -eq 1 ]; then
+    mkdir -p "kernels/compiled/$arch"
+    cp "$dir/hsaco/$arch"/*.hsaco "kernels/compiled/$arch/"
+    cp "$dir/hsaco/$arch"/*.hash "kernels/compiled/$arch/" 2>/dev/null || true
+    echo "  pinned $(ls -1 "kernels/compiled/$arch"/*.hsaco 2>/dev/null | wc -l) packaged code objects -> kernels/compiled/$arch"
+
+    # Evict locally-JIT'd blobs so the pinned ones are what actually load.
+    rm -rf "${HIPFIRE_KERNEL_CACHE:-.hipfire_kernels}/$arch"
+
+    # Make the engine take the "no valid hash AND no compiler" branch so our
+    # blobs are used verbatim.
+    #
+    # Do NOT do this by deleting PATH entries: the ROCm bin directory holds the
+    # compilers AND rocminfo/rocm-smi, so dropping it breaks device detection
+    # and the bench hangs until its 1200s timeout. Instead SHADOW just the
+    # compiler names with stubs that exit non-zero. The engine's probe is
+    # `Command::new("hipcc").arg("--version")` and it keys off
+    # `status.success()`, so a failing stub is sufficient and everything else
+    # on PATH survives untouched.
+    local shim; shim="$(mktemp -d)"
+    SHIM_DIR="$shim"
+    local cc
+    for cc in "${DEVICE_COMPILERS[@]}"; do
+      printf '#!/bin/sh\nexit 1\n' > "$shim/$cc"
+      chmod +x "$shim/$cc"
+    done
+    env_prefix=(env "PATH=$shim:$PATH")
+    echo "  shadowed device compilers with failing stubs (${DEVICE_COMPILERS[*]})"
+    echo "  rocminfo/rocm-smi and the rest of PATH are left intact"
+    echo "  the engine will warn 'Output may be incorrect' — that is EXPECTED here"
+    echo "  and is the confirmation that OUR code objects are executing."
+  fi
+
+  echo
+  echo "  running golden fixture for $arch ..."
+  "${env_prefix[@]}" "$PY" scripts/golden-redline.py --arch "$arch" ${passthrough[@]+"${passthrough[@]}"}
+}
+
+[ $# -gt 0 ] || usage 1
+case "$1" in
+  capture) shift; cmd_capture "$@" ;;
+  verify)  shift; cmd_verify "$@" ;;
+  run)     shift; cmd_run "$@" ;;
+  -h|--help) usage 0 ;;
+  *) die "unknown subcommand: $1 (expected capture|verify|run)" ;;
+esac


### PR DESCRIPTION
Two related commits. The second was discovered while building the first.

---

## 1. `fix(rocm)`: centralise ROCm installation discovery

Every call site resolved ROCm differently, and most only worked on a literal `/opt/rocm`:

| site | what it did |
|---|---|
| `hip-bridge` (Linux) | asked the loader for a bare `libamdhip64.so`, **no root resolution at all** — worked only if `LD_LIBRARY_PATH`/ldconfig already pointed at ROCm. The doc comment claimed it searched `/opt/rocm/lib`; it did not. `HIP_PATH` was Windows-only. |
| `hsa-bridge` | hardcoded `/opt/rocm/lib/libhsa-runtime64.so*` |
| `rocblas`, `rccl` | hardcoded `/opt/rocm/lib/*` |
| `rdna-compute` | bare `hipcc` off `PATH` |

That breaks on side-by-side installs (`/opt/rocm-6.4`) and on the `/opt/rocm/core-<ver>` layout used when a host ROCm is overmounted into a container — **the layout this fleet actually runs**. The symptom is a confusing "Is ROCm installed?" on a machine where it plainly is.

New `hipfire_config::rocm` owns the policy:

1. `HIPFIRE_ROCM_PATH` — explicit override, always wins
2. `ROCM_PATH`
3. `HIP_PATH` — trailing `hip` component stripped
4. parent of a device compiler found on `PATH`
5. `/opt/rocm`
6. versioned siblings `/opt/rocm-*` and `/opt/rocm/core-*`, newest first (`core-7.14` beats `core-7`)

`library_candidates()` puts resolved roots first and **bare sonames last**, so a correctly configured loader path keeps working exactly as before — additive, not a redirect.

`compiler.rs` is deliberately more conservative: `PATH` stays authoritative so an explicit `module load` still wins; the resolved root is consulted **only** when `PATH` has no hipcc at all — the case that previously degraded silently to `has_hipcc=false` and disabled JIT.

`DEVICE_COMPILERS` lists `amdclang++`/`amdclang`/`clang++` alongside `hipcc`, since hipcc is being wound down upstream and on ROCm 7.14 is already an ELF wrapper around `amdclang++`.

### Verified on hiptrx (ROCm 7.14 at `/opt/rocm/core-7.14`)

```
roots:      /opt/rocm, /opt/rocm/core-7.14, /opt/rocm/core-7   (newest first)
version():  "7.14.0"                     <- /opt/rocm/.info/version DOES NOT EXIST here
tool(hipcc): /opt/rocm/core-7.14/bin/hipcc  <- /opt/rocm/bin/hipcc DOES NOT EXIST here
candidates: /opt/rocm/core-7.14/lib/libamdhip64.so   (exists, symlink -> .so.7)
            /opt/rocm/core-7/lib/libamdhip64.so
            libamdhip64.so                            (loader fallback, last)
```

Version detection and tool discovery both succeed at paths where the previous hardcoded logic returned `unknown` / found nothing.

**Scope honesty:** the library-*loading* improvement is not proven in anger on this box, because `libamdhip64.so` is already in its ldconfig cache (`/opt/rocm/core/lib/`) — so a no-PATH run succeeds via the loader either way. What is verified is that the first resolved candidate exists, so the resolution would succeed on a box without ldconfig coverage. `gpus_smoke` enumerates both GPUs identically before and after, i.e. no regression.

5 unit tests cover version ordering, `HIP_PATH` normalisation, sibling scanning (including that a matching *regular file* isn't mistaken for a root), the bare-soname-last invariant, and root dedup. They use a synthetic tree and need no ROCm.

---

## 2. `feat(redline)`: reproduction package for golden-fixture disputes

`golden-redline.py` pins the model, sampling profile, benchmark contract, PM4 policy and route identity — but **not the compiled code objects or the host toolchain**. That is exactly where the gfx1201 dispute lives: @taniguchi-taku-softm reports PM4 slower than HIP with a **byte-identical tape** (733 dispatches / 23 kernels / `3318ffca3daf2338`, same 20,511 command DWORDs), same commit, same model SHA-256, same ROCm 7.14.

| subcommand | does |
|---|---|
| `capture` | ~156 KB package: 46 code objects + manifest hash, ROCm and codegen versions, GPU state, PM4 policy, floors, required tape, attestation |
| `verify` | BLOCKING (arch, model SHA-256, PM4 policy) vs ADVISORY (commit, daemon hash, ROCm, codegen, code-object manifest); exits 2, `--force` overrides |
| `run` | verify then run; `--pin-kernels` makes the engine execute **our** binaries |

### Validated on hiptrx (gfx1201 R9700)

| test | result |
|---|---|
| capture | 46 objects / 655,304 B / manifest `c111fc7b17e40017` |
| self-verify | zero mismatches, exit 0 |
| PM4 policy override | BLOCKING, exit 2 |
| `--force` | exit 0 |
| wrong arch | BLOCKING |
| `--pin-kernels` | **0 recompile events**, 1 precompiled-accept warning, warm-up 20.40s → 2.41s |
| pinned fixture run | HIP 171.241 → PM4 **202.160 tok/s (1.18056x)**, valid=True |

Zero recompiles plus the shortened warm-up is the proof the packaged objects executed rather than being rebuilt locally.

Pinning works because of this ordering in `compiler.rs`:

```
precompiled kernels/compiled/<arch>/<name>.hsaco exists?
  .hash sidecar matches src_hash        -> use it
  no valid hash AND no device compiler  -> use it, engine warns
  no valid hash AND compiler present    -> RECOMPILE (pinning defeated)
```

`--pin-kernels` installs the blobs and **shadows compiler names with failing stubs**. It deliberately does *not* delete PATH entries: the ROCm `bin/` holds the compilers alongside `rocminfo`/`rocm-smi`, and my first attempt dropped the whole directory, which stripped device detection and hung the bench until its 1200 s timeout. `has_hipcc` keys off `status.success()`, so a stub that exits 1 is sufficient and surgical.

---

## Follow-up not fixed here

`toolchain_id` is the **first line of `hipcc --version`**, which on ROCm 7.14 is `HIP version: 7.14.60850-0000000` — the HIP *runtime* version, not the code generator. Two ROCm builds sharing a HIP version but differing in clang hash identically, which is precisely the "invalid device image" trap the field exists to prevent. `amdclang++ --version` line 1 *is* the compiler identity, so moving the engine to the LLVM driver fixes this as a side effect.

## Test plan

- [x] `cargo check --workspace --all-targets --locked` clean
- [x] 1,125 workspace lib tests pass (1,120 + 5 new resolver tests)
- [x] `bash -n` + `shellcheck -S warning` clean on the script
- [x] Script exit codes: usage → 1, `--help` → 0, blocking → 2, `--force` → 0
- [x] Live rebuild + `gpus_smoke` on gfx1201: both GPUs enumerate, no regression
- [x] End-to-end capture → verify → `run --pin-kernels` on real hardware
- [ ] A contributor who cannot reproduce runs `--pin-kernels` and reports whether it changes their result
