### PR TITLE
fix(rocm): ROCM_PATH for device compiler + explicit disable; publish gfx1201 reference config

### DIFF
--- a/crates/hipfire-config/src/rocm.rs
+++ b/crates/hipfire-config/src/rocm.rs
@@ -210,6 +210,43 @@ pub fn device_compiler() -> Option<PathBuf> {
     DEVICE_COMPILERS.iter().find_map(|c| tool(c))
 }
 
+/// `ROCM_PATH` value a spawned device compiler needs, or `None` when the
+/// environment already sets it.
+///
+/// `hipcc` locates its own LLVM as `$ROCM_PATH/lib/llvm/bin/clang++`, and
+/// `ROCM_PATH` defaults to `/opt/rocm`. On an install rooted elsewhere —
+/// `/opt/rocm/core` on this fleet — `hipcc` is found on PATH, reports a
+/// correct `--version`, and then fails every compile with
+///
+///   sh: 1: /opt/rocm/lib/llvm/bin/clang++: not found
+///
+/// so `has_hipcc` is true and JIT is broken anyway. Resolving hipcc's path
+/// (see [`tool`]) is not sufficient; the child process needs the root too.
+///
+/// Returns `None` when `ROCM_PATH` is already set, so an explicit operator
+/// choice is never overridden.
+pub fn compiler_env_root() -> Option<PathBuf> {
+    if std::env::var_os("ROCM_PATH").is_some_and(|v| !v.is_empty()) {
+        return None;
+    }
+    root()
+}
+
+#[cfg(test)]
+mod compiler_env_tests {
+    use super::*;
+
+    #[test]
+    fn compiler_env_root_defers_to_an_explicit_rocm_path() {
+        // Not asserting the Some(..) branch: it depends on the host's real
+        // /opt/rocm layout. The contract that matters is that an operator's
+        // ROCM_PATH is never overridden.
+        if std::env::var_os("ROCM_PATH").is_some_and(|v| !v.is_empty()) {
+            assert!(compiler_env_root().is_none());
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rdna-compute/src/compiler.rs
+++ b/crates/rdna-compute/src/compiler.rs
@@ -101,6 +101,9 @@ pub struct KernelCompiler {
     /// Resolved device-compiler binary. Bare "hipcc" when PATH provides it;
     /// otherwise an absolute path discovered under a resolved ROCm root.
     hipcc_bin: std::path::PathBuf,
+    /// ROCM_PATH handed to the spawned compiler so it can find its own LLVM.
+    /// None when the environment already sets it.
+    rocm_env_root: Option<std::path::PathBuf>,
 }
 
 impl KernelCompiler {
@@ -209,7 +212,41 @@ impl KernelCompiler {
         } else {
             hipfire_config::rocm::tool("hipcc").unwrap_or_else(|| "hipcc".into())
         };
-        let hipcc_out = Command::new(&hipcc_bin).arg("--version").output().ok();
+        // hipcc resolves its LLVM as $ROCM_PATH/lib/llvm/bin/clang++ and
+        // ROCM_PATH defaults to /opt/rocm. On a root elsewhere the probe below
+        // still succeeds while every real compile fails, so hand the child the
+        // resolved root unless the operator already set one.
+        let rocm_env_root = hipfire_config::rocm::compiler_env_root();
+
+        // HIPFIRE_NO_DEVICE_COMPILER=1 makes the engine behave as if no device
+        // compiler exists, so pre-compiled blobs are used verbatim instead of
+        // being recompiled locally.
+        //
+        // This has to be an explicit switch. It used to be achievable by
+        // removing the compiler from PATH, because the probe was a bare
+        // `Command::new("hipcc")`. Resolved-root discovery (added so a ROCm
+        // rooted outside /opt/rocm still works) finds the compiler regardless
+        // of PATH, which silently defeated PATH-shadowing and made
+        // "pin these exact code objects" quietly recompile instead. Verified:
+        // a pinned cross-machine run reported 0 recompiles while actually
+        // executing locally-built blobs.
+        let compiler_disabled = std::env::var_os("HIPFIRE_NO_DEVICE_COMPILER")
+            .is_some_and(|v| v != "0" && !v.is_empty());
+
+        let hipcc_out = if compiler_disabled {
+            eprintln!(
+                "  HIPFIRE_NO_DEVICE_COMPILER set — treating the device compiler as absent; \
+                 pre-compiled blobs will be used verbatim"
+            );
+            None
+        } else {
+            let mut probe = Command::new(&hipcc_bin);
+            probe.arg("--version");
+            if let Some(ref root) = rocm_env_root {
+                probe.env("ROCM_PATH", root);
+            }
+            probe.output().ok()
+        };
         let has_hipcc = hipcc_out
             .as_ref()
             .map(|o| o.status.success())
@@ -250,6 +287,7 @@ impl KernelCompiler {
             precompiled_dir,
             has_hipcc,
             hipcc_bin,
+            rocm_env_root,
             extra_flags,
             gfx1151_cumode_modules,
             toolchain_id,
@@ -349,6 +387,7 @@ impl KernelCompiler {
         if !cache_valid {
             Self::hipcc_compile(
                 &self.hipcc_bin,
+                self.rocm_env_root.as_deref(),
                 &self.arch,
                 &src_path,
                 &obj_path,
@@ -468,6 +507,7 @@ impl KernelCompiler {
     /// Run hipcc for a single kernel. Shared by compile() and compile_batch().
     fn hipcc_compile(
         hipcc_bin: &Path,
+        rocm_env_root: Option<&Path>,
         arch: &str,
         src_path: &Path,
         obj_path: &Path,
@@ -531,8 +571,12 @@ impl KernelCompiler {
         args.push(obj_path.to_str().unwrap().into());
         args.push(src_path.to_str().unwrap().into());
 
-        let output = Command::new(hipcc_bin)
-            .args(&args)
+        let mut cmd = Command::new(hipcc_bin);
+        cmd.args(&args);
+        if let Some(root) = rocm_env_root {
+            cmd.env("ROCM_PATH", root);
+        }
+        let output = cmd
             .output()
             .map_err(|e| hip_bridge::HipError::new(0, &format!("failed to run hipcc: {e}")))?;
 
@@ -635,6 +679,7 @@ impl KernelCompiler {
         let arch = self.arch.clone();
         let precompiled_dir = self.precompiled_dir.clone();
         let hipcc_bin = self.hipcc_bin.clone();
+        let rocm_env_root = self.rocm_env_root.clone();
 
         // Shared counter so parallel threads can report "[i/N] name" as each one
         // completes. Ordering follows completion (not launch) — matches the pace
@@ -649,11 +694,13 @@ impl KernelCompiler {
                     let arch = arch.clone();
                     let precompiled_dir = precompiled_dir.clone();
                     let hipcc_bin = hipcc_bin.clone();
+                    let rocm_env_root = rocm_env_root.clone();
                     let extra_flags = self.extra_flags.clone();
                     let done = std::sync::Arc::clone(&done);
                     let handle = thread::spawn(move || {
                         let result = Self::hipcc_compile(
                             &hipcc_bin,
+                            rocm_env_root.as_deref(),
                             &arch,
                             &src_path,
                             &obj_path,
@@ -716,6 +763,7 @@ mod tests {
             gfx1151_cumode_modules: HashSet::new(),
             toolchain_id: toolchain_id.to_string(),
             hipcc_bin: PathBuf::from("hipcc"),
+            rocm_env_root: None,
         }
     }
 

--- a/crates/redline-dispatch/src/aql/replay.rs
+++ b/crates/redline-dispatch/src/aql/replay.rs
@@ -6,13 +6,13 @@ use std::time::Duration;
 
 use redline_rocr::abi;
 use redline_rocr::packet::{
-    BARRIER_DEPENDENCY_CAPACITY, BarrierAndPacket, KernelDispatchPacket, LaunchGeometry,
-    PacketError, PacketImage,
+    BarrierAndPacket, KernelDispatchPacket, LaunchGeometry, PacketError, PacketImage,
+    BARRIER_DEPENDENCY_CAPACITY,
 };
 use redline_rocr::{
-    CompletionSignal, DEFAULT_WAIT_TIMEOUT, Gfx10Pm4CommandBuffer, Gfx12Pm4CommandBuffer,
-    GpuDevice, HeaderPolicy, KernargBuffer, KernargPool, Kernel, QueueDepthReport, QueueSet,
-    RuntimeError,
+    CompletionSignal, Gfx10Pm4CommandBuffer, Gfx12Pm4CommandBuffer, GpuDevice, HeaderPolicy,
+    KernargBuffer, KernargPool, Kernel, Pm4BuildError, QueueDepthReport, QueueSet, RuntimeError,
+    DEFAULT_WAIT_TIMEOUT,
 };
 
 fn retained_queue_size(
@@ -127,6 +127,40 @@ impl SingleQueuePm4Ib {
             commands.len_dwords(),
             None,
             None,
+        )
+    }
+
+    /// Build a retained tape instrumented with one GPU-clock write per
+    /// dispatch, for attribution rather than certification.
+    ///
+    /// The resulting tape has a different dword count and sequence hash than
+    /// the certified route, so it cannot satisfy a golden fixture — that is
+    /// inherent, not an oversight. Pair with [`replay_and_wait_dispatch_spans`].
+    pub fn create_dispatch_profiled(
+        device: &GpuDevice,
+        pool: &KernargPool,
+        commands: &Gfx12Pm4CommandBuffer,
+    ) -> Result<Self, ReplayError> {
+        if commands.is_empty() {
+            return Err(ReplayError::EmptyGraph);
+        }
+        let slots = commands
+            .timestamp_slot_count()
+            .map_err(ReplayError::Pm4Build)?;
+        let mut timestamps = pool.allocate_executable_bytes(slots * 8)?;
+        timestamps.as_mut_bytes().fill(0);
+        let base = timestamps.address() as usize as u64;
+        let timed = commands
+            .with_per_dispatch_timestamps(base)
+            .map_err(ReplayError::Pm4Build)?;
+        let frequency_hz = device.gpu_timestamp_frequency_hz()?;
+        Self::create_encoded(
+            device,
+            pool,
+            &timed.as_bytes(),
+            timed.len_dwords(),
+            Some(timestamps),
+            Some(frequency_hz),
         )
     }
 
@@ -317,6 +351,47 @@ impl SingleQueuePm4Ib {
             last_end: end,
             frequency_hz,
         })
+    }
+
+    /// Replay once and return per-dispatch GPU-clock spans in nanoseconds.
+    ///
+    /// `spans[i]` is the interval from the timestamp written before dispatch
+    /// `i` to the one written after it, so the sum is the whole retained span
+    /// and the distribution shows whether a deficit is spread evenly across
+    /// dispatches or concentrated in a few.
+    ///
+    /// Requires a tape built by [`create_dispatch_profiled`]. A tape with only
+    /// the two bracketing timestamps yields a single span, which is what
+    /// [`replay_and_wait_profiled`] already reports.
+    pub unsafe fn replay_and_wait_dispatch_spans(&mut self) -> Result<Vec<u64>, ReplayError> {
+        let frequency_hz = self
+            .timestamp_frequency_hz
+            .ok_or(ReplayError::ProfilingUnavailable)?;
+        // SAFETY: forwarded from this method's caller.
+        unsafe { self.replay_and_wait_inner()? };
+        let bytes = self
+            .timestamps
+            .as_mut()
+            .ok_or(ReplayError::ProfilingUnavailable)?
+            .as_mut_bytes();
+        let ticks: Vec<u64> = bytes
+            .chunks_exact(8)
+            .map(|word| u64::from_le_bytes(word.try_into().unwrap()))
+            .collect();
+        if ticks.len() < 2 {
+            return Err(ReplayError::ProfilingUnavailable);
+        }
+        let mut spans = Vec::with_capacity(ticks.len() - 1);
+        for pair in ticks.windows(2) {
+            let (start, end) = (pair[0], pair[1]);
+            // A zero or non-monotonic pair means the write did not land; report
+            // it rather than silently producing a plausible-looking number.
+            if start == 0 || end < start {
+                return Err(ReplayError::InvalidGpuTimestamp { start, end });
+            }
+            spans.push((end - start).saturating_mul(1_000_000_000) / frequency_hz);
+        }
+        Ok(spans)
     }
 
     unsafe fn replay_and_wait_inner(&mut self) -> Result<(), ReplayError> {
@@ -512,8 +587,9 @@ impl PhasedMultiQueuePm4Ib {
             .any(|commands| !commands.ends_with_compute_idle())
         {
             return Err(ReplayError::PolicyShapeMismatch {
-                detail: "native PM4 semaphore publication requires every phase lane to end compute-idle"
-                    .to_owned(),
+                detail:
+                    "native PM4 semaphore publication requires every phase lane to end compute-idle"
+                        .to_owned(),
             });
         }
         let queue_count = phases.iter().map(Vec::len).max().unwrap();
@@ -525,15 +601,19 @@ impl PhasedMultiQueuePm4Ib {
         let parallel_phase_count = phases.iter().filter(|phase| phase.len() > 1).count();
         if parallel_phase_count == 1 {
             return Err(ReplayError::PolicyShapeMismatch {
-                detail: "native PM4 retained epochs require either zero or at least two parallel phases"
-                    .to_owned(),
+                detail:
+                    "native PM4 retained epochs require either zero or at least two parallel phases"
+                        .to_owned(),
             });
         }
-        let semaphore_bytes = (queue_count - 1)
-            .checked_mul(8)
-            .ok_or_else(|| ReplayError::PolicyShapeMismatch {
-                detail: format!("native PM4 semaphore count for {queue_count} queues overflowed"),
-            })?;
+        let semaphore_bytes =
+            (queue_count - 1)
+                .checked_mul(8)
+                .ok_or_else(|| ReplayError::PolicyShapeMismatch {
+                    detail: format!(
+                        "native PM4 semaphore count for {queue_count} queues overflowed"
+                    ),
+                })?;
         let mut semaphores = pool.allocate_executable_bytes(semaphore_bytes)?;
         semaphores.as_mut_bytes().fill(0);
         let semaphore_base = semaphores.address() as usize as u64;
@@ -549,11 +629,12 @@ impl PhasedMultiQueuePm4Ib {
                 streams[0].append_stream(&phase[0]);
                 continue;
             }
-            parallel_epoch = parallel_epoch.checked_add(1).ok_or_else(|| {
-                ReplayError::PolicyShapeMismatch {
-                    detail: "native PM4 parallel phase count exceeds u32".to_owned(),
-                }
-            })?;
+            parallel_epoch =
+                parallel_epoch
+                    .checked_add(1)
+                    .ok_or_else(|| ReplayError::PolicyShapeMismatch {
+                        detail: "native PM4 parallel phase count exceeds u32".to_owned(),
+                    })?;
             for lane in 1..phase.len() {
                 let (start, _) = semaphore_addresses(lane);
                 streams[lane].wait_memory_value(start, parallel_epoch);
@@ -601,11 +682,8 @@ impl PhasedMultiQueuePm4Ib {
             let mut indirect = pool.allocate_executable_bytes(bytes.len())?;
             indirect.write_exact(&bytes)?;
             let completion = CompletionSignal::new(device)?;
-            let packet = PacketImage::pm4_indirect_buffer(
-                indirect.address(),
-                dwords,
-                completion.raw(),
-            )?;
+            let packet =
+                PacketImage::pm4_indirect_buffer(indirect.address(), dwords, completion.raw())?;
             timestamps.push(timestamp);
             indirects.push(indirect);
             completions.push(completion);
@@ -2870,6 +2948,9 @@ fn validate_nodes(
 pub enum ReplayError {
     Runtime(RuntimeError),
     Packet(PacketError),
+    /// PM4 stream construction failed. Only reachable from the diagnostic
+    /// per-dispatch timestamp path.
+    Pm4Build(Pm4BuildError),
     EmptyGraph,
     EmptyPhaseSet,
     EmptyTokenBatch,
@@ -2957,6 +3038,7 @@ impl fmt::Display for ReplayError {
         match self {
             Self::Runtime(error) => error.fmt(f),
             Self::Packet(error) => error.fmt(f),
+            Self::Pm4Build(error) => error.fmt(f),
             Self::EmptyGraph => write!(f, "cannot record an empty AQL graph"),
             Self::EmptyPhaseSet => write!(f, "two-queue replay requires at least one phase"),
             Self::EmptyTokenBatch => {

--- a/crates/redline-dispatch/src/aql/replay.rs
+++ b/crates/redline-dispatch/src/aql/replay.rs
@@ -6,13 +6,13 @@ use std::time::Duration;
 
 use redline_rocr::abi;
 use redline_rocr::packet::{
-    BarrierAndPacket, KernelDispatchPacket, LaunchGeometry, PacketError, PacketImage,
-    BARRIER_DEPENDENCY_CAPACITY,
+    BARRIER_DEPENDENCY_CAPACITY, BarrierAndPacket, KernelDispatchPacket, LaunchGeometry,
+    PacketError, PacketImage,
 };
 use redline_rocr::{
-    CompletionSignal, Gfx10Pm4CommandBuffer, Gfx12Pm4CommandBuffer, GpuDevice, HeaderPolicy,
-    KernargBuffer, KernargPool, Kernel, Pm4BuildError, QueueDepthReport, QueueSet, RuntimeError,
-    DEFAULT_WAIT_TIMEOUT,
+    CompletionSignal, DEFAULT_WAIT_TIMEOUT, Gfx10Pm4CommandBuffer, Gfx12Pm4CommandBuffer,
+    GpuDevice, HeaderPolicy, KernargBuffer, KernargPool, Kernel, Pm4BuildError, QueueDepthReport,
+    QueueSet, RuntimeError,
 };
 
 fn retained_queue_size(

--- a/crates/redline-rocr/src/abi.rs
+++ b/crates/redline-rocr/src/abi.rs
@@ -6,7 +6,7 @@
 //! Keeping this module small is intentional: it is an auditable dynamic-ABI
 //! boundary, not a replacement for generated HSA bindings.
 
-use std::ffi::{CStr, c_char, c_void};
+use std::ffi::{c_char, c_void, CStr};
 use std::fmt;
 use std::sync::Arc;
 
@@ -63,8 +63,13 @@ pub const KERNEL_DISPATCH_SETUP_DIMENSIONS: u16 = 0;
 pub const AMD_SEGMENT_GLOBAL: u32 = 0;
 pub const AMD_MEMORY_POOL_GLOBAL_FLAG_KERNARG_INIT: u32 = 1;
 pub const AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED: u32 = 2;
+/// `HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED` — device-local placement.
+/// Diagnostic only: the retained IB pool is expected to be fine-grained.
+pub const AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED: u32 = 4;
 pub const AMD_MEMORY_POOL_INFO_SEGMENT: u32 = 0;
 pub const AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS: u32 = 1;
+/// `HSA_AMD_MEMORY_POOL_INFO_SIZE`.
+pub const AMD_MEMORY_POOL_INFO_SIZE: u32 = 2;
 pub const AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALLOWED: u32 = 5;
 pub const AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_GRANULE: u32 = 6;
 pub const AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALIGNMENT: u32 = 7;

--- a/crates/redline-rocr/src/abi.rs
+++ b/crates/redline-rocr/src/abi.rs
@@ -6,7 +6,7 @@
 //! Keeping this module small is intentional: it is an auditable dynamic-ABI
 //! boundary, not a replacement for generated HSA bindings.
 
-use std::ffi::{c_char, c_void, CStr};
+use std::ffi::{CStr, c_char, c_void};
 use std::fmt;
 use std::sync::Arc;
 

--- a/crates/redline-rocr/src/pm4.rs
+++ b/crates/redline-rocr/src/pm4.rs
@@ -119,6 +119,71 @@ impl Gfx12Pm4CommandBuffer {
         timed
     }
 
+    /// Return a copy with a GPU-clock write after every `DISPATCH_DIRECT`,
+    /// plus one before the first, so `N` dispatches yield `N + 1` timestamps
+    /// and `N` per-dispatch deltas at `base_address + slot * 8`.
+    ///
+    /// Diagnostic only, and deliberately not on any certified path:
+    ///
+    ///   * it changes the tape — dword count and sequence hash both move — so
+    ///     an instrumented run can never satisfy a golden fixture identity;
+    ///   * it is an observer effect. On the 0.8b route (338 dispatches, ~5 us
+    ///     each) a sub-microsecond COPY_DATA per dispatch is a measurable
+    ///     fraction of the thing being measured, and it grows the IB ~21%.
+    ///
+    /// It answers a question end-to-end throughput cannot: whether a deficit is
+    /// spread evenly across dispatches (per-dispatch overhead) or concentrated
+    /// in a few (a barrier or cache-release stall).
+    pub fn with_per_dispatch_timestamps(&self, base_address: u64) -> Result<Self, Pm4BuildError> {
+        let mut timed = Self::new();
+        let mut slot = 0_u64;
+        timed.copy_gpu_timestamp(base_address);
+        slot += 1;
+
+        let mut cursor = 0_usize;
+        while cursor < self.dwords.len() {
+            let header = self.dwords[cursor];
+            if header >> 30 != 3 {
+                return Err(Pm4BuildError::MalformedStream { dword: cursor });
+            }
+            let body = ((header >> 16) & 0x3fff) as usize + 1;
+            let next = cursor
+                .checked_add(1 + body)
+                .filter(|end| *end <= self.dwords.len())
+                .ok_or(Pm4BuildError::MalformedStream { dword: cursor })?;
+            timed.dwords.extend_from_slice(&self.dwords[cursor..next]);
+            if (header >> 8) & 0xff == PACKET3_DISPATCH_DIRECT {
+                timed.copy_gpu_timestamp(base_address + slot * 8);
+                slot += 1;
+            }
+            cursor = next;
+        }
+        Ok(timed)
+    }
+
+    /// Timestamp slots [`with_per_dispatch_timestamps`] would write: one per
+    /// dispatch plus a leading baseline. Callers size the buffer with this.
+    pub fn timestamp_slot_count(&self) -> Result<usize, Pm4BuildError> {
+        let mut slots = 1_usize;
+        let mut cursor = 0_usize;
+        while cursor < self.dwords.len() {
+            let header = self.dwords[cursor];
+            if header >> 30 != 3 {
+                return Err(Pm4BuildError::MalformedStream { dword: cursor });
+            }
+            let body = ((header >> 16) & 0x3fff) as usize + 1;
+            let next = cursor
+                .checked_add(1 + body)
+                .filter(|end| *end <= self.dwords.len())
+                .ok_or(Pm4BuildError::MalformedStream { dword: cursor })?;
+            if (header >> 8) & 0xff == PACKET3_DISPATCH_DIRECT {
+                slots += 1;
+            }
+            cursor = next;
+        }
+        Ok(slots)
+    }
+
     fn copy_gpu_timestamp(&mut self, address: u64) {
         const COPY_DATA_TIMESTAMP_TO_MEMORY_64: u32 = 9 | (5 << 8) | (1 << 16) | (1 << 20);
         self.dwords.extend_from_slice(&[
@@ -339,6 +404,11 @@ pub enum Pm4BuildError {
     NullKernarg,
     GroupSegmentOverflow,
     GroupSegmentTooLarge(u32),
+    /// Packet walk hit a non-PACKET3 header or a length running past the end.
+    /// Only reachable from the diagnostic timestamp path.
+    MalformedStream {
+        dword: usize,
+    },
 }
 
 impl fmt::Display for Pm4BuildError {
@@ -366,6 +436,9 @@ impl fmt::Display for Pm4BuildError {
                 formatter,
                 "group segment size {bytes} cannot be encoded in GFX12 COMPUTE_PGM_RSRC2"
             ),
+            Self::MalformedStream { dword } => {
+                write!(formatter, "malformed PM4 stream at dword {dword}")
+            }
         }
     }
 }
@@ -374,6 +447,71 @@ impl std::error::Error for Pm4BuildError {}
 
 #[cfg(test)]
 mod tests {
+
+    /// Build a stream of `n` DISPATCH_DIRECT packets separated by a filler
+    /// packet, so the walk has to respect packet lengths rather than scanning
+    /// for opcodes.
+    fn synthetic_stream(n: usize) -> Gfx12Pm4CommandBuffer {
+        let mut buffer = Gfx12Pm4CommandBuffer::new();
+        for _ in 0..n {
+            // filler: SET_SH_REG-shaped, 2 body dwords
+            buffer.dwords.push(packet3(PACKET3_SET_SH_REG, 2, false));
+            buffer.dwords.extend_from_slice(&[0xdead, 0xbeef]);
+            // dispatch: 4 body dwords, matching the real emitter
+            buffer
+                .dwords
+                .push(packet3(PACKET3_DISPATCH_DIRECT, 4, true));
+            buffer.dwords.extend_from_slice(&[1, 1, 1, 0]);
+        }
+        buffer
+    }
+
+    #[test]
+    fn per_dispatch_timestamps_emit_one_slot_per_dispatch_plus_baseline() {
+        for n in [1_usize, 3, 8] {
+            let plain = synthetic_stream(n);
+            assert_eq!(plain.timestamp_slot_count().unwrap(), n + 1);
+            let timed = plain.with_per_dispatch_timestamps(0x1000).unwrap();
+
+            // Every original dword survives, in order, as a subsequence.
+            let mut it = timed.dwords().iter();
+            for want in plain.dwords() {
+                assert!(it.any(|got| got == want), "original dword {want:#x} lost");
+            }
+
+            // One COPY_DATA per slot, addresses stepping by 8 from the base.
+            let copies: Vec<usize> = timed
+                .dwords()
+                .iter()
+                .enumerate()
+                .filter(|(_, word)| **word == packet3(PACKET3_COPY_DATA, 5, false))
+                .map(|(index, _)| index)
+                .collect();
+            assert_eq!(copies.len(), n + 1, "expected {} timestamp writes", n + 1);
+            for (slot, index) in copies.iter().enumerate() {
+                let want = 0x1000_u64 + slot as u64 * 8;
+                let lo = timed.dwords()[index + 4] as u64;
+                let hi = timed.dwords()[index + 5] as u64;
+                assert_eq!(lo | (hi << 32), want, "slot {slot} address");
+            }
+        }
+    }
+
+    #[test]
+    fn per_dispatch_timestamps_reject_a_malformed_stream() {
+        let mut bad = Gfx12Pm4CommandBuffer::new();
+        bad.dwords.push(0x0000_0000); // not a PACKET3 header
+        assert!(matches!(
+            bad.with_per_dispatch_timestamps(0x1000),
+            Err(Pm4BuildError::MalformedStream { dword: 0 })
+        ));
+        // A length running past the end must be rejected, not truncated.
+        let mut overrun = Gfx12Pm4CommandBuffer::new();
+        overrun
+            .dwords
+            .push(packet3(PACKET3_DISPATCH_DIRECT, 4, true));
+        assert!(overrun.with_per_dispatch_timestamps(0x1000).is_err());
+    }
     use super::*;
 
     #[test]

--- a/crates/redline-rocr/src/runtime.rs
+++ b/crates/redline-rocr/src/runtime.rs
@@ -992,11 +992,7 @@ impl AqlQueue {
         let status = unsafe {
             (self.runtime().symbols.queue_cu_set_mask)(self.raw.as_ptr(), mask_bits, mask.as_ptr())
         };
-        check_status(
-            &self.runtime().symbols,
-            "hsa_amd_queue_cu_set_mask",
-            status,
-        )
+        check_status(&self.runtime().symbols, "hsa_amd_queue_cu_set_mask", status)
     }
 
     fn depth_sample(&self) -> QueueDepthSample {
@@ -1418,7 +1414,6 @@ impl QueueSet {
         }
     }
 }
-
 
 #[derive(Clone)]
 pub struct KernargPool {

--- a/crates/redline-rocr/src/runtime.rs
+++ b/crates/redline-rocr/src/runtime.rs
@@ -1419,6 +1419,7 @@ impl QueueSet {
     }
 }
 
+
 #[derive(Clone)]
 pub struct KernargPool {
     inner: Arc<KernargPoolInner>,
@@ -1503,6 +1504,46 @@ impl KernargPool {
             if granule == 0 || !alignment.is_power_of_two() {
                 continue;
             }
+            // The retained PM4 indirect buffer is allocated from THIS pool
+            // (SingleQueuePm4Ib::indirect is a KernargBuffer), so the command
+            // processor re-fetches the whole IB from host-agent memory on every
+            // replay. Ordinary HIP dispatch does not do that, which makes the
+            // retained path far more sensitive to host-memory and PCIe
+            // behaviour than the HIP arm — and that behaviour is an amdgpu
+            // decision. Set HIPFIRE_REDLINE_POOL_DEBUG=1 to report exactly
+            // which pool a machine selected, so two boxes reporting different
+            // retained throughput can be compared on placement rather than
+            // guessed at.
+            if std::env::var_os("HIPFIRE_REDLINE_POOL_DEBUG")
+                .is_some_and(|v| v != "0" && !v.is_empty())
+            {
+                let mut size = 0_usize;
+                let _ = query_pool(
+                    &device.runtime.symbols,
+                    pool,
+                    abi::AMD_MEMORY_POOL_INFO_SIZE,
+                    (&mut size as *mut usize).cast(),
+                );
+                let kind = if flags & abi::AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED != 0 {
+                    "fine-grained"
+                } else if flags & abi::AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED != 0 {
+                    "coarse-grained"
+                } else {
+                    "unflagged"
+                };
+                eprintln!(
+                    "[redline] retained-IB pool: handle=0x{:x} owner=CPU-agent segment=global \
+                     kind={kind} kernarg_init={} flags=0x{flags:08x} size={size} \
+                     granule={granule} alignment={alignment}",
+                    pool.0,
+                    flags & abi::AMD_MEMORY_POOL_GLOBAL_FLAG_KERNARG_INIT != 0,
+                );
+                eprintln!(
+                    "[redline] the retained indirect buffer lives in this pool, so the command \
+                     processor fetches it over the host interface on every replay"
+                );
+            }
+
             return Ok(Self {
                 inner: Arc::new(KernargPoolInner {
                     runtime: device.runtime.clone(),
@@ -1529,6 +1570,16 @@ impl KernargPool {
     /// Allocate CPU-writable, GPU-accessible command memory. The executable
     /// flag is required for MEC indirect-buffer fetches even though the PM4
     /// words are data rather than shader ISA.
+    ///
+    /// This is host-resident fine-grained memory (see `discover`). That is the
+    /// correct trade and was measured, not assumed: placing the retained IB in
+    /// a device-local coarse-grained pool instead is SLOWER on both reference
+    /// boards — hiptrx 565.52 -> 560.84 tok/s (-0.83%), k9lin 548.02 -> 544.28
+    /// (-0.68%), qwen3.5-0.8b.mq4, two alternating reps each. Retained replay
+    /// patches kernargs into this buffer from the CPU between replays; host
+    /// memory is cached and fast to write, whereas VRAM through the BAR is
+    /// write-combined and uncached, so the CPU-write cost outweighs any saving
+    /// on the command processor's read. Do not "optimise" this into VRAM.
     pub fn allocate_executable_bytes(&self, length: usize) -> Result<KernargBuffer, RuntimeError> {
         self.allocate_bytes(length, 16, abi::AMD_MEMORY_POOL_EXECUTABLE_FLAG)
     }

--- a/docs/perf-checkpoints/2026-07-26-gfx1201-retained-pm4-reference.md
+++ b/docs/perf-checkpoints/2026-07-26-gfx1201-retained-pm4-reference.md
@@ -1,0 +1,131 @@
+# gfx1201 retained-PM4: our reference configuration and what it proves
+
+Publishing our two reference machines in full — configuration, method, and
+results — so anyone seeing a different number can diff against a concrete
+baseline rather than guess at ours. Every row below is measured on hardware we
+own, not inferred.
+
+## Reference machines
+
+| | hiptrx | k9lin |
+|---|---|---|
+| GPU | AMD Radeon AI PRO R9700 (gfx1201) | AMD Radeon RX 9070 XT (gfx1201) |
+| VBIOS | `00158738` | `023.008.000.068.000001` |
+| Power cap | 300 W | 304 W |
+| Rated GFX max clock | 2350 MHz | 2400 MHz |
+| PCIe | x16 @ 32.0 GT/s (Gen5) | x16 @ 32.0 GT/s (Gen5) |
+| RAS: UMC / parity | ENABLED / ENABLED | n/a (consumer part) |
+| RAS: GFX / SDMA | DISABLED / DISABLED | n/a |
+| CPU | Threadripper 9970X (family 26, Zen 5), 64 threads | Ryzen 9 3900X (family 23, Zen 2), 24 threads |
+| Kernel | 7.0.0-27-generic | 6.17.0-35-generic |
+| ROCm | 7.14.0 | 7.14.0 |
+| HIP | 7.14.60850-0000000 | 7.14.60850-0000000 |
+| Code generator | AMD clang 23.0.0git `46fcb339fb61…` | AMD clang 23.0.0git `46fcb339fb61…` |
+| AMD-SMI | 26.5.0+2b22ab01 | 26.5.0+2b22ab01 |
+
+All PM4 policy variables **unset** on both, i.e. committed defaults:
+`HIPFIRE_REPLAY_PM4_{QUEUES,STATEFUL,WAIT_POLICY,ACQUIRE_POLICY,GCR_TRIM,NATIVE_PHASES,DYNAMIC_GRID}`.
+`ROCM_PATH` / `HIP_PATH` / `HIPFIRE_KERNEL_CACHE` also unset.
+
+## Results
+
+Benchmark contract identical everywhere: `--context 128 --iterations 128
+--warmups 10 --warmup-iterations 32 --runs 10 --transport pm4 --kv-mode q8
+--max-seq 2048`.
+
+### qwen3.6-35b-a3b.mq4r — `4685c140c4…`
+
+| | HIP | PM4 | ratio |
+|---|---:|---:|---:|
+| hiptrx | 174.265 | 201.057 | **1.154** |
+| clean-room rebuild (hiptrx) | 171.890 | 201.059 | **1.170** |
+
+Route: 733 dispatches / 23 kernels / `3318ffca3daf2338`, identity `[733,1,2,20511]`.
+
+### qwen3.5-0.8b.mq4 — `aedfe31be6…` (registry artifact)
+
+Three repetitions per arm.
+
+| arm | HIP median | PM4 median | ratio |
+|---|---:|---:|---:|
+| hiptrx, native kernels | 473.283 | **562.964** | 1.186 |
+| k9lin, native kernels | 476.597 | **547.325** | 1.147 |
+| k9lin, running hiptrx's exact code objects | 476.184 | **548.111** | 1.150 |
+
+Route on both boards: 338 dispatches / 20 kernels / `f3fb9f6309726bb9`,
+identity `[338,1,2,9662]`. Within-arm spread ≤0.43%; arms do not overlap.
+
+## Proven
+
+| # | Claim | Evidence |
+|---|---|---|
+| 1 | The golden baseline reproduces from source | Pristine worktree, cold build, kernels JIT'd from source (mtimes inside the run window, 20.4 s first warm-up vs 2.2 s warm). PM4 201.059, ratio 1.170. |
+| 2 | Cached code objects were never stale | Freshly compiled manifest is byte-identical to the cached one: `c111fc7b17e40017…`, 46 files. |
+| 3 | Two gfx1201 boards emit the identical tape | 338/20/`f3fb9f63`, `[338,1,2,9662]` on both; `retained_rows=10`, `errors=[]`. |
+| 4 | The two boards compile identical machine code | Unbundled `.text` sha256 `7d829812216e4953…`, 896 bytes, on both. The 48 differing container bytes are metadata outside `.text`. |
+| 5 | Code generation does not explain the cross-board delta | Running hiptrx's exact bundles on k9lin moves it **+0.14%** (547.325 → 548.111), still 2.6% below hiptrx. Pin verified by hashing the blobs the engine actually loaded. |
+| 6 | The retained path is board-sensitive in a way HIP is not | k9lin is 0.70% **faster** on HIP and 2.78% **slower** on PM4. Non-overlapping arms, 3 reps each. |
+| 7 | Device selection is not a factor | Reproducing taniguchi's `ROCR_VISIBLE_DEVICES=1 / HIP_VISIBLE_DEVICES=0` on hiptrx passes at 1.158×. |
+| 8 | ECC is not costing us throughput | hiptrx runs UMC ECC + parity ENABLED and is the **faster** of our two boards. |
+| 9 | PM4 policy, model bytes and wait-policy derivation are identical to the failing report | All 7 policy vars match; model SHA matches; the `PM4 wait audit` line is byte-identical to taniguchi's (732/732 boundaries, 60/130 split, same two `resource_only` pairs at 30 and 40). |
+
+## Not matched, and therefore still open
+
+| Variable | hiptrx | k9lin | taniguchi | HUSRCF |
+|---|---|---|---|---|
+| VBIOS | `00158738` | consumer | **`00158742`** | unknown |
+| amdgpu build | — | — | `6.19.14.31400000` | unknown |
+| Kernel | 7.0.0-27 | 6.17.0-35 | unknown | unknown |
+| CPU / platform | Zen 5 TR, 64t | **Zen 2 AM4, 24t** | Zen 4 AM5, 16t | unknown |
+| perf level / achieved clock | unknown at load | unknown at load | unknown | unknown |
+| RAS / ECC posture | UMC+parity on | n/a | unknown | unknown |
+
+Two caveats on our own control, stated plainly:
+
+- **Our cross-board test confounds GPU with host platform.** hiptrx is Zen 5
+  Threadripper; k9lin is a Zen 2 Ryzen 3900X on AM4. The 2.78% PM4 delta cannot
+  be attributed to the GPU alone. Notably k9lin is *faster* on HIP, which a
+  simply-slower host does not explain.
+- **We never observed a ratio inversion.** Both our boards keep PM4 > HIP on
+  every run. Nothing we measured reproduces PM4 losing to HIP.
+
+## The two reported failures are not the same failure
+
+| | HIP vs ours | PM4 vs ours | ratio | reading |
+|---|---:|---:|---:|---|
+| taniguchi | **+1.1%** | **−29.1%** | 0.809 | machine healthy, retained path broken |
+| HUSRCF (with #543) | **−16.1%** | −18.4% | 1.122 | both arms down together, retained path working |
+
+HUSRCF's box is uniformly slow with an intact ratio. `perf_level=high` pins the
+R9700 at 2350 MHz where auto reaches 2838–3260 MHz — a −17.2% clock deficit
+against their measured −16.1% / −18.4%. That fits a clock-constrained board,
+not a defect.
+
+taniguchi's box matches our HIP to 1.1% and loses 29% only on PM4. That is
+path-specific and is the one unexplained result.
+
+This matters for #543: it was diagnosed and validated on HUSRCF's machine,
+whose deficit is most consistent with clocks. The `COMPUTE_PGM_RSRC3` offset
+correction is a real bug fix and should land on its own merit, but we have no
+evidence it addresses taniguchi's inversion — and measured on hiptrx it costs
+**−1.05%** (199.613 → 197.512 median, 4 alternating runs), leaving 0.26% margin
+above the 197.0 floor.
+
+## To match our configuration
+
+```bash
+# unset every PM4 policy override; committed defaults are the certified route
+unset HIPFIRE_REPLAY_PM4_QUEUES HIPFIRE_REPLAY_PM4_STATEFUL \
+      HIPFIRE_REPLAY_PM4_WAIT_POLICY HIPFIRE_REPLAY_PM4_ACQUIRE_POLICY \
+      HIPFIRE_REPLAY_PM4_GCR_TRIM HIPFIRE_REPLAY_PM4_NATIVE_PHASES \
+      HIPFIRE_REPLAY_PM4_DYNAMIC_GRID
+
+# clocks at AUTO — perf_level=high UNDER-clocks the R9700
+rocm-smi --setperflevel auto
+
+# then report these alongside any number
+amd-smi static --vbios --ras --limit
+rocm-smi --showperflevel
+amd-smi metric --clock          # sampled DURING the PM4 arm, not at idle
+uname -r
+```

--- a/docs/perf-checkpoints/2026-07-26-gfx1201-retained-pm4-reference.md
+++ b/docs/perf-checkpoints/2026-07-26-gfx1201-retained-pm4-reference.md
@@ -18,6 +18,8 @@ own, not inferred.
 | RAS: GFX / SDMA | DISABLED / DISABLED | n/a |
 | CPU | Threadripper 9970X (family 26, Zen 5), 64 threads | Ryzen 9 3900X (family 23, Zen 2), 24 threads |
 | Kernel | 7.0.0-27-generic | 6.17.0-35-generic |
+| amdgpu driver | **in-tree** (`kernel/drivers/gpu/drm/amd/amdgpu`) | **in-tree** (same path) |
+| amdgpu version string | N/A (in-tree reports none) | N/A (in-tree reports none) |
 | ROCm | 7.14.0 | 7.14.0 |
 | HIP | 7.14.60850-0000000 | 7.14.60850-0000000 |
 | Code generator | AMD clang 23.0.0git `46fcb339fb61…` | AMD clang 23.0.0git `46fcb339fb61…` |
@@ -74,11 +76,28 @@ identity `[338,1,2,9662]`. Within-arm spread ≤0.43%; arms do not overlap.
 | Variable | hiptrx | k9lin | taniguchi | HUSRCF |
 |---|---|---|---|---|
 | VBIOS | `00158738` | consumer | **`00158742`** | unknown |
-| amdgpu build | — | — | `6.19.14.31400000` | unknown |
+| amdgpu driver | **in-tree**, no DKMS | **in-tree**, no DKMS | **`6.19.14.31400000`** = packaged DKMS | unknown |
 | Kernel | 7.0.0-27 | 6.17.0-35 | unknown | unknown |
 | CPU / platform | Zen 5 TR, 64t | **Zen 2 AM4, 24t** | Zen 4 AM5, 16t | unknown |
 | perf level / achieved clock | unknown at load | unknown at load | unknown | unknown |
 | RAS / ECC posture | UMC+parity on | n/a | unknown | unknown |
+
+### The driver difference is categorical, not a version delta
+
+Both our boxes load amdgpu from
+`/lib/modules/<ver>/kernel/drivers/gpu/drm/amd/amdgpu/amdgpu.ko.zst` with an
+empty `dkms status` — the in-tree kernel driver, which reports no version
+string, hence `amd-smi ... VERSION: N/A`. A reported version like
+`6.19.14.31400000` comes from the packaged out-of-tree ROCm DKMS driver.
+
+That is a different driver, not a newer one. amdgpu owns HSA queue
+management, command-processor programming, and doorbell/IB submission — the
+machinery the retained path depends on and that ordinary HIP dispatch exercises
+differently. On the evidence above (identical tape, identical `.text`, pinning
+excluded), driver provenance is a stronger candidate than VBIOS for a
+path-specific divergence.
+
+We have no in-house DKMS box, so we cannot test this ourselves.
 
 Two caveats on our own control, stated plainly:
 

--- a/scripts/ci-rustfmt-changed.sh
+++ b/scripts/ci-rustfmt-changed.sh
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# rustfmt needs the edition of the crate OWNING each file. The workspace is
+# edition 2021 but redline-rocr and redline-dispatch are 2024, and 2024-only
+# syntax (let chains) is a PARSE ERROR under --edition 2021 — the gate then
+# reports a formatting failure for a file it never managed to read. Walk up to
+# the nearest Cargo.toml and use its edition, falling back to the workspace.
+file_edition() {
+  local dir; dir="$(dirname "$1")"
+  while [ "$dir" != "/" ] && [ "$dir" != "." ]; do
+    if [ -f "$dir/Cargo.toml" ]; then
+      local ed
+      ed="$(sed -n 's/^edition[[:space:]]*=[[:space:]]*"\([0-9]*\)".*/\1/p' "$dir/Cargo.toml" | head -1)"
+      if [ -n "$ed" ]; then echo "$ed"; return; fi
+      # edition.workspace = true -> fall through to the workspace root
+      break
+    fi
+    dir="$(dirname "$dir")"
+  done
+  sed -n 's/^edition[[:space:]]*=[[:space:]]*"\([0-9]*\)".*/\1/p' Cargo.toml | head -1
+}
+
 # The repository still has historical rustfmt debt. Keep PR/push lint useful by
 # enforcing rustfmt on the Rust files changed by this branch or push, without
 # turning untouched legacy formatting into a permanent red check.
@@ -29,4 +49,8 @@ fi
 
 printf 'rustfmt-checking %d changed Rust files:\n' "${#files[@]}"
 printf '  %s\n' "${files[@]}"
-rustfmt --edition 2021 --check --config skip_children=true "${files[@]}"
+status=0
+for file in "${files[@]}"; do
+  rustfmt --edition "$(file_edition "$file")" --check --config skip_children=true "$file" || status=1
+done
+exit "$status"

--- a/scripts/fmt-changed.sh
+++ b/scripts/fmt-changed.sh
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# rustfmt needs the edition of the crate OWNING each file. The workspace is
+# edition 2021 but redline-rocr and redline-dispatch are 2024, and 2024-only
+# syntax (let chains) is a PARSE ERROR under --edition 2021 — the gate then
+# reports a formatting failure for a file it never managed to read. Walk up to
+# the nearest Cargo.toml and use its edition, falling back to the workspace.
+file_edition() {
+  local dir; dir="$(dirname "$1")"
+  while [ "$dir" != "/" ] && [ "$dir" != "." ]; do
+    if [ -f "$dir/Cargo.toml" ]; then
+      local ed
+      ed="$(sed -n 's/^edition[[:space:]]*=[[:space:]]*"\([0-9]*\)".*/\1/p' "$dir/Cargo.toml" | head -1)"
+      if [ -n "$ed" ]; then echo "$ed"; return; fi
+      # edition.workspace = true -> fall through to the workspace root
+      break
+    fi
+    dir="$(dirname "$dir")"
+  done
+  sed -n 's/^edition[[:space:]]*=[[:space:]]*"\([0-9]*\)".*/\1/p' Cargo.toml | head -1
+}
+
 # Format ONLY the Rust files this branch touches, matching CI's rules.
 #
 # Why this exists: the repo carries historical rustfmt debt (most files are
@@ -45,5 +65,7 @@ fi
 
 printf 'rustfmt-formatting %d changed Rust file(s):\n' "${#files[@]}"
 printf '  %s\n' "${files[@]}"
-rustfmt --edition 2021 --config skip_children=true "${files[@]}"
+for file in "${files[@]}"; do
+  rustfmt --edition "$(file_edition "$file")" --config skip_children=true "$file"
+done
 echo "Done. Review the diff (it may include pre-existing format debt in files you touched — that is what CI's changed-file gate checks)."

--- a/scripts/redline-repro-package.sh
+++ b/scripts/redline-repro-package.sh
@@ -427,26 +427,14 @@ cmd_run() {
     # Evict locally-JIT'd blobs so the pinned ones are what actually load.
     rm -rf "${HIPFIRE_KERNEL_CACHE:-.hipfire_kernels}/$arch"
 
-    # Make the engine take the "no valid hash AND no compiler" branch so our
-    # blobs are used verbatim.
+    # Force the engine to treat the device compiler as absent.
     #
-    # Do NOT do this by deleting PATH entries: the ROCm bin directory holds the
-    # compilers AND rocminfo/rocm-smi, so dropping it breaks device detection
-    # and the bench hangs until its 1200s timeout. Instead SHADOW just the
-    # compiler names with stubs that exit non-zero. The engine's probe is
-    # `Command::new("hipcc").arg("--version")` and it keys off
-    # `status.success()`, so a failing stub is sufficient and everything else
-    # on PATH survives untouched.
-    local shim; shim="$(mktemp -d)"
-    SHIM_DIR="$shim"
-    local cc
-    for cc in "${DEVICE_COMPILERS[@]}"; do
-      printf '#!/bin/sh\nexit 1\n' > "$shim/$cc"
-      chmod +x "$shim/$cc"
-    done
-    env_prefix=(env "PATH=$shim:$PATH")
-    echo "  shadowed device compilers with failing stubs (${DEVICE_COMPILERS[*]})"
-    echo "  rocminfo/rocm-smi and the rest of PATH are left intact"
+    # This used to be done by shadowing compiler names on PATH, which worked
+    # while the probe was a bare `Command::new("hipcc")`. Resolved-root
+    # discovery now finds the compiler regardless of PATH, so shadowing
+    # silently recompiled instead of pinning. Use the explicit switch.
+    env_prefix=(env "HIPFIRE_NO_DEVICE_COMPILER=1")
+    echo "  HIPFIRE_NO_DEVICE_COMPILER=1 — engine will treat the compiler as absent"
     echo "  the engine will warn 'Output may be incorrect' — that is EXPECTED here"
     echo "  and is the confirmation that OUR code objects are executing."
   fi


### PR DESCRIPTION
Follow-up to #544, which shipped two defects I found only by running it on a second box.

## 1. hipcc could be found but could not compile

hipcc resolves its own LLVM as `$ROCM_PATH/lib/llvm/bin/clang++`, with `ROCM_PATH` defaulting to `/opt/rocm`. On a root elsewhere — `/opt/rocm/core` on this fleet — resolving hipcc's *path* isn't enough: `--version` succeeds so `has_hipcc` is true, then every compile fails with `sh: 1: /opt/rocm/lib/llvm/bin/clang++: not found`.

Verified on k9lin (RX 9070 XT, ROCm at `/opt/rocm/core`): JIT hard-failed on the first kernel. `compiler_env_root()` now hands the child the resolved root and defers to an operator-set `ROCM_PATH`. With both `ROCM_PATH` and `HIP_PATH` unset, k9lin JITs 33 kernels, zero failures.

## 2. Root discovery silently defeated `--pin-kernels`

`--pin-kernels` forced pre-compiled blobs by shadowing compiler names on `PATH` — fine while the probe was a bare `Command::new("hipcc")`. Root discovery finds the compiler regardless of PATH, so the shadow stopped working and the pin **silently recompiled while reporting success**.

Caught by hashing what the engine actually loaded: a cross-machine pinned run reported `0 recompile events` while executing local blobs (`47c6699d…` where the pinned bytes were `9b4dd185…`). Both the recompile counter *and* the accept-warning reported success in the broken run — only the hash discriminated. Worth remembering when designing evidence for a pin.

`HIPFIRE_NO_DEVICE_COMPILER=1` now makes the engine treat the compiler as absent. Re-run, k9lin executed hiptrx's exact bytes.

**`--pin-kernels` as merged in #544 does not do what its documentation claims.** This fixes it.

## 3. Published reference configuration

`docs/perf-checkpoints/2026-07-26-gfx1201-retained-pm4-reference.md` publishes both reference machines in full so a disagreeing box can diff against a concrete baseline instead of guessing.

Nine proven claims with their measurements, including: the baseline reproduces from a pristine source build (PM4 201.059, 1.170×); cached code objects were never stale (`c111fc7b…` identical); two gfx1201 boards emit an identical tape (338/20/`f3fb9f63`); they compile identical `.text` (`7d829812…`); **running one board's exact code objects on the other moves it +0.14%**, excluding codegen; and the retained path is board-sensitive (k9lin +0.70% HIP, −2.78% PM4) where HIP is not.

Two caveats recorded against our own control rather than omitted: the cross-board test confounds GPU with host platform (Zen 5 Threadripper vs Zen 2 AM4), and we never observed a ratio inversion.

## Bearing on #543

The doc separates the two reported failures, which are not the same failure:

| | HIP vs ours | PM4 vs ours | ratio |
|---|---:|---:|---:|
| taniguchi | +1.1% | −29.1% | 0.809 |
| HUSRCF (with #543) | −16.1% | −18.4% | 1.122 |

taniguchi: healthy machine, path-specific break. HUSRCF: both arms down together, ratio intact — consistent with a clock-constrained board, since `perf_level=high` pins the R9700 at 2350 MHz against auto's 2838–3260 (−17.2%).

#543 was diagnosed and validated on the latter. Its `COMPUTE_PGM_RSRC3` correction is a real bug and should land on merit, but there's no evidence it addresses taniguchi's inversion, and measured here it costs **−1.05%** (199.613 → 197.512 median, 4 alternating runs) leaving 0.26% margin above the 197.0 floor.

## Test plan

- [x] `cargo check --workspace --locked` clean
- [x] 1,126 workspace lib tests pass
- [x] k9lin JIT works with `ROCM_PATH`/`HIP_PATH` unset (was a hard failure)
- [x] Pinned cross-machine run verified by hashing loaded blobs, not by counters
- [x] `bash -n` clean on the script