### PR TITLE
perf(qwen35): reduce owned prefill scratch VRAM

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -6451,7 +6451,7 @@ pub fn forward_prefill_batch_with_pbs(
 /// Like `forward_prefill_batch`, but accepts a caller-owned `PrefillBatchScratch`
 /// so the ~25 per-cycle tensor allocations can be amortized across many calls.
 ///
-/// `pbs = None` preserves the original behavior (per-call allocate + free);
+/// `pbs = None` allocates and frees a right-sized scratch per call;
 /// `pbs = Some(&pbs)` reuses the provided scratch. The provided scratch's
 /// `max_batch` determines the chunk size — `tokens` is processed in chunks of
 /// up to `pbs.max_batch`. Callers driving DFlash verify should size `pbs`
@@ -6692,17 +6692,25 @@ pub fn forward_prefill_batch_with_pbs_opts(
     // Allocate the batch scratch once per call (or reuse a caller-owned one).
     // When `pbs_in` is Some, we neither allocate nor free — the caller retains
     // ownership across DFlash cycles to avoid ~25 per-cycle tensor alloc/free
-    // pairs on the hot verify path. When None we fall back to the original
-    // allocate-here / free-on-exit pattern so unmodified callers behave the
-    // same. The chunk size is `pbs.max_batch` so a caller-owned scratch sized
-    // to e.g. `block_size` or `1 + tree_budget` keeps DFlash verify in one
-    // chunk without the full 256-row MAX_BATCH footprint.
+    // pairs on the hot verify path. When None, size the allocation to this
+    // call's largest possible chunk and allocate the DeltaNet S-state tape only
+    // for tree verify. Plain prefill never consumes that tape, and short
+    // prompts should not pay the full 256-row scratch footprint. The chunk size
+    // is `pbs.max_batch` so a caller-owned scratch sized to e.g. `block_size`
+    // or `1 + tree_budget` keeps DFlash verify in one chunk.
     let mut own_pbs: Option<PrefillBatchScratch> = None;
     let result = (|| -> HipResult<()> {
         let pbs: &PrefillBatchScratch = match pbs_in {
             Some(p) => p,
             None => {
-                own_pbs = Some(PrefillBatchScratch::new(gpu, config, max_batch)?);
+                let (owned_max_batch, cap_gdn_tape) =
+                    owned_prefill_scratch_plan(n, max_batch, tree_verify.is_some());
+                own_pbs = Some(PrefillBatchScratch::new_opt(
+                    gpu,
+                    config,
+                    owned_max_batch,
+                    cap_gdn_tape,
+                )?);
                 own_pbs.as_ref().unwrap()
             }
         };
@@ -7225,6 +7233,22 @@ fn moe_ffn_batched_admissible_for_dtypes(
 /// Threshold below which batching overhead isn't worth the alloc + per-layer
 /// dispatch — single-token prefill must not take the batched path.
 const MIN_BATCH: usize = 2;
+
+/// Plan scratch owned by one prefill call.
+///
+/// Large prompts retain the configured chunk size, while a short prompt gets
+/// exactly one right-sized chunk. The DeltaNet S-state tape is consumed only by
+/// tree verify; ordinary prefill advances recurrent state in place.
+#[inline]
+fn owned_prefill_scratch_plan(
+    n: usize,
+    configured_max_batch: usize,
+    tree_verify: bool,
+) -> (usize, bool) {
+    debug_assert!(n > 0);
+    debug_assert!(configured_max_batch >= MIN_BATCH);
+    (configured_max_batch.min(n.max(MIN_BATCH)), tree_verify)
+}
 
 /// Whether `forward_prefill_batch_with_pbs` will take the tape-capturing
 /// batched (PBS) path for an `n`-token call — equivalently, whether a `GdnTape`
@@ -17802,6 +17826,21 @@ mod tests {
         assert!(prefill_should_emit_last_token_logits(true, true));
         assert!(prefill_should_emit_last_token_logits(false, false));
         assert!(!prefill_should_emit_last_token_logits(true, false));
+    }
+
+    #[test]
+    fn owned_prefill_scratch_is_right_sized_without_tree_tape() {
+        assert_eq!(owned_prefill_scratch_plan(1, 256, false), (2, false));
+        assert_eq!(owned_prefill_scratch_plan(2, 256, false), (2, false));
+        assert_eq!(owned_prefill_scratch_plan(32, 256, false), (32, false));
+        assert_eq!(owned_prefill_scratch_plan(256, 256, false), (256, false));
+        assert_eq!(owned_prefill_scratch_plan(1024, 256, false), (256, false));
+    }
+
+    #[test]
+    fn owned_prefill_scratch_preserves_tree_verify_tape() {
+        assert_eq!(owned_prefill_scratch_plan(22, 256, true), (22, true));
+        assert_eq!(owned_prefill_scratch_plan(64, 64, true), (64, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Right-size Qwen3.5's ordinary per-call prefill scratch to the active chunk instead of the configured maximum batch, and avoid allocating the DeltaNet tree tape unless tree verification is requested. Caller-owned DFlash/tree scratch behavior is unchanged.

**Measured VRAM result:** across Qwen3.5 0.8B, 4B, 9B, 27B, and 35B-A3B, peak reductions range from **322.00 to 966.00 MiB at pp256**, and from **370.01 to 1,104.02 MiB at pp32**. The full per-model table is below.

An additional process-scoped pp4K/pp8K matrix independently confirms **322.00 to 966.00 MiB** of long-context savings, with no decode-speed regression across the five-model matrix.

The implementation is intentionally limited to one source file and includes focused tests for the ordinary and tree-verification allocation plans.

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [ ] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [x] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template — touch only when refining the new-arch reference)
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [ ] docs / CI / scripts

## Test plan

- [ ] `./scripts/no-gpu-ci.sh` passes, or equivalent CI job is green
  - Ran to completion: 371 Python tests passed and 10 failed. All 10 failures are pre-existing `autoresearch/ar/tests/test_gpu_gate_workflow.py` failures caused by the missing `.github/workflows/gpu-gates.yml`; clean `beta@87c9321c` reproduces the same 10/10 failures.
- [x] `cargo build --release --workspace --features deltanet` clean
- [x] `cargo test --lib --workspace --features deltanet` passes
- [x] If kernel/dispatch changed: N/A — no kernel or dispatch changes
- [x] If spec-decode changed: N/A — no spec-decode changes
- [ ] If perf-relevant: `./scripts/speed-gate.sh` within ±2% of locked baselines
  - Full gate was run on both this patch and clean `beta@87c9321c` on the same R9700. Both produced the same 12 pass / 3 fail set; the inherited failures are 0.8B pp32, 0.8B pp128, and 4B pp128 against the locked hiptrx floors. The patch was neutral or faster than clean beta in the paired gate runs.

Additional validation:

- `scripts/agentic-gate.sh --fast`: PASS on Qwen3.5-35B-A3B, 1/1 cells, 0 soft warnings.
- Path-specific numerical oracle: clean beta and the patch produced byte-identical final-logit dumps for all 10 combinations of 0.8B/4B/9B/27B/35B-A3B × pp32/pp256.
- All 80 fresh-process warmup/measured benchmark rows completed without panic, HIP illegal access, OOM, fatal error, or parse failure.
- All 80 fresh-process peak-VRAM runs across two opposite arm orderings passed.
- Long-context watchdog matrix: 60/60 fresh-process cases passed; every case completed pp4K/pp8K prefill plus exactly 1,024 decode tokens.
- `git diff --check` and `scripts/check-fmt-bomb.sh`: PASS.
- Changed-file rustfmt remains blocked by broad pre-existing formatting debt in `qwen35.rs`; formatting the whole file would turn this focused change into an unrelated formatting rewrite.

### Long-context pp4K/pp8K + 1,024-token decode

Environment: Radeon AI PRO R9700 (`gfx1201`, 34,208,743,424 B VRAM), Q8 KV, graph/spec off, ordinary own-PBS path. Each cell is the median of three fresh processes per arm in A-B-B-A-A-B order, with 16 untimed decode warmup tokens followed by 1,024 timed decode tokens. One GPU lock and a per-process watchdog enforced strictly serial execution. Peak VRAM came from the process-scoped KFD counter (`/sys/class/kfd/kfd/proc/<pid>/vram_40686`), so exited-process ROCm residency cannot contaminate the measurement.

Baseline binary SHA-256: `f18374cfd2ff3a4ddfe18c9cca38fe8c7083c280bc28666248fabacabb653e71`. Patch binary SHA-256: `1215ea6f86bcb5bae065636cca930fa65133d97b7e01639b61765f16806dd627`.

| Model | pp4K VRAM saved | pp4K prefill / decode Δ | pp8K VRAM saved | pp8K prefill / decode Δ |
|---|---:|---:|---:|---:|
| Qwen3.5 0.8B | 337,641,472 B (322.00 MiB) | +0.38% / +0.54% | 337,641,472 B (322.00 MiB) | -0.57% / +0.41% |
| Qwen3.5 4B | 675,282,944 B (644.00 MiB) | +0.26% / +0.14% | 675,282,944 B (644.00 MiB) | +0.25% / +0.22% |
| Qwen3.5 9B | 675,282,944 B (644.00 MiB) | +0.37% / +0.20% | 675,282,944 B (644.00 MiB) | +0.15% / +0.20% |
| Qwen3.5 27B | 1,012,924,416 B (966.00 MiB) | -0.29% / 0.00% | 1,012,924,416 B (966.00 MiB) | +0.21% / +0.30% |
| Qwen3.5 35B-A3B | 675,282,944 B (644.00 MiB) | +0.32% / 0.00% | 675,282,944 B (644.00 MiB) | -0.17% / +0.20% |

All 60 cases passed with no timeout, OOM, HIP illegal access, panic, shortened decode, or error marker. Prefill deltas stay within ±0.57%; all decode medians are equal or slightly faster on the patch. Once the active prefill chunk reaches the 256-row cap, pp4K and pp8K intentionally save the same fixed tree-only tape allocation; the longer KV cache grows equally on both arms.

### Peak VRAM A/B

Environment: Radeon AI PRO R9700 (`gfx1201`), Q8 KV, graph/spec off, ordinary own-PBS path. `/sys/class/drm/card1/device/mem_info_vram_used` was sampled for the whole fresh process. Two opposite arm orderings were run; the table reports the mean reduction from the two order estimates, which agreed within 64 KiB in every cell.

| Model | pp32 peak reduction | pp256 peak reduction |
|---|---:|---:|
| Qwen3.5 0.8B | 387,979,264 B (370.01 MiB) | 337,641,472 B (322.00 MiB) |
| Qwen3.5 4B | 773,849,088 B (738.00 MiB) | 675,284,992 B (644.00 MiB) |
| Qwen3.5 9B | 780,126,208 B (743.99 MiB) | 675,297,280 B (644.01 MiB) |
| Qwen3.5 27B | 1,157,648,384 B (1,104.02 MiB) | 1,012,924,416 B (966.00 MiB) |
| Qwen3.5 35B-A3B | 792,170,496 B (755.47 MiB) | 675,276,800 B (643.99 MiB) |

At pp256 the active chunk remains 256 rows, so the reduction primarily reflects skipping the unused tree-only DeltaNet tape. At pp32, right-sizing the rest of the owned scratch to the active chunk produces the additional savings.

### Fresh-process matched A/B

Environment: Radeon AI PRO R9700 (`gfx1201`), HIP 7.14.60850, Q8 KV, graph/spec off, ordinary own-PBS path (`HIPFIRE_PREFILL_REUSE_PBS=0`). Each cell used one warmup per arm and three measured fresh-process runs per arm in A-B-B-A-A-B order. The benchmark uses its deterministic generated token input, so there is no prompt-file hash. Benchmark binary MD5: beta `68fed8ec4bab947655129ef7b6ab8e4d`, patch `5ea9de46a4328ef9374026e115e610d5`.

| Model | pp32 beta → patch | Delta | pp256 beta → patch | Delta |
|---|---:|---:|---:|---:|
| Qwen3.5 0.8B | 2819.3 → 2929.1 tok/s | +3.89% | 10131.4 → 10326.9 tok/s | +1.93% |
| Qwen3.5 4B | 1695.7 → 1763.1 tok/s | +3.97% | 3831.4 → 3857.2 tok/s | +0.67% |
| Qwen3.5 9B | 1262.6 → 1284.7 tok/s | +1.75% | 2481.2 → 2490.0 tok/s | +0.35% |
| Qwen3.5 27B | 509.9 → 516.5 tok/s | +1.29% | 758.5 → 756.0 tok/s | -0.33% |
| Qwen3.5 35B-A3B | 945.8 → 978.7 tok/s | +3.48% | 2725.7 → 2729.9 tok/s | +0.15% |

## Architecture-trait change?

No. This does not change the `Architecture` trait surface.
