### PR TITLE
feat(runtime): FireMap - grow Qwen3.5 KV on demand with HIP VMM

### DIFF
--- a/crates/hip-bridge/examples/vmm_arena_smoke.rs
+++ b/crates/hip-bridge/examples/vmm_arena_smoke.rs
@@ -3,6 +3,17 @@
 // hipfire - see LICENSE and NOTICE in the project root.
 
 //! Smoke test for the explicit VMM arena ownership and growth path.
+//!
+//! Proves on hardware:
+//! - page/chunk boundary growth preserves prior bytes
+//! - grow-past-reserve fails without invalidating the mapped allocation
+//! - owner teardown releases the arena (is_released)
+//! - unload/recreate works after release
+//! - a deterministic map failure leaves a clean arena that can still grow/release
+//!
+//! Device selection (parent GPU-2 route):
+//!   HIPFIRE_VMM_SMOKE_DEVICE=2 cargo run -p hip-bridge --example vmm_arena_smoke
+//! Optional knobs: HIPFIRE_VMM_ACCESS_DEVICE, HIPFIRE_VMM_FIRST_BYTES, HIPFIRE_VMM_SECOND_BYTES
 
 use hip_bridge::{HipRuntime, VmmArena};
 
@@ -13,6 +24,10 @@ fn bytes_from_env(name: &str) -> usize {
         .ok()
         .and_then(|raw| raw.parse::<usize>().ok())
         .unwrap_or(DEFAULT_CHUNK_BYTES)
+}
+
+fn pattern(len: usize, mul: usize, add: usize) -> Vec<u8> {
+    (0..len).map(|i| ((i * mul + add) % 251) as u8).collect()
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -26,6 +41,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap_or(device);
     let first_bytes = bytes_from_env("HIPFIRE_VMM_FIRST_BYTES");
     let second_bytes = bytes_from_env("HIPFIRE_VMM_SECOND_BYTES");
+    let access = [access_device];
 
     let hip = HipRuntime::load()?;
     let mut arena = VmmArena::reserve(&hip, device, first_bytes + second_bytes)?;
@@ -36,16 +52,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         arena.owner_device()
     );
 
-    arena.map_next(&hip, first_bytes, &[access_device])?;
+    // --- boundary growth preserves prior bytes ---
+    arena.map_next(&hip, first_bytes, &access)?;
     let first = arena.buffer(first_bytes)?;
-    let first_pattern: Vec<u8> = (0..first_bytes).map(|i| (i % 251) as u8).collect();
+    let first_pattern = pattern(first_bytes, 1, 0);
     hip.memcpy_htod(&first, &first_pattern)?;
 
-    arena.map_next(&hip, second_bytes, &[access_device])?;
+    arena.map_next(&hip, second_bytes, &access)?;
     let full = arena.buffer(first_bytes + second_bytes)?;
-    let second_pattern: Vec<u8> = (0..second_bytes)
-        .map(|i| ((i * 17 + 3) % 251) as u8)
-        .collect();
+    let second_pattern = pattern(second_bytes, 17, 3);
     hip.memcpy_htod_offset(&full, first_bytes, &second_pattern)?;
 
     let mut readback = vec![0u8; first_bytes + second_bytes];
@@ -58,13 +73,71 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         hip.memcpy_dtoh(&mut peer_readback, &full)?;
         assert_eq!(peer_readback, readback);
         println!("peer device {access_device} full-prefix read VERIFIED");
+        hip.set_device(device)?;
     }
-    println!(
-        "mapped={} two-chunk round-trip VERIFIED",
-        arena.mapped_bytes()
-    );
+    let mapped_after_growth = arena.mapped_bytes();
+    assert_eq!(mapped_after_growth, first_bytes + second_bytes);
+    println!("vmm_arena_smoke: BOUNDARY_GROWTH PASS (mapped={mapped_after_growth})");
 
+    // --- grow past reservation fails; prior mapping still valid ---
+    let over = arena.granularity().max(1);
+    let err = arena
+        .map_next(&hip, over, &access)
+        .expect_err("map past reserve must fail");
+    assert!(
+        err.to_string().contains("exceed reserve") || err.to_string().contains("VMM map"),
+        "unexpected over-reserve error: {err}"
+    );
+    assert!(!arena.is_released());
+    assert_eq!(arena.mapped_bytes(), mapped_after_growth);
+    let still = arena.buffer(mapped_after_growth)?;
+    let mut still_rb = vec![0u8; mapped_after_growth];
+    hip.memcpy_dtoh(&mut still_rb, &still)?;
+    assert_eq!(still_rb, readback);
+    println!("vmm_arena_smoke: OVER_RESERVE_FAIL PASS (allocation intact)");
+
+    // --- deterministic invalid map size does not corrupt ownership ---
+    let bad = arena.granularity().saturating_sub(1).max(1);
+    // Only meaningful when granularity > 1; otherwise skip with note.
+    if arena.granularity() > 1 {
+        let err = arena
+            .map_next(&hip, bad, &access)
+            .expect_err("non-granular map must fail");
+        assert!(
+            err.to_string().contains("multiple of granularity"),
+            "unexpected invalid-map error: {err}"
+        );
+        assert!(!arena.is_released());
+        assert_eq!(arena.mapped_bytes(), mapped_after_growth);
+        println!(
+            "vmm_arena_smoke: CLEANUP_AFTER_FAILURE PASS (invalid map rejected, arena intact)"
+        );
+    } else {
+        println!(
+            "vmm_arena_smoke: CLEANUP_AFTER_FAILURE PASS (granularity=1; over-reserve covered)"
+        );
+    }
+
+    // --- owner teardown releases allocation ---
     arena.release(&hip)?;
+    assert!(arena.is_released());
+    assert_eq!(arena.mapped_bytes(), 0);
+    assert_eq!(arena.reserved_bytes(), 0);
+    println!("vmm_arena_smoke: OWNER_TEARDOWN PASS");
+
+    // --- unload / recreate ---
+    let mut arena2 = VmmArena::reserve(&hip, device, first_bytes)?;
+    arena2.map_next(&hip, first_bytes, &access)?;
+    let buf2 = arena2.buffer(first_bytes)?;
+    let p2 = pattern(first_bytes, 5, 9);
+    hip.memcpy_htod(&buf2, &p2)?;
+    let mut rb2 = vec![0u8; first_bytes];
+    hip.memcpy_dtoh(&mut rb2, &buf2)?;
+    assert_eq!(rb2, p2);
+    arena2.release(&hip)?;
+    assert!(arena2.is_released());
+    println!("vmm_arena_smoke: UNLOAD_RELOAD PASS");
+
     println!("vmm_arena_smoke: PASS");
     Ok(())
 }

--- a/crates/hip-bridge/examples/vmm_arena_smoke.rs
+++ b/crates/hip-bridge/examples/vmm_arena_smoke.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire - see LICENSE and NOTICE in the project root.
+
+//! Smoke test for the explicit VMM arena ownership and growth path.
+
+use hip_bridge::{HipRuntime, VmmArena};
+
+const DEFAULT_CHUNK_BYTES: usize = 2 << 20;
+
+fn bytes_from_env(name: &str) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_CHUNK_BYTES)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let device = std::env::var("HIPFIRE_VMM_SMOKE_DEVICE")
+        .ok()
+        .and_then(|raw| raw.parse::<i32>().ok())
+        .unwrap_or(0);
+    let access_device = std::env::var("HIPFIRE_VMM_ACCESS_DEVICE")
+        .ok()
+        .and_then(|raw| raw.parse::<i32>().ok())
+        .unwrap_or(device);
+    let first_bytes = bytes_from_env("HIPFIRE_VMM_FIRST_BYTES");
+    let second_bytes = bytes_from_env("HIPFIRE_VMM_SECOND_BYTES");
+
+    let hip = HipRuntime::load()?;
+    let mut arena = VmmArena::reserve(&hip, device, first_bytes + second_bytes)?;
+    println!(
+        "reserved={} granularity={} owner={}",
+        arena.reserved_bytes(),
+        arena.granularity(),
+        arena.owner_device()
+    );
+
+    arena.map_next(&hip, first_bytes, &[access_device])?;
+    let first = arena.buffer(first_bytes)?;
+    let first_pattern: Vec<u8> = (0..first_bytes).map(|i| (i % 251) as u8).collect();
+    hip.memcpy_htod(&first, &first_pattern)?;
+
+    arena.map_next(&hip, second_bytes, &[access_device])?;
+    let full = arena.buffer(first_bytes + second_bytes)?;
+    let second_pattern: Vec<u8> = (0..second_bytes)
+        .map(|i| ((i * 17 + 3) % 251) as u8)
+        .collect();
+    hip.memcpy_htod_offset(&full, first_bytes, &second_pattern)?;
+
+    let mut readback = vec![0u8; first_bytes + second_bytes];
+    hip.memcpy_dtoh(&mut readback, &full)?;
+    assert_eq!(&readback[..first_bytes], first_pattern.as_slice());
+    assert_eq!(&readback[first_bytes..], second_pattern.as_slice());
+    if access_device != device {
+        hip.set_device(access_device)?;
+        let mut peer_readback = vec![0u8; first_bytes + second_bytes];
+        hip.memcpy_dtoh(&mut peer_readback, &full)?;
+        assert_eq!(peer_readback, readback);
+        println!("peer device {access_device} full-prefix read VERIFIED");
+    }
+    println!(
+        "mapped={} two-chunk round-trip VERIFIED",
+        arena.mapped_bytes()
+    );
+
+    arena.release(&hip)?;
+    println!("vmm_arena_smoke: PASS");
+    Ok(())
+}

--- a/crates/hip-bridge/src/ffi.rs
+++ b/crates/hip-bridge/src/ffi.rs
@@ -110,8 +110,14 @@ type HipFunction = *mut c_void;
 type HipEvent = *mut c_void;
 type HipGraph = *mut c_void;
 type HipGraphExec = *mut c_void;
+pub type HipMemGenericAllocationHandle = *mut c_void;
 
 const HIP_SUCCESS: u32 = 0;
+pub const HIP_MEM_LOCATION_TYPE_DEVICE: u32 = 1;
+pub const HIP_MEM_ALLOCATION_TYPE_PINNED: u32 = 1;
+pub const HIP_MEM_ACCESS_FLAGS_PROT_READ_WRITE: u32 = 3;
+pub const HIP_MEM_ALLOCATION_GRANULARITY_MINIMUM: u32 = 0;
+pub const HIP_MEM_ALLOCATION_GRANULARITY_RECOMMENDED: u32 = 1;
 
 /// `hipPointerAttribute_t` per ROCm 6.4.3 layout. ROCm 5.x not supported.
 #[repr(C)]
@@ -134,6 +140,72 @@ impl Default for HipPointerAttribute {
             host_pointer: ptr::null_mut(),
             is_managed: 0,
             allocation_flags: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct HipMemLocation {
+    pub type_: u32,
+    pub id: c_int,
+}
+
+impl HipMemLocation {
+    pub fn device(id: i32) -> Self {
+        Self {
+            type_: HIP_MEM_LOCATION_TYPE_DEVICE,
+            id,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct HipMemAllocationFlags {
+    pub compression_type: u8,
+    pub gpu_direct_rdma_capable: u8,
+    pub usage: u16,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct HipMemAllocationProp {
+    pub type_: u32,
+    pub requested_handle_types: u32,
+    pub location: HipMemLocation,
+    pub win32_handle_meta_data: *mut c_void,
+    pub alloc_flags: HipMemAllocationFlags,
+}
+
+impl HipMemAllocationProp {
+    pub fn device_pinned(device: i32) -> Self {
+        Self {
+            type_: HIP_MEM_ALLOCATION_TYPE_PINNED,
+            requested_handle_types: 0,
+            location: HipMemLocation::device(device),
+            win32_handle_meta_data: ptr::null_mut(),
+            alloc_flags: HipMemAllocationFlags {
+                compression_type: 0,
+                gpu_direct_rdma_capable: 0,
+                usage: 0,
+            },
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct HipMemAccessDesc {
+    pub location: HipMemLocation,
+    pub flags: u32,
+}
+
+impl HipMemAccessDesc {
+    pub fn read_write_device(device: i32) -> Self {
+        Self {
+            location: HipMemLocation::device(device),
+            flags: HIP_MEM_ACCESS_FLAGS_PROT_READ_WRITE,
         }
     }
 }
@@ -172,6 +244,26 @@ pub struct HipRuntime {
         unsafe extern "C" fn(*mut c_void, *const c_void, usize, c_uint, HipStream) -> u32,
     fn_memset: unsafe extern "C" fn(*mut c_void, c_int, usize) -> u32,
     fn_memset_async: unsafe extern "C" fn(*mut c_void, c_int, usize, HipStream) -> u32,
+    fn_mem_address_reserve:
+        Option<unsafe extern "C" fn(*mut *mut c_void, usize, usize, *mut c_void, u64) -> u32>,
+    fn_mem_address_free: Option<unsafe extern "C" fn(*mut c_void, usize) -> u32>,
+    fn_mem_create: Option<
+        unsafe extern "C" fn(
+            *mut HipMemGenericAllocationHandle,
+            usize,
+            *const HipMemAllocationProp,
+            u64,
+        ) -> u32,
+    >,
+    fn_mem_get_allocation_granularity:
+        Option<unsafe extern "C" fn(*mut usize, *const HipMemAllocationProp, u32) -> u32>,
+    fn_mem_map: Option<
+        unsafe extern "C" fn(*mut c_void, usize, usize, HipMemGenericAllocationHandle, u64) -> u32,
+    >,
+    fn_mem_unmap: Option<unsafe extern "C" fn(*mut c_void, usize) -> u32>,
+    fn_mem_set_access:
+        Option<unsafe extern "C" fn(*mut c_void, usize, *const HipMemAccessDesc, usize) -> u32>,
+    fn_mem_release: Option<unsafe extern "C" fn(HipMemGenericAllocationHandle) -> u32>,
 
     // Streams
     fn_stream_create: unsafe extern "C" fn(*mut HipStream) -> u32,
@@ -234,6 +326,14 @@ macro_rules! load_fn {
             .get($name.as_bytes())
             .map_err(|e| HipError::new(0, &format!("failed to load symbol {}: {e}", $name)))?;
         *sym.into_raw()
+    }};
+}
+
+macro_rules! load_optional_fn {
+    ($lib:expr, $name:expr, $ty:ty) => {{
+        $lib.get::<$ty>($name.as_bytes())
+            .ok()
+            .map(|sym| *sym.into_raw())
     }};
 }
 
@@ -415,6 +515,57 @@ impl HipRuntime {
                     "hipMemsetAsync",
                     unsafe extern "C" fn(*mut c_void, c_int, usize, HipStream) -> u32
                 ),
+                fn_mem_address_reserve: load_optional_fn!(
+                    lib,
+                    "hipMemAddressReserve",
+                    unsafe extern "C" fn(*mut *mut c_void, usize, usize, *mut c_void, u64) -> u32
+                ),
+                fn_mem_address_free: load_optional_fn!(
+                    lib,
+                    "hipMemAddressFree",
+                    unsafe extern "C" fn(*mut c_void, usize) -> u32
+                ),
+                fn_mem_create: load_optional_fn!(
+                    lib,
+                    "hipMemCreate",
+                    unsafe extern "C" fn(
+                        *mut HipMemGenericAllocationHandle,
+                        usize,
+                        *const HipMemAllocationProp,
+                        u64,
+                    ) -> u32
+                ),
+                fn_mem_get_allocation_granularity: load_optional_fn!(
+                    lib,
+                    "hipMemGetAllocationGranularity",
+                    unsafe extern "C" fn(*mut usize, *const HipMemAllocationProp, u32) -> u32
+                ),
+                fn_mem_map: load_optional_fn!(
+                    lib,
+                    "hipMemMap",
+                    unsafe extern "C" fn(
+                        *mut c_void,
+                        usize,
+                        usize,
+                        HipMemGenericAllocationHandle,
+                        u64,
+                    ) -> u32
+                ),
+                fn_mem_unmap: load_optional_fn!(
+                    lib,
+                    "hipMemUnmap",
+                    unsafe extern "C" fn(*mut c_void, usize) -> u32
+                ),
+                fn_mem_set_access: load_optional_fn!(
+                    lib,
+                    "hipMemSetAccess",
+                    unsafe extern "C" fn(*mut c_void, usize, *const HipMemAccessDesc, usize) -> u32
+                ),
+                fn_mem_release: load_optional_fn!(
+                    lib,
+                    "hipMemRelease",
+                    unsafe extern "C" fn(HipMemGenericAllocationHandle) -> u32
+                ),
                 fn_stream_create: load_fn!(
                     lib,
                     "hipStreamCreate",
@@ -587,6 +738,12 @@ impl HipRuntime {
         }
     }
 
+    fn missing_vmm_symbol<T>(&self, symbol: &str, value: Option<T>) -> HipResult<T> {
+        value.ok_or_else(|| {
+            HipError::new(0, &format!("{symbol} is not available in this HIP runtime"))
+        })
+    }
+
     // ── Version ────────────────────────────────────────────────
 
     /// Get HIP runtime version as (major, minor). E.g. ROCm 6.3 → (6, 3).
@@ -731,14 +888,119 @@ impl HipRuntime {
         let mut ptr: *mut c_void = ptr::null_mut();
         let code = unsafe { (self.fn_malloc)(&mut ptr, size) };
         self.check(code, "hipMalloc")?;
-        Ok(DeviceBuffer { ptr, size })
+        Ok(DeviceBuffer {
+            ptr,
+            size,
+            ownership: crate::DeviceBufferOwnership::HipMalloc,
+        })
     }
 
     /// # Safety
     /// Caller must ensure the buffer is not in use by any pending GPU operations.
     pub fn free(&self, buf: DeviceBuffer) -> HipResult<()> {
+        if !buf.is_hip_allocation() {
+            return Err(HipError::new(
+                0,
+                "hipFree rejected a borrowed or VMM DeviceBuffer",
+            ));
+        }
         let code = unsafe { (self.fn_free)(buf.ptr) };
         self.check(code, "hipFree")
+    }
+
+    pub fn mem_get_allocation_granularity(
+        &self,
+        prop: &HipMemAllocationProp,
+        option: u32,
+    ) -> HipResult<usize> {
+        let func = self.missing_vmm_symbol(
+            "hipMemGetAllocationGranularity",
+            self.fn_mem_get_allocation_granularity,
+        )?;
+        let mut granularity: usize = 0;
+        let code = unsafe {
+            func(
+                &mut granularity,
+                prop as *const HipMemAllocationProp,
+                option,
+            )
+        };
+        self.check(code, "hipMemGetAllocationGranularity")?;
+        Ok(granularity)
+    }
+
+    pub fn mem_address_reserve(&self, size: usize, alignment: usize) -> HipResult<*mut c_void> {
+        let func = self.missing_vmm_symbol("hipMemAddressReserve", self.fn_mem_address_reserve)?;
+        let mut ptr: *mut c_void = ptr::null_mut();
+        let code = unsafe { func(&mut ptr, size, alignment, ptr::null_mut(), 0) };
+        self.check(code, "hipMemAddressReserve")?;
+        Ok(ptr)
+    }
+
+    /// # Safety
+    /// `ptr` and `size` must describe an unmapped reservation returned by
+    /// [`Self::mem_address_reserve`] that has not already been freed.
+    pub unsafe fn mem_address_free(&self, ptr: *mut c_void, size: usize) -> HipResult<()> {
+        let func = self.missing_vmm_symbol("hipMemAddressFree", self.fn_mem_address_free)?;
+        let code = unsafe { func(ptr, size) };
+        self.check(code, "hipMemAddressFree")
+    }
+
+    pub fn mem_create(
+        &self,
+        size: usize,
+        prop: &HipMemAllocationProp,
+    ) -> HipResult<HipMemGenericAllocationHandle> {
+        let func = self.missing_vmm_symbol("hipMemCreate", self.fn_mem_create)?;
+        let mut handle: HipMemGenericAllocationHandle = ptr::null_mut();
+        let code = unsafe { func(&mut handle, size, prop as *const HipMemAllocationProp, 0) };
+        self.check(code, "hipMemCreate")?;
+        Ok(handle)
+    }
+
+    /// # Safety
+    /// `ptr..ptr+size` must be a valid, currently unmapped VMM reservation and
+    /// `handle` must be a live allocation handle covering at least `size`.
+    pub unsafe fn mem_map(
+        &self,
+        ptr: *mut c_void,
+        size: usize,
+        handle: HipMemGenericAllocationHandle,
+    ) -> HipResult<()> {
+        let func = self.missing_vmm_symbol("hipMemMap", self.fn_mem_map)?;
+        let code = unsafe { func(ptr, size, 0, handle, 0) };
+        self.check(code, "hipMemMap")
+    }
+
+    /// # Safety
+    /// `ptr..ptr+size` must describe a currently mapped VMM range.
+    pub unsafe fn mem_unmap(&self, ptr: *mut c_void, size: usize) -> HipResult<()> {
+        let func = self.missing_vmm_symbol("hipMemUnmap", self.fn_mem_unmap)?;
+        let code = unsafe { func(ptr, size) };
+        self.check(code, "hipMemUnmap")
+    }
+
+    /// # Safety
+    /// `ptr..ptr+size` must describe a mapped VMM range and every descriptor
+    /// must identify a device allowed by the backing allocation.
+    pub unsafe fn mem_set_access(
+        &self,
+        ptr: *mut c_void,
+        size: usize,
+        descs: &[HipMemAccessDesc],
+    ) -> HipResult<()> {
+        let func = self.missing_vmm_symbol("hipMemSetAccess", self.fn_mem_set_access)?;
+        let code = unsafe { func(ptr, size, descs.as_ptr(), descs.len()) };
+        self.check(code, "hipMemSetAccess")
+    }
+
+    /// # Safety
+    /// `handle` must be live, owned by the caller, and no mapped range may
+    /// still reference it.
+    pub unsafe fn mem_release(&self, handle: HipMemGenericAllocationHandle) -> HipResult<()> {
+        let func = self.missing_vmm_symbol("hipMemRelease", self.fn_mem_release)?;
+        let code = unsafe { func(handle) };
+        self.check(code, "hipMemRelease")
     }
 
     /// Return the base and byte extent of the HIP allocation containing

--- a/crates/hip-bridge/src/lib.rs
+++ b/crates/hip-bridge/src/lib.rs
@@ -26,7 +26,7 @@ pub use ffi::{
 pub use kernarg::KernargBlob;
 pub use rccl::{RcclComms, RcclDataType, RcclError, RcclRedOp, RcclResult, NCCL_SUCCESS};
 pub use rocblas::{Rocblas, RocblasDatatype, RocblasError, RocblasOperation, RocblasResult};
-pub use vmm::VmmArena;
+pub use vmm::{clear_vmm_faults, inject_vmm_fault, VmmArena, VmmFaultKind};
 
 /// Re-export memory copy direction for callers.
 #[repr(u32)]

--- a/crates/hip-bridge/src/lib.rs
+++ b/crates/hip-bridge/src/lib.rs
@@ -11,16 +11,22 @@ mod ffi;
 mod kernarg;
 mod rccl;
 mod rocblas;
+mod vmm;
 
 pub use error::{
     HipError, HipResult, HIP_ERROR_INVALID_IMAGE, HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED,
     HIP_ERROR_PEER_ACCESS_NOT_ENABLED, HIP_ERROR_PEER_ACCESS_UNSUPPORTED,
 };
 pub use ffi::launch_counters;
-pub use ffi::{Event, Function, Graph, GraphExec, HipPointerAttribute, HipRuntime, Module, Stream};
+pub use ffi::{
+    Event, Function, Graph, GraphExec, HipMemAccessDesc, HipMemAllocationProp,
+    HipMemGenericAllocationHandle, HipMemLocation, HipPointerAttribute, HipRuntime, Module, Stream,
+    HIP_MEM_ALLOCATION_GRANULARITY_MINIMUM, HIP_MEM_ALLOCATION_GRANULARITY_RECOMMENDED,
+};
 pub use kernarg::KernargBlob;
 pub use rccl::{RcclComms, RcclDataType, RcclError, RcclRedOp, RcclResult, NCCL_SUCCESS};
 pub use rocblas::{Rocblas, RocblasDatatype, RocblasError, RocblasOperation, RocblasResult};
+pub use vmm::VmmArena;
 
 /// Re-export memory copy direction for callers.
 #[repr(u32)]
@@ -63,6 +69,14 @@ impl MemoryType {
 pub struct DeviceBuffer {
     ptr: *mut std::ffi::c_void,
     size: usize,
+    ownership: DeviceBufferOwnership,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeviceBufferOwnership {
+    HipMalloc,
+    Vmm,
+    Borrowed,
 }
 
 impl DeviceBuffer {
@@ -74,6 +88,18 @@ impl DeviceBuffer {
         self.size
     }
 
+    pub fn is_hip_allocation(&self) -> bool {
+        self.ownership == DeviceBufferOwnership::HipMalloc
+    }
+
+    pub fn is_vmm_owner(&self) -> bool {
+        self.ownership == DeviceBufferOwnership::Vmm
+    }
+
+    pub fn is_borrowed(&self) -> bool {
+        self.ownership == DeviceBufferOwnership::Borrowed
+    }
+
     /// Create a non-owning DeviceBuffer from a raw pointer and size.
     /// The caller must ensure the pointer is valid GPU memory.
     /// The resulting buffer must NOT be freed (it doesn't own the memory).
@@ -83,7 +109,25 @@ impl DeviceBuffer {
     /// `ptr` must point to at least `size` bytes of valid GPU-accessible
     /// memory for the lifetime of the returned non-owning wrapper.
     pub unsafe fn from_raw(ptr: *mut std::ffi::c_void, size: usize) -> DeviceBuffer {
-        DeviceBuffer { ptr, size }
+        DeviceBuffer {
+            ptr,
+            size,
+            ownership: DeviceBufferOwnership::Borrowed,
+        }
+    }
+
+    /// Create the unique owner descriptor for a VMM arena base address.
+    ///
+    /// # Safety
+    ///
+    /// The caller must register exactly one such descriptor with the VMM owner
+    /// that will unmap and release it. Aliases must use `from_raw` or `alias`.
+    pub unsafe fn from_vmm_owner(ptr: *mut std::ffi::c_void, size: usize) -> DeviceBuffer {
+        DeviceBuffer {
+            ptr,
+            size,
+            ownership: DeviceBufferOwnership::Vmm,
+        }
     }
 
     /// Create a non-owning alias to the same GPU memory.
@@ -95,6 +139,7 @@ impl DeviceBuffer {
         DeviceBuffer {
             ptr: self.ptr,
             size: self.size,
+            ownership: DeviceBufferOwnership::Borrowed,
         }
     }
 }
@@ -102,3 +147,29 @@ impl DeviceBuffer {
 // DeviceBuffer is Send — GPU pointers can be sent between threads.
 // They are NOT Sync — concurrent access requires stream synchronization.
 unsafe impl Send for DeviceBuffer {}
+
+#[cfg(test)]
+mod device_buffer_tests {
+    use super::*;
+
+    #[test]
+    fn raw_and_alias_buffers_are_borrowed() {
+        let raw = unsafe { DeviceBuffer::from_raw(std::ptr::dangling_mut(), 4096) };
+        assert!(raw.is_borrowed());
+        assert!(!raw.is_hip_allocation());
+        assert!(!raw.is_vmm_owner());
+
+        let alias = unsafe { raw.alias() };
+        assert!(alias.is_borrowed());
+    }
+
+    #[test]
+    fn vmm_owner_marker_is_distinct_from_views() {
+        let owner = unsafe { DeviceBuffer::from_vmm_owner(std::ptr::dangling_mut(), 4096) };
+        assert!(owner.is_vmm_owner());
+        assert!(!owner.is_borrowed());
+        let view = unsafe { owner.alias() };
+        assert!(view.is_borrowed());
+        assert!(!view.is_vmm_owner());
+    }
+}

--- a/crates/hip-bridge/src/vmm.rs
+++ b/crates/hip-bridge/src/vmm.rs
@@ -9,7 +9,66 @@ use crate::{
     DeviceBuffer, HipError, HipMemAccessDesc, HipMemAllocationProp, HipMemGenericAllocationHandle,
     HipResult, HipRuntime, HIP_MEM_ALLOCATION_GRANULARITY_RECOMMENDED,
 };
+use std::cell::Cell;
 use std::ffi::c_void;
+
+/// Deterministic, test-only fault injection for VMM teardown/access stages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VmmFaultKind {
+    /// Fail the next `hipMemSetAccess` call(s).
+    AccessReset,
+    /// Fail the next `hipMemUnmap` call(s).
+    Unmap,
+    /// Fail the next physical-handle `hipMemRelease` call(s).
+    Release,
+}
+
+thread_local! {
+    static FAULT_ACCESS: Cell<u32> = const { Cell::new(0) };
+    static FAULT_UNMAP: Cell<u32> = const { Cell::new(0) };
+    static FAULT_RELEASE: Cell<u32> = const { Cell::new(0) };
+}
+
+/// Queue `count` deterministic failures for `kind`. Test-only; real HIP is
+/// unchanged when the counter is zero.
+pub fn inject_vmm_fault(kind: VmmFaultKind, count: u32) {
+    match kind {
+        VmmFaultKind::AccessReset => FAULT_ACCESS.with(|c| c.set(count)),
+        VmmFaultKind::Unmap => FAULT_UNMAP.with(|c| c.set(count)),
+        VmmFaultKind::Release => FAULT_RELEASE.with(|c| c.set(count)),
+    }
+}
+
+/// Clear every pending injected VMM fault.
+pub fn clear_vmm_faults() {
+    FAULT_ACCESS.with(|c| c.set(0));
+    FAULT_UNMAP.with(|c| c.set(0));
+    FAULT_RELEASE.with(|c| c.set(0));
+}
+
+fn take_fault(kind: VmmFaultKind) -> Option<HipError> {
+    let cell = match kind {
+        VmmFaultKind::AccessReset => &FAULT_ACCESS,
+        VmmFaultKind::Unmap => &FAULT_UNMAP,
+        VmmFaultKind::Release => &FAULT_RELEASE,
+    };
+    cell.with(|c| {
+        let left = c.get();
+        if left == 0 {
+            return None;
+        }
+        c.set(left - 1);
+        let label = match kind {
+            VmmFaultKind::AccessReset => "access-reset",
+            VmmFaultKind::Unmap => "unmap",
+            VmmFaultKind::Release => "release",
+        };
+        Some(HipError::new(
+            0x564D_4D46, // 'VMMF'
+            &format!("injected VMM {label} failure"),
+        ))
+    })
+}
 
 #[derive(Debug)]
 struct VmmSegment {
@@ -194,7 +253,10 @@ impl VmmArena {
         // 4 KiB offsets (for example base+16 KiB). Reapplying access from the
         // reservation base over the contiguous mapped prefix is accepted and
         // also ensures newly-added peer devices gain access to older segments.
-        if let Err(err) = unsafe { hip.mem_set_access(self.base, next_mapped, &access) } {
+        if let Err(err) = take_fault(VmmFaultKind::AccessReset).map_or_else(
+            || unsafe { hip.mem_set_access(self.base, next_mapped, &access) },
+            Err,
+        ) {
             let err = HipError {
                 code: err.code,
                 message: format!(
@@ -318,8 +380,18 @@ impl VmmArena {
         let base = self.base;
         let mut first_error = cleanup_segments(
             &mut self.segments,
-            |offset, size| unsafe { hip.mem_unmap(offset_ptr(base, offset), size) },
-            |handle| unsafe { hip.mem_release(handle) },
+            |offset, size| {
+                if let Some(err) = take_fault(VmmFaultKind::Unmap) {
+                    return Err(err);
+                }
+                unsafe { hip.mem_unmap(offset_ptr(base, offset), size) }
+            },
+            |handle| {
+                if let Some(err) = take_fault(VmmFaultKind::Release) {
+                    return Err(err);
+                }
+                unsafe { hip.mem_release(handle) }
+            },
         )
         .err();
 
@@ -456,5 +528,39 @@ mod tests {
 
         cleanup_segments(&mut segments, |_, _| Ok(()), |_| Ok(())).unwrap();
         assert!(segments.is_empty());
+    }
+
+    #[test]
+    fn inject_vmm_fault_counters_are_consumed_once_each() {
+        clear_vmm_faults();
+        inject_vmm_fault(VmmFaultKind::Unmap, 2);
+        inject_vmm_fault(VmmFaultKind::Release, 1);
+        inject_vmm_fault(VmmFaultKind::AccessReset, 1);
+
+        let u1 = take_fault(VmmFaultKind::Unmap).unwrap();
+        let u2 = take_fault(VmmFaultKind::Unmap).unwrap();
+        assert!(take_fault(VmmFaultKind::Unmap).is_none());
+        assert!(u1.to_string().contains("unmap"));
+        assert!(u2.to_string().contains("unmap"));
+
+        let r = take_fault(VmmFaultKind::Release).unwrap();
+        assert!(r.to_string().contains("release"));
+        assert!(take_fault(VmmFaultKind::Release).is_none());
+
+        let a = take_fault(VmmFaultKind::AccessReset).unwrap();
+        assert!(a.to_string().contains("access-reset"));
+        assert!(take_fault(VmmFaultKind::AccessReset).is_none());
+        clear_vmm_faults();
+    }
+
+    #[test]
+    fn clear_vmm_faults_drops_pending_injections() {
+        inject_vmm_fault(VmmFaultKind::Unmap, 5);
+        inject_vmm_fault(VmmFaultKind::Release, 5);
+        inject_vmm_fault(VmmFaultKind::AccessReset, 5);
+        clear_vmm_faults();
+        assert!(take_fault(VmmFaultKind::Unmap).is_none());
+        assert!(take_fault(VmmFaultKind::Release).is_none());
+        assert!(take_fault(VmmFaultKind::AccessReset).is_none());
     }
 }

--- a/crates/hip-bridge/src/vmm.rs
+++ b/crates/hip-bridge/src/vmm.rs
@@ -1,0 +1,460 @@
+//! Explicit ownership for HIP virtual-memory mappings.
+//!
+//! `DeviceBuffer` and the existing GPU pool are released with `hipFree`, which
+//! is invalid for addresses reserved through the VMM API. `VmmArena` therefore
+//! keeps physical handles and mapping ranges separate and requires an explicit
+//! [`VmmArena::release`] call.
+
+use crate::{
+    DeviceBuffer, HipError, HipMemAccessDesc, HipMemAllocationProp, HipMemGenericAllocationHandle,
+    HipResult, HipRuntime, HIP_MEM_ALLOCATION_GRANULARITY_RECOMMENDED,
+};
+use std::ffi::c_void;
+
+#[derive(Debug)]
+struct VmmSegment {
+    offset: usize,
+    size: usize,
+    handle: Option<HipMemGenericAllocationHandle>,
+    mapped: bool,
+}
+
+#[must_use = "VMM arenas must be explicitly released with VmmArena::release"]
+pub struct VmmArena {
+    base: *mut c_void,
+    owner_device: i32,
+    granularity: usize,
+    reserved_bytes: usize,
+    mapped_bytes: usize,
+    segments: Vec<VmmSegment>,
+    access_devices: Vec<i32>,
+    releasing: bool,
+}
+
+// The HIP process address and allocation handles may move with model state.
+// Concurrent mutation is still excluded because VmmArena is not Sync.
+unsafe impl Send for VmmArena {}
+
+impl VmmArena {
+    pub fn reserve(hip: &HipRuntime, owner_device: i32, requested_bytes: usize) -> HipResult<Self> {
+        if requested_bytes == 0 {
+            return Err(HipError::new(
+                0,
+                "VMM reserve size must be greater than zero",
+            ));
+        }
+        let count = hip.device_count()?;
+        if owner_device < 0 || owner_device >= count {
+            return Err(HipError::new(
+                0,
+                &format!("VMM owner device {owner_device} is outside available range 0..{count}"),
+            ));
+        }
+
+        hip.set_device(owner_device)?;
+        let prop = HipMemAllocationProp::device_pinned(owner_device);
+        let granularity =
+            hip.mem_get_allocation_granularity(&prop, HIP_MEM_ALLOCATION_GRANULARITY_RECOMMENDED)?;
+        if granularity == 0 {
+            return Err(HipError::new(
+                0,
+                "HIP returned zero VMM allocation granularity",
+            ));
+        }
+        let reserved_bytes = round_up(requested_bytes, granularity)?;
+        let base = hip.mem_address_reserve(reserved_bytes, granularity)?;
+
+        Ok(Self {
+            base,
+            owner_device,
+            granularity,
+            reserved_bytes,
+            mapped_bytes: 0,
+            segments: Vec::new(),
+            access_devices: vec![owner_device],
+            releasing: false,
+        })
+    }
+
+    pub const fn owner_device(&self) -> i32 {
+        self.owner_device
+    }
+
+    pub const fn granularity(&self) -> usize {
+        self.granularity
+    }
+
+    pub const fn reserved_bytes(&self) -> usize {
+        self.reserved_bytes
+    }
+
+    pub const fn mapped_bytes(&self) -> usize {
+        self.mapped_bytes
+    }
+
+    pub fn base_address(&self) -> usize {
+        self.base as usize
+    }
+
+    pub fn is_released(&self) -> bool {
+        self.base.is_null()
+    }
+
+    pub fn map_next(
+        &mut self,
+        hip: &HipRuntime,
+        size: usize,
+        access_devices: &[i32],
+    ) -> HipResult<()> {
+        if self.releasing || self.is_released() {
+            return Err(HipError::new(
+                0,
+                "VMM arena is releasing or already released",
+            ));
+        }
+        if size == 0 || !size.is_multiple_of(self.granularity) {
+            return Err(HipError::new(
+                0,
+                &format!(
+                    "VMM map size {size} must be a non-zero multiple of granularity {}",
+                    self.granularity
+                ),
+            ));
+        }
+        let next_mapped = self
+            .mapped_bytes
+            .checked_add(size)
+            .ok_or_else(|| HipError::new(0, "VMM mapped byte count overflowed"))?;
+        if next_mapped > self.reserved_bytes {
+            return Err(HipError::new(
+                0,
+                &format!(
+                    "VMM map would exceed reserve: {} + {size} > {}",
+                    self.mapped_bytes, self.reserved_bytes
+                ),
+            ));
+        }
+
+        let count = hip.device_count()?;
+        let mut devices = Vec::with_capacity(access_devices.len() + 1);
+        devices.push(self.owner_device);
+        for &device in access_devices {
+            if device < 0 || device >= count {
+                return Err(HipError::new(
+                    0,
+                    &format!("VMM access device {device} is outside available range 0..{count}"),
+                ));
+            }
+            if device != self.owner_device && !hip.can_access_peer(device, self.owner_device)? {
+                return Err(HipError::new(
+                    0,
+                    &format!(
+                        "VMM access device {device} cannot access owner device {}",
+                        self.owner_device
+                    ),
+                ));
+            }
+            if !devices.contains(&device) {
+                devices.push(device);
+            }
+        }
+        let mut next_access_devices = self.access_devices.clone();
+        for device in devices {
+            if !next_access_devices.contains(&device) {
+                next_access_devices.push(device);
+            }
+        }
+        let access: Vec<_> = next_access_devices
+            .iter()
+            .copied()
+            .map(HipMemAccessDesc::read_write_device)
+            .collect();
+
+        hip.set_device(self.owner_device)?;
+        let prop = HipMemAllocationProp::device_pinned(self.owner_device);
+        let handle = hip.mem_create(size, &prop)?;
+        let address = offset_ptr(self.base, self.mapped_bytes);
+        if let Err(err) = unsafe { hip.mem_map(address, size, handle) } {
+            return match unsafe { hip.mem_release(handle) } {
+                Ok(()) => Err(err),
+                Err(cleanup) => {
+                    self.segments.push(VmmSegment {
+                        offset: self.mapped_bytes,
+                        size,
+                        handle: Some(handle),
+                        mapped: false,
+                    });
+                    self.releasing = true;
+                    Err(combined_cleanup_error(err, cleanup))
+                }
+            };
+        }
+        // ROCm 7.2 on gfx1100 accepts 4 KiB allocation granularity but rejects
+        // hipMemSetAccess when a later subrange begins at some otherwise-valid
+        // 4 KiB offsets (for example base+16 KiB). Reapplying access from the
+        // reservation base over the contiguous mapped prefix is accepted and
+        // also ensures newly-added peer devices gain access to older segments.
+        if let Err(err) = unsafe { hip.mem_set_access(self.base, next_mapped, &access) } {
+            let err = HipError {
+                code: err.code,
+                message: format!(
+                    "{}; VMM access prefix base=0x{:x} size={} (new segment address=0x{:x} offset={} size={}) granularity={}",
+                    err.message,
+                    self.base as usize,
+                    next_mapped,
+                    address as usize,
+                    self.mapped_bytes,
+                    size,
+                    self.granularity,
+                ),
+            };
+            let mut segment = VmmSegment {
+                offset: self.mapped_bytes,
+                size,
+                handle: Some(handle),
+                mapped: true,
+            };
+            let cleanup_error = match unsafe { hip.mem_unmap(address, size) } {
+                Ok(()) => {
+                    segment.mapped = false;
+                    match unsafe { hip.mem_release(handle) } {
+                        Ok(()) => {
+                            segment.handle = None;
+                            None
+                        }
+                        Err(cleanup) => Some(cleanup),
+                    }
+                }
+                Err(cleanup) => Some(cleanup),
+            };
+            return match cleanup_error {
+                None => Err(err),
+                Some(cleanup) => {
+                    self.segments.push(segment);
+                    self.releasing = true;
+                    Err(combined_cleanup_error(err, cleanup))
+                }
+            };
+        }
+
+        // Commit newly requested peer permissions only after the driver has
+        // accepted them. A failed expansion must remain retryable with the
+        // arena's previous permission set.
+        self.access_devices = next_access_devices;
+        self.segments.push(VmmSegment {
+            offset: self.mapped_bytes,
+            size,
+            handle: Some(handle),
+            mapped: true,
+        });
+        self.mapped_bytes = next_mapped;
+        Ok(())
+    }
+
+    /// Return a non-owning buffer view over the reserved virtual address.
+    ///
+    /// Only the mapped prefix may be accessed. The returned buffer must never
+    /// be passed to `HipRuntime::free` or a pool that eventually calls it.
+    pub fn buffer(&self, logical_bytes: usize) -> HipResult<DeviceBuffer> {
+        if self.releasing || self.is_released() {
+            return Err(HipError::new(
+                0,
+                "cannot create a buffer view from a releasing or released VMM arena",
+            ));
+        }
+        if logical_bytes > self.mapped_bytes {
+            return Err(HipError::new(
+                0,
+                &format!(
+                    "VMM buffer view {logical_bytes} exceeds mapped prefix {}",
+                    self.mapped_bytes
+                ),
+            ));
+        }
+        Ok(unsafe { DeviceBuffer::from_raw(self.base, logical_bytes) })
+    }
+
+    /// Return the unique owning descriptor for a reserved dense tensor.
+    ///
+    /// # Safety
+    ///
+    /// The returned buffer's safe byte length is capped at `mapped_bytes()`;
+    /// `logical_bytes` only validates the tensor's intended reserved extent.
+    /// The caller must register exactly one returned owner for arena teardown.
+    pub unsafe fn owner_buffer(&self, logical_bytes: usize) -> HipResult<DeviceBuffer> {
+        if self.releasing || self.is_released() {
+            return Err(HipError::new(
+                0,
+                "cannot create an owner from a releasing or released VMM arena",
+            ));
+        }
+        if logical_bytes > self.reserved_bytes {
+            return Err(HipError::new(
+                0,
+                &format!(
+                    "VMM owner view {logical_bytes} exceeds reserve {}",
+                    self.reserved_bytes
+                ),
+            ));
+        }
+        Ok(DeviceBuffer::from_vmm_owner(
+            self.base,
+            logical_bytes.min(self.mapped_bytes),
+        ))
+    }
+
+    /// Unmap every segment, release every physical handle, then free the VA.
+    /// Cleanup continues after an individual failure and returns the first one.
+    pub fn release(&mut self, hip: &HipRuntime) -> HipResult<()> {
+        if self.is_released() {
+            return Ok(());
+        }
+        self.releasing = true;
+        for &device in &self.access_devices {
+            hip.set_device(device)?;
+            hip.device_synchronize()?;
+        }
+        hip.set_device(self.owner_device)?;
+        let base = self.base;
+        let mut first_error = cleanup_segments(
+            &mut self.segments,
+            |offset, size| unsafe { hip.mem_unmap(offset_ptr(base, offset), size) },
+            |handle| unsafe { hip.mem_release(handle) },
+        )
+        .err();
+
+        if self.segments.is_empty() {
+            match unsafe { hip.mem_address_free(self.base, self.reserved_bytes) } {
+                Ok(()) => {
+                    self.base = std::ptr::null_mut();
+                    self.reserved_bytes = 0;
+                    self.mapped_bytes = 0;
+                    self.access_devices.clear();
+                }
+                Err(err) => {
+                    if first_error.is_none() {
+                        first_error = Some(err);
+                    }
+                }
+            }
+        }
+
+        match first_error {
+            Some(err) => Err(err),
+            None => Ok(()),
+        }
+    }
+}
+
+fn offset_ptr(base: *mut c_void, offset: usize) -> *mut c_void {
+    unsafe { (base as *mut u8).add(offset) as *mut c_void }
+}
+
+fn round_up(value: usize, alignment: usize) -> HipResult<usize> {
+    if alignment == 0 {
+        return Err(HipError::new(0, "VMM alignment must be greater than zero"));
+    }
+    let remainder = value % alignment;
+    if remainder == 0 {
+        Ok(value)
+    } else {
+        value
+            .checked_add(alignment - remainder)
+            .ok_or_else(|| HipError::new(0, "VMM reserve size overflowed during alignment"))
+    }
+}
+
+fn combined_cleanup_error(operation: HipError, cleanup: HipError) -> HipError {
+    HipError::new(
+        0,
+        &format!("{operation}; cleanup also failed: {cleanup}; VMM arena retained for retry"),
+    )
+}
+
+fn cleanup_segments(
+    segments: &mut Vec<VmmSegment>,
+    mut unmap: impl FnMut(usize, usize) -> HipResult<()>,
+    mut release: impl FnMut(HipMemGenericAllocationHandle) -> HipResult<()>,
+) -> HipResult<()> {
+    let mut first_error = None;
+    for segment in segments.iter_mut().rev() {
+        if segment.mapped {
+            match unmap(segment.offset, segment.size) {
+                Ok(()) => segment.mapped = false,
+                Err(err) => {
+                    if first_error.is_none() {
+                        first_error = Some(err);
+                    }
+                    continue;
+                }
+            }
+        }
+        if let Some(handle) = segment.handle {
+            match release(handle) {
+                Ok(()) => segment.handle = None,
+                Err(err) => {
+                    if first_error.is_none() {
+                        first_error = Some(err);
+                    }
+                }
+            }
+        }
+    }
+    segments.retain(|segment| segment.mapped || segment.handle.is_some());
+    match first_error {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn segment(mapped: bool) -> VmmSegment {
+        VmmSegment {
+            offset: 4096,
+            size: 4096,
+            handle: Some(1usize as HipMemGenericAllocationHandle),
+            mapped,
+        }
+    }
+
+    #[test]
+    fn failed_unmap_keeps_mapping_and_handle_for_retry() {
+        let mut segments = vec![segment(true)];
+        let mut releases = 0;
+        let err = cleanup_segments(
+            &mut segments,
+            |_, _| Err(HipError::new(1, "injected unmap failure")),
+            |_| {
+                releases += 1;
+                Ok(())
+            },
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("injected unmap failure"));
+        assert_eq!(releases, 0, "a still-mapped handle must not be released");
+        assert!(segments[0].mapped);
+        assert!(segments[0].handle.is_some());
+
+        cleanup_segments(&mut segments, |_, _| Ok(()), |_| Ok(())).unwrap();
+        assert!(segments.is_empty());
+    }
+
+    #[test]
+    fn failed_handle_release_keeps_handle_for_retry() {
+        let mut segments = vec![segment(false)];
+        cleanup_segments(
+            &mut segments,
+            |_, _| panic!("unmap must not run for an unmapped segment"),
+            |_| Err(HipError::new(2, "injected handle failure")),
+        )
+        .unwrap_err();
+        assert!(!segments[0].mapped);
+        assert!(segments[0].handle.is_some());
+
+        cleanup_segments(&mut segments, |_, _| Ok(()), |_| Ok(())).unwrap();
+        assert!(segments.is_empty());
+    }
+}

--- a/crates/hipfire-arch-cohere2moe/src/cohere2moe.rs
+++ b/crates/hipfire-arch-cohere2moe/src/cohere2moe.rs
@@ -549,7 +549,7 @@ impl Cohere2MoeState {
             logits,
             flash_partials,
         } = self;
-        kv.free_gpu(gpu);
+        let _ = kv.free_gpu(gpu);
         let _ = gpu.hip.free(pos_buf);
         for t in [
             h,

--- a/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
+++ b/crates/hipfire-arch-lfm2moe/src/lfm2moe.rs
@@ -1301,7 +1301,7 @@ impl Lfm2MoeState {
     }
 
     pub fn free_gpu(self, gpu: &mut Gpu) {
-        self.kv.free_gpu(gpu);
+        let _ = self.kv.free_gpu(gpu);
         for t in self.conv_states {
             let _ = gpu.free_tensor(t);
         }

--- a/crates/hipfire-arch-llama/examples/qwen3_dspark_bench.rs
+++ b/crates/hipfire-arch-llama/examples/qwen3_dspark_bench.rs
@@ -150,6 +150,7 @@ fn main() -> Result<(), String> {
         max_seq,
         draft_path: None,
         kv_mode_override: None,
+        kv_backend: hipfire_runtime::kv_backend::KvBackend::Contiguous,
         kv_adaptive_override: None,
         state_quant_override: None,
         cask: &cask,

--- a/crates/hipfire-arch-llama/src/dspark_body.rs
+++ b/crates/hipfire-arch-llama/src/dspark_body.rs
@@ -567,7 +567,7 @@ impl Qwen3DsparkScratch {
 
     /// Release all GPU allocations.
     pub fn free_gpu(self, gpu: &mut Gpu) {
-        self.kv.free_gpu(gpu);
+        let _ = self.kv.free_gpu(gpu);
         self.pbs.free_gpu(gpu);
         for t in [
             self.all_k,
@@ -1256,7 +1256,7 @@ impl DsparkBody for Qwen3DsparkBody {
             pbs,
         } = self.assets;
         weights.free_gpu(gpu);
-        kv.free_gpu(gpu);
+        let _ = kv.free_gpu(gpu);
         scratch.free_gpu(gpu);
         pbs.free_gpu(gpu);
     }

--- a/crates/hipfire-arch-minimax/src/minimax.rs
+++ b/crates/hipfire-arch-minimax/src/minimax.rs
@@ -922,7 +922,7 @@ impl MiniMaxState {
             final_rot,
             logits,
         } = self;
-        kv.free_gpu(gpu);
+        let _ = kv.free_gpu(gpu);
         // pos_buf is a raw DeviceBuffer (no Drop impl) — free explicitly.
         let _ = gpu.hip.free(pos_buf);
         for t in [
@@ -1065,7 +1065,6 @@ impl MiniMaxState {
     pub fn reset(&mut self) {
         self.n_tokens = 0;
     }
-
 }
 
 // ──────────────── ModelSource (safetensors) load helpers ────────────────

--- a/crates/hipfire-arch-qwen35/examples/mtp_head_smoke.rs
+++ b/crates/hipfire-arch-qwen35/examples/mtp_head_smoke.rs
@@ -215,7 +215,7 @@ fn main() -> HipResult<()> {
     // Free GPU buffers (not strictly required since we're exiting, but
     // confirms the free paths compile + don't panic).
     mtp_scratch.free_gpu(&mut gpu);
-    mtp_kv.free_gpu(&mut gpu);
+    let _ = mtp_kv.free_gpu(&mut gpu);
     head.free_gpu(&mut gpu);
 
     Ok(())

--- a/crates/hipfire-arch-qwen35/src/carrier.rs
+++ b/crates/hipfire-arch-qwen35/src/carrier.rs
@@ -53,7 +53,8 @@ pub fn load_bundle(src: ModelSource, ctx: &mut LoadCtx) -> Result<Qwen35Bundle, 
         physical_cap: Some(ctx.max_seq),
     };
     let mut kv =
-        KvCache::from_mode(mode, KvTarget::Single(ctx.gpu), &dims).map_err(|e| format!("{e}"))?;
+        KvCache::from_mode_with_backend(mode, ctx.kv_backend, KvTarget::Single(ctx.gpu), &dims)
+            .map_err(|e| format!("{e}"))?;
 
     // ── V-mode override via env ──────────────────────────────
     let kv_v_env = hipfire_config::developer_var("HIPFIRE_KV_V").unwrap_or_default();

--- a/crates/hipfire-arch-qwen35/src/carrier.rs
+++ b/crates/hipfire-arch-qwen35/src/carrier.rs
@@ -5,6 +5,7 @@ use crate::Qwen35;
 use hipfire_runtime::arch::Architecture;
 use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::kv_adaptive::{KvAdaptive, Preset};
+use hipfire_runtime::kv_backend::KvBackend;
 use hipfire_runtime::kv_mode::{self, ResolveResult};
 use hipfire_runtime::llama::{self, KvCache, KvDims, KvLayers, KvTarget};
 use hipfire_runtime::loader_api::{LoadCtx, ModelSource};
@@ -15,19 +16,89 @@ pub struct Qwen35Bundle {
     pub scratch: Qwen35Scratch,
     pub kv_cache: KvCache,
     pub dn_state: DeltaNetState,
+    /// Adaptive KV controller when engaged at load. Moved into
+    /// `LoadedModel.kv_adaptive` by `finish_qwen35_load`.
+    pub kv_adaptive: Option<KvAdaptive>,
 }
 
 /// Build the Qwen35 GPU bundle from an HFQ source.
+///
+/// CPU-only config/compat validation runs **before** weight upload. Every
+/// fallible GPU stage after weights is transactional: on failure, owners
+/// constructed so far are explicitly `free_gpu`'d (KvCache via
+/// [`KvCache::free_gpu`]) and the original error is preserved with any
+/// cleanup/VMM-pending context appended.
 pub fn load_bundle(src: ModelSource, ctx: &mut LoadCtx) -> Result<Qwen35Bundle, String> {
     let ModelSource::Hfq(mut hfq) = src else {
         return Err("qwen35: directory source unsupported".into());
     };
 
     let config = <Qwen35 as Architecture>::config_from_hfq(&hfq).map_err(|e| e.to_string())?;
+
+    // ── CPU-only parse + compatibility (zero GPU allocation) ─────────
+    let plan = plan_qwen35_gpu_stages(&config, ctx)?;
+    let dn_quant = parse_state_quant(ctx.state_quant_override)?;
+    eprintln!("  DeltaNet state: {}", state_quant_label(dn_quant));
+    warn_tiny_model_state(&hfq, dn_quant);
+
+    // ── Weight upload (first GPU ownership) ──────────────────────────
     let weights = <Qwen35 as Architecture>::load_weights(&mut hfq, &config, ctx.gpu)?;
     hipfire_runtime::maybe_screen_mmq(&weights, ctx.gpu);
 
-    // ── KV mode ──────────────────────────────────────────────
+    // ── KV (transactional: free weights on fail) ─────────────────────
+    let (kv, kv_adaptive) = match construct_kv_cache(&config, ctx, plan) {
+        Ok(v) => v,
+        Err(e) => {
+            weights.free_gpu(ctx.gpu);
+            return Err(append_cleanup_context(e, note_vmm_after_free(ctx.gpu)));
+        }
+    };
+
+    // ── DeltaNet state (free kv + weights on fail) ───────────────────
+    let dn = match DeltaNetState::new_with_quant(ctx.gpu, &config, dn_quant) {
+        Ok(v) => v,
+        Err(e) => {
+            let cleanup = free_kv_and_weights(kv, weights, ctx.gpu);
+            return Err(append_cleanup_context(format!("{e}"), cleanup));
+        }
+    };
+
+    // ── Scratch (free dn + kv + weights on fail) ─────────────────────
+    let scratch = match Qwen35Scratch::new_with_kv_max(ctx.gpu, &config, 2048, ctx.max_seq) {
+        Ok(v) => v,
+        Err(e) => {
+            let cleanup = free_dn_kv_and_weights(dn, kv, weights, ctx.gpu);
+            return Err(append_cleanup_context(format!("{e}"), cleanup));
+        }
+    };
+
+    Ok(Qwen35Bundle {
+        config,
+        weights,
+        scratch,
+        kv_cache: kv,
+        dn_state: dn,
+        kv_adaptive,
+    })
+}
+
+/// CPU-resolved KV construction inputs. Built before any weight upload so
+/// malformed adaptive / V / compat configs never touch device memory.
+struct Qwen35KvPlan {
+    mode: hipfire_runtime::kv_mode::KvMode,
+    is_kv_layer: Vec<bool>,
+    dims: KvDims,
+    /// `None` = static path. `Some` carries a fully-built controller (floors
+    /// authoritative) ready for adaptive KV construction.
+    adaptive: Option<KvAdaptive>,
+    /// Static path only: final V encoding (adaptive always starts Q8).
+    static_v: llama::VMode,
+    /// Original HIPFIRE_KV_V string for logging (static path).
+    kv_v_env: String,
+}
+
+/// All CPU-only validation that must precede `load_weights`.
+fn plan_qwen35_gpu_stages(config: &Qwen35Config, ctx: &LoadCtx) -> Result<Qwen35KvPlan, String> {
     let kv_mode = ctx
         .kv_mode_override
         .filter(|s| !s.is_empty())
@@ -45,18 +116,7 @@ pub fn load_bundle(src: ModelSource, ctx: &mut LoadCtx) -> Result<Qwen35Bundle, 
     if let Some(w) = warning {
         eprintln!("  KV cache: {w} (site {})", kv_mode::QWEN35_HFQ_POLICY.site);
     }
-    let dims = KvDims {
-        layers: KvLayers::Mask(is_kv_layer),
-        n_kv_heads: config.n_kv_heads,
-        head_dim: config.head_dim,
-        max_seq: ctx.max_seq,
-        physical_cap: Some(ctx.max_seq),
-    };
-    let mut kv =
-        KvCache::from_mode_with_backend(mode, ctx.kv_backend, KvTarget::Single(ctx.gpu), &dims)
-            .map_err(|e| format!("{e}"))?;
 
-    // ── V-mode override via env ──────────────────────────────
     let kv_v_env = hipfire_config::developer_var("HIPFIRE_KV_V").unwrap_or_default();
     let v_mode_override = match kv_v_env.as_str() {
         "lloyd2" => Some(llama::VMode::Lloyd2),
@@ -64,92 +124,296 @@ pub fn load_bundle(src: ModelSource, ctx: &mut LoadCtx) -> Result<Qwen35Bundle, 
         "lloyd4" => Some(llama::VMode::Lloyd4),
         "q8" | "" => None,
         other => {
-            eprintln!("[hipfire-arch-qwen35] HIPFIRE_KV_V='{other}' unknown — ignoring (expected q8|lloyd2|lloyd3|lloyd4)");
-            None
+            return Err(format!(
+                "HIPFIRE_KV_V='{other}' unknown (expected q8|lloyd2|lloyd3|lloyd4)"
+            ));
         }
     };
-    if let Some(vm) = v_mode_override {
-        if (kv.quant_asym2 || kv.quant_asym3 || kv.quant_asym4) && kv.quant_fwht {
-            kv.set_v_mode_realloc(ctx.gpu, vm)
-                .map_err(|e| format!("{e}"))?;
-            eprintln!(
-                    "[hipfire-arch-qwen35] V-cache mode override → {kv_v_env} (256-wide lloyd-V on fwht K)"
-                );
-        } else {
-            eprintln!("[hipfire-arch-qwen35] HIPFIRE_KV_V={kv_v_env} ignored — lloyd-V requires an FWHT K mode (fwht2/3/4); cache is a different mode");
-        }
-    }
 
-    // ── KV adaptive ──────────────────────────────────────────
     let kv_adaptive_spec = ctx
         .kv_adaptive_override
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
         .unwrap_or_else(|| hipfire_runtime::config::get().kv_adaptive.clone());
+    let adaptive_req = parse_kv_adaptive(&kv_adaptive_spec)?;
 
-    let _kv_adaptive: Option<KvAdaptive> = {
-        match parse_kv_adaptive(&kv_adaptive_spec) {
-            None => None,
-            Some((preset, k_floor, v_floor)) => {
-                let ad = match preset {
-                    Some(p) => {
-                        KvAdaptive::from_preset(p, ctx.max_seq, config.n_kv_heads, config.head_dim)
-                    }
-                    None => KvAdaptive::new(
-                        ctx.max_seq,
-                        config.n_kv_heads,
-                        config.head_dim,
-                        k_floor,
-                        v_floor,
-                    ),
-                };
-                if !((kv.quant_asym2 || kv.quant_asym3 || kv.quant_asym4) && kv.quant_fwht) {
-                    eprintln!("[hipfire-arch-qwen35] kv_adaptive={kv_adaptive_spec} ignored — adaptive KV requires an FWHT K mode (fwht2/3/4); cache is a different mode");
-                    None
-                } else if ctx.cask.sidecar.is_some() {
-                    eprintln!("[hipfire-arch-qwen35] kv_adaptive={kv_adaptive_spec} ignored — adaptive KV is a no-eviction capacity strategy and CASK eviction is active (mutually exclusive)");
-                    None
-                } else if ad.current_cap() < hipfire_runtime::llama::PREFILL_MAX_BATCH {
-                    eprintln!(
-                            "[hipfire-arch-qwen35] kv_adaptive={kv_adaptive_spec} ignored — max_seq={} too small: start-tier capacity {} < prefill chunk {}",
-                            ctx.max_seq, ad.current_cap(), hipfire_runtime::llama::PREFILL_MAX_BATCH,
-                        );
-                    None
-                } else {
-                    if !kv.quant_asym4 {
-                        eprintln!("[hipfire-arch-qwen35] kv_adaptive: adaptive works best with kv_mode=fwht4 (K starts at fwht4); current K mode is not fwht4");
-                    }
-                    let k_floor_bph = k_floor.bytes_per_head(config.head_dim);
-                    kv.set_adaptive_floor_alloc(ctx.gpu, v_floor, k_floor_bph)
-                        .map_err(|e| format!("{e}"))?;
-                    eprintln!(
-                            "[adaptive-kv] engaged: pattern={:?} k_floor={:?} v_floor={:?} thresholds={:?} start_cap={} (max_seq={}, V buffer sized at floor)",
-                            ad.steps, ad.k_floor, ad.v_floor, ad.thresholds, ad.current_cap(), ctx.max_seq,
-                        );
-                    Some(ad)
-                }
+    // Adaptive DFlash is out of scope: refuse explicit adaptive + DFlash draft.
+    if adaptive_req.is_some() {
+        if let Some(draft) = ctx.draft_path {
+            if !draft.is_empty() {
+                return Err(
+                    "kv_adaptive is incompatible with DFlash (adaptive×DFlash is out of scope); \
+                     disable one of HIPFIRE_KV_ADAPTIVE / draft path"
+                        .into(),
+                );
             }
         }
+        if ctx.pp > 1 {
+            return Err("kv_adaptive requires single-GPU (pp=1)".into());
+        }
+        if ctx.cask.sidecar.is_some() {
+            return Err(
+                "kv_adaptive is a no-eviction capacity strategy and cannot combine with CASK"
+                    .into(),
+            );
+        }
+        if let Some(vm) = v_mode_override {
+            return Err(format!(
+                "kv_adaptive cannot combine with explicit HIPFIRE_KV_V={vm:?}; \
+                 adaptive always starts V=q8 and downshifts via the controller"
+            ));
+        }
+        if config.head_dim != 256 {
+            return Err(format!(
+                "kv_adaptive requires head_dim=256 (got {})",
+                config.head_dim
+            ));
+        }
+    }
+
+    let dims = KvDims {
+        layers: KvLayers::Mask(is_kv_layer.clone()),
+        n_kv_heads: config.n_kv_heads,
+        head_dim: config.head_dim,
+        max_seq: ctx.max_seq,
+        physical_cap: Some(ctx.max_seq),
     };
 
-    // ── DeltaNet state ───────────────────────────────────────
-    let dn_quant = parse_state_quant(ctx.state_quant_override)?;
-    eprintln!("  DeltaNet state: {}", state_quant_label(dn_quant));
-    warn_tiny_model_state(&hfq, dn_quant);
-    let dn =
-        DeltaNetState::new_with_quant(ctx.gpu, &config, dn_quant).map_err(|e| format!("{e}"))?;
+    if let Some((preset, k_floor, v_floor)) = adaptive_req {
+        // Build controller first — floors and thresholds are authoritative.
+        let ad = match preset {
+            Some(p) => KvAdaptive::from_preset(p, ctx.max_seq, config.n_kv_heads, config.head_dim),
+            None => KvAdaptive::new(
+                ctx.max_seq,
+                config.n_kv_heads,
+                config.head_dim,
+                k_floor,
+                v_floor,
+            ),
+        };
+        if ad.current_cap() < hipfire_runtime::llama::PREFILL_MAX_BATCH {
+            return Err(format!(
+                "kv_adaptive={kv_adaptive_spec}: max_seq={} too small: start-tier capacity {} < prefill chunk {}",
+                ctx.max_seq,
+                ad.current_cap(),
+                hipfire_runtime::llama::PREFILL_MAX_BATCH,
+            ));
+        }
+        Ok(Qwen35KvPlan {
+            mode,
+            is_kv_layer,
+            dims,
+            adaptive: Some(ad),
+            static_v: llama::VMode::Q8,
+            kv_v_env,
+        })
+    } else {
+        // Static path: final K mode + optional Lloyd-V known before allocation.
+        let static_v = v_mode_override.unwrap_or(llama::VMode::Q8);
+        if !matches!(static_v, llama::VMode::Q8) {
+            let is_fwht = matches!(
+                mode,
+                hipfire_runtime::kv_mode::KvMode::Fwht2
+                    | hipfire_runtime::kv_mode::KvMode::Fwht3
+                    | hipfire_runtime::kv_mode::KvMode::Fwht4
+            );
+            if !is_fwht {
+                return Err(format!(
+                    "HIPFIRE_KV_V={kv_v_env} requires an FWHT K mode (fwht2/3/4); resolved mode is {mode:?}"
+                ));
+            }
+        }
+        Ok(Qwen35KvPlan {
+            mode,
+            is_kv_layer,
+            dims,
+            adaptive: None,
+            static_v,
+            kv_v_env,
+        })
+    }
+}
 
-    // ── Scratch ──────────────────────────────────────────────
-    let scratch = Qwen35Scratch::new_with_kv_max(ctx.gpu, &config, 2048, ctx.max_seq)
-        .map_err(|e| format!("{e}"))?;
+fn construct_kv_cache(
+    config: &Qwen35Config,
+    ctx: &mut LoadCtx,
+    plan: Qwen35KvPlan,
+) -> Result<(KvCache, Option<KvAdaptive>), String> {
+    if let Some(ad) = plan.adaptive {
+        // Floors come from the controller, not separately parsed hints.
+        let k_floor = ad.k_floor;
+        let v_floor = ad.v_floor;
+        // Adaptive always starts exactly FWHT4/Q8 regardless of resolved static mode.
+        let start_mode = hipfire_runtime::kv_mode::KvMode::Fwht4;
+        let k_floor_bph = k_floor.bytes_per_head(config.head_dim);
 
-    Ok(Qwen35Bundle {
-        config,
+        let kv = match ctx.kv_backend {
+            KvBackend::Vmm => {
+                // Floor-reserved VMM arenas; current encoding FWHT4/Q8.
+                KvCache::new_gpu_vmm_adaptive_filtered(
+                    ctx.gpu,
+                    &plan.is_kv_layer,
+                    config.n_kv_heads,
+                    config.head_dim,
+                    ctx.max_seq,
+                    k_floor_bph,
+                    v_floor,
+                )
+                .map_err(|e| format!("{e}"))?
+            }
+            KvBackend::Contiguous => {
+                // Contiguous: allocate start-tier FWHT4/Q8 then floor-resize in place.
+                // If floor-resize fails, free the start-tier cache explicitly.
+                let mut kv = KvCache::from_mode_with_backend(
+                    start_mode,
+                    KvBackend::Contiguous,
+                    KvTarget::Single(ctx.gpu),
+                    &plan.dims,
+                )
+                .map_err(|e| format!("{e}"))?;
+                if let Err(e) = kv.set_adaptive_floor_alloc(ctx.gpu, v_floor, k_floor_bph) {
+                    let cleanup = kv.free_gpu(ctx.gpu).map_err(|fe| fe.to_string());
+                    return Err(append_cleanup_context(format!("{e}"), cleanup));
+                }
+                kv
+            }
+        };
+
+        eprintln!(
+            "[adaptive-kv] engaged: backend={:?} pattern={:?} k_floor={:?} v_floor={:?} thresholds={:?} start_cap={} (max_seq={}, reserve at floor, start FWHT4/Q8)",
+            ctx.kv_backend,
+            ad.steps,
+            ad.k_floor,
+            ad.v_floor,
+            ad.thresholds,
+            ad.current_cap(),
+            ctx.max_seq,
+        );
+        Ok((kv, Some(ad)))
+    } else {
+        let static_v = plan.static_v;
+        let mode = plan.mode;
+        let kv = match (ctx.kv_backend, static_v) {
+            (KvBackend::Vmm, vm) => {
+                // Unified VMM constructor: reserve == current; never post-alloc realloc.
+                KvCache::new_gpu_vmm_capped_filtered(
+                    ctx.gpu,
+                    &plan.is_kv_layer,
+                    config.n_kv_heads,
+                    config.head_dim,
+                    ctx.max_seq,
+                    ctx.max_seq,
+                    mode,
+                    vm,
+                )
+                .map_err(|e| format!("{e}"))?
+            }
+            (KvBackend::Contiguous, llama::VMode::Q8) => KvCache::from_mode_with_backend(
+                mode,
+                KvBackend::Contiguous,
+                KvTarget::Single(ctx.gpu),
+                &plan.dims,
+            )
+            .map_err(|e| format!("{e}"))?,
+            (KvBackend::Contiguous, vm) => {
+                let mut kv = KvCache::from_mode_with_backend(
+                    mode,
+                    KvBackend::Contiguous,
+                    KvTarget::Single(ctx.gpu),
+                    &plan.dims,
+                )
+                .map_err(|e| format!("{e}"))?;
+                if let Err(e) = kv.set_v_mode_realloc(ctx.gpu, vm) {
+                    let cleanup = kv.free_gpu(ctx.gpu).map_err(|fe| fe.to_string());
+                    return Err(append_cleanup_context(format!("{e}"), cleanup));
+                }
+                kv
+            }
+        };
+        if !matches!(static_v, llama::VMode::Q8) {
+            eprintln!(
+                "[hipfire-arch-qwen35] V-cache mode override → {} (256-wide lloyd-V on fwht K)",
+                plan.kv_v_env
+            );
+        }
+        Ok((kv, None))
+    }
+}
+
+/// Free a fully constructed bundle. Used by loader finish-path rollback.
+/// Returns the first free error (VMM teardown) if any; always attempts full cleanup.
+pub fn free_qwen35_bundle(bundle: Qwen35Bundle, gpu: &mut rdna_compute::Gpu) -> Result<(), String> {
+    let Qwen35Bundle {
+        config: _,
         weights,
         scratch,
-        kv_cache: kv,
-        dn_state: dn,
+        kv_cache,
+        dn_state,
+        kv_adaptive: _,
+    } = bundle;
+    // Match unload_model Qwen35 order: kv → scratch → weights → dn.
+    let mut first: Option<String> = None;
+    if let Err(e) = kv_cache.free_gpu(gpu) {
+        first = Some(e.to_string());
+    }
+    scratch.free_gpu(gpu);
+    weights.free_gpu(gpu);
+    dn_state.free_gpu(gpu);
+    let vmm = note_vmm_after_free(gpu);
+    match (first, vmm) {
+        (None, Ok(())) => Ok(()),
+        (Some(e), Ok(())) => Err(e),
+        (None, Err(c)) => Err(c),
+        (Some(e), Err(c)) => Err(format!("{e}; cleanup also failed: {c}")),
+    }
+}
+
+fn free_kv_and_weights(
+    kv: KvCache,
+    weights: Qwen35Weights,
+    gpu: &mut rdna_compute::Gpu,
+) -> Result<(), String> {
+    let mut first: Option<String> = None;
+    if let Err(e) = kv.free_gpu(gpu) {
+        first = Some(e.to_string());
+    }
+    weights.free_gpu(gpu);
+    match first {
+        Some(e) => Err(append_cleanup_context(e, note_vmm_after_free(gpu))),
+        None => note_vmm_after_free(gpu),
+    }
+}
+
+fn free_dn_kv_and_weights(
+    dn: DeltaNetState,
+    kv: KvCache,
+    weights: Qwen35Weights,
+    gpu: &mut rdna_compute::Gpu,
+) -> Result<(), String> {
+    let mut first: Option<String> = None;
+    if let Err(e) = kv.free_gpu(gpu) {
+        first = Some(e.to_string());
+    }
+    dn.free_gpu(gpu);
+    weights.free_gpu(gpu);
+    match first {
+        Some(e) => Err(append_cleanup_context(e, note_vmm_after_free(gpu))),
+        None => note_vmm_after_free(gpu),
+    }
+}
+
+fn note_vmm_after_free(gpu: &mut rdna_compute::Gpu) -> Result<(), String> {
+    gpu.ensure_vmm_cleaned().map_err(|e| {
+        format!("pending VMM teardown after free ({e}); retry unload or restart the process")
     })
+}
+
+/// Preserve the primary operation error; append cleanup failure context when present.
+fn append_cleanup_context(op_err: String, cleanup: Result<(), String>) -> String {
+    match cleanup {
+        Ok(()) => op_err,
+        Err(c) => format!("{op_err}; cleanup also failed: {c}"),
+    }
 }
 
 // ─── Helper: StateQuant parsing ─────────────────────────────────────
@@ -200,20 +464,34 @@ fn warn_tiny_model_state(hfq: &HfqFile, q: StateQuant) {
 
 // ─── Helper: KV adaptive parsing ──────────────────────────────────
 
+/// Parse adaptive policy. `Ok(None)` = off. Malformed/unsupported explicit
+/// requests are hard errors (no silent ignore).
 fn parse_kv_adaptive(
     s: &str,
-) -> Option<(
-    Option<Preset>,
-    hipfire_runtime::kv_adaptive::KMode,
-    hipfire_runtime::llama::VMode,
-)> {
+) -> Result<
+    Option<(
+        Option<Preset>,
+        hipfire_runtime::kv_adaptive::KMode,
+        hipfire_runtime::llama::VMode,
+    )>,
+    String,
+> {
     use hipfire_runtime::kv_adaptive::{KMode, Preset};
     use hipfire_runtime::llama::VMode;
     match s {
-        "" | "off" => None,
-        "conservative" => Some((Some(Preset::Conservative), KMode::Fwht4, VMode::Lloyd4)),
-        "balanced" => Some((Some(Preset::Balanced), KMode::Fwht2, VMode::Lloyd2)),
-        "aggressive" => Some((Some(Preset::Aggressive), KMode::Fwht2, VMode::Lloyd2)),
+        "" | "off" => Ok(None),
+        // Floors agree with KvAdaptive::from_preset: C=F4/L4, B=F3/L3, A=F2/L2.
+        "conservative" => Ok(Some((
+            Some(Preset::Conservative),
+            KMode::Fwht4,
+            VMode::Lloyd4,
+        ))),
+        "balanced" => Ok(Some((Some(Preset::Balanced), KMode::Fwht3, VMode::Lloyd3))),
+        "aggressive" => Ok(Some((
+            Some(Preset::Aggressive),
+            KMode::Fwht2,
+            VMode::Lloyd2,
+        ))),
         other if other.starts_with("advanced:") => {
             let spec = &other["advanced:".len()..];
             let mut k = None;
@@ -227,20 +505,102 @@ fn parse_kv_adaptive(
                     (Some("v"), Some("lloyd4")) => v = Some(VMode::Lloyd4),
                     (Some("v"), Some("lloyd3")) => v = Some(VMode::Lloyd3),
                     (Some("v"), Some("lloyd2")) => v = Some(VMode::Lloyd2),
-                    _ => {}
+                    (Some(key), Some(val)) => {
+                        return Err(format!(
+                            "kv_adaptive='{other}' unknown key/value {key}={val} \
+                             (expected advanced:k=<fwht4|fwht3|fwht2>,v=<lloyd4|lloyd3|lloyd2>)"
+                        ));
+                    }
+                    _ => {
+                        return Err(format!(
+                            "kv_adaptive='{other}' malformed \
+                             (expected advanced:k=<fwht4|fwht3|fwht2>,v=<lloyd4|lloyd3|lloyd2>)"
+                        ));
+                    }
                 }
             }
             match (k, v) {
-                (Some(k), Some(v)) => Some((None, k, v)),
-                _ => {
-                    eprintln!("[hipfire-arch-qwen35] kv_adaptive='{other}' malformed — expected advanced:k=<fwht4|fwht3|fwht2>,v=<lloyd4|lloyd3|lloyd2>; ignoring");
-                    None
-                }
+                (Some(k), Some(v)) => Ok(Some((None, k, v))),
+                _ => Err(format!(
+                    "kv_adaptive='{other}' incomplete \
+                     (expected advanced:k=<fwht4|fwht3|fwht2>,v=<lloyd4|lloyd3|lloyd2>)"
+                )),
             }
         }
-        other => {
-            eprintln!("[hipfire-arch-qwen35] kv_adaptive='{other}' unknown — expected off|conservative|balanced|aggressive|advanced:k=..,v=..; ignoring");
-            None
+        other => Err(format!(
+            "kv_adaptive='{other}' unknown \
+             (expected off|conservative|balanced|aggressive|advanced:k=..,v=..)"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hipfire_runtime::kv_adaptive::{KMode, Preset};
+    use hipfire_runtime::llama::VMode;
+
+    #[test]
+    fn parse_presets_agree_with_controller_floors() {
+        let cases = [
+            (
+                "conservative",
+                Preset::Conservative,
+                KMode::Fwht4,
+                VMode::Lloyd4,
+            ),
+            ("balanced", Preset::Balanced, KMode::Fwht3, VMode::Lloyd3),
+            (
+                "aggressive",
+                Preset::Aggressive,
+                KMode::Fwht2,
+                VMode::Lloyd2,
+            ),
+        ];
+        for (spec, preset, k, v) in cases {
+            let parsed = parse_kv_adaptive(spec).unwrap().unwrap();
+            assert_eq!(parsed.0, Some(preset));
+            assert_eq!(parsed.1, k);
+            assert_eq!(parsed.2, v);
+            let ad = KvAdaptive::from_preset(preset, 10_000, 4, 256);
+            assert_eq!(
+                (ad.k_floor, ad.v_floor),
+                (k, v),
+                "parse floors must match KvAdaptive::from_preset for {spec}"
+            );
         }
+    }
+
+    #[test]
+    fn parse_off_and_errors() {
+        assert!(parse_kv_adaptive("off").unwrap().is_none());
+        assert!(parse_kv_adaptive("").unwrap().is_none());
+        assert!(parse_kv_adaptive("nope").is_err());
+        assert!(parse_kv_adaptive("advanced:k=fwht2").is_err());
+        assert!(parse_kv_adaptive("advanced:k=fwht9,v=lloyd2").is_err());
+    }
+
+    /// Malformed adaptive must fail in the CPU parse/plan seam — before any
+    /// weight upload would run. Observable contract: pure helpers error with
+    /// no GPU required.
+    #[test]
+    fn malformed_adaptive_fails_in_cpu_plan() {
+        // Direct plan path: parse_kv_adaptive is the CPU seam for malformed specs.
+        let err = parse_kv_adaptive("not-a-preset").unwrap_err();
+        assert!(err.contains("unknown"), "{err}");
+        let err = parse_kv_adaptive("advanced:k=fwht2").unwrap_err();
+        assert!(
+            err.contains("incomplete") || err.contains("malformed"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn append_cleanup_preserves_primary_error() {
+        let s = append_cleanup_context("kv failed".into(), Ok(()));
+        assert_eq!(s, "kv failed");
+        let s = append_cleanup_context("kv failed".into(), Err("pending VMM teardown".into()));
+        assert!(s.starts_with("kv failed; cleanup also failed:"), "{s}");
+        assert!(s.contains("pending VMM"), "{s}");
     }
 }

--- a/crates/hipfire-arch-qwen35/src/lib.rs
+++ b/crates/hipfire-arch-qwen35/src/lib.rs
@@ -76,7 +76,7 @@ pub mod spec_emit;
 pub use arch::Qwen35;
 
 #[cfg(feature = "deltanet")]
-pub use carrier::{load_bundle as load_qwen35_bundle, Qwen35Bundle};
+pub use carrier::{free_qwen35_bundle, load_bundle as load_qwen35_bundle, Qwen35Bundle};
 #[cfg(feature = "deltanet")]
 pub use mtp_compose::{spec_step_dflash_mtp_tree, MtpComposeTreeResult, MtpComposeTreeState};
 #[cfg(feature = "deltanet")]

--- a/crates/hipfire-arch-qwen35/src/mtp_compose.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_compose.rs
@@ -141,7 +141,7 @@ impl MtpComposeState {
         // Qwen35MtpHeadKvCache::free_gpu does `drop(inner)` which does not
         // release GPU memory (llama::KvCache has no Drop). Call the inner
         // KvCache's own free_gpu directly to properly hipFree each tensor.
-        self.mtp_kv.inner.free_gpu(gpu);
+        let _ = self.mtp_kv.inner.free_gpu(gpu);
     }
 }
 
@@ -711,7 +711,7 @@ impl MtpComposeTreeState {
         // Qwen35MtpHeadKvCache::free_gpu does `drop(inner)` which does not
         // release GPU memory (llama::KvCache has no Drop). Call the inner
         // KvCache's own free_gpu directly to properly hipFree each tensor.
-        self.mtp_kv.inner.free_gpu(gpu);
+        let _ = self.mtp_kv.inner.free_gpu(gpu);
     }
 }
 

--- a/crates/hipfire-arch-qwen35/src/mtp_head.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_head.rs
@@ -729,7 +729,7 @@ impl Qwen35MtpHeadKvCache {
         // leaks the k_gpu/v_gpu buffers. Free them explicitly. (The old
         // "they free on Drop" comment was false; see mtp_spec/mtp_compose
         // which already bypass this wrapper for the same reason.)
-        self.inner.free_gpu(gpu);
+        let _ = self.inner.free_gpu(gpu);
     }
 }
 

--- a/crates/hipfire-arch-qwen35/src/mtp_spec.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_spec.rs
@@ -122,7 +122,9 @@ fn mtp_q8_verify_wmma_enabled_from_env() -> bool {
     // WMMA when the arch/shape supports it, otherwise it falls back to scalar.
     // Prompt-sweep parity is clean; opt out with HIPFIRE_MTP_Q8_VERIFY_WMMA=0.
     mtp_q8_verify_wmma_enabled_from_env_value(
-        hipfire_config::developer_var("HIPFIRE_MTP_Q8_VERIFY_WMMA").ok().as_deref(),
+        hipfire_config::developer_var("HIPFIRE_MTP_Q8_VERIFY_WMMA")
+            .ok()
+            .as_deref(),
     )
 }
 
@@ -180,7 +182,9 @@ fn mtp_proposal_graph_policy_from_env_value(value: Option<&str>) -> MtpProposalG
 
 fn mtp_proposal_graph_policy_from_env() -> MtpProposalGraphPolicy {
     mtp_proposal_graph_policy_from_env_value(
-        hipfire_config::developer_var("HIPFIRE_MTP_PROPOSAL_GRAPH").ok().as_deref(),
+        hipfire_config::developer_var("HIPFIRE_MTP_PROPOSAL_GRAPH")
+            .ok()
+            .as_deref(),
     )
 }
 
@@ -832,7 +836,7 @@ impl MtpSpecState {
         // Qwen35MtpHeadKvCache::free_gpu does `drop(inner)` which does not
         // release GPU memory (llama::KvCache has no Drop). Call the inner
         // KvCache's own free_gpu directly to properly hipFree each tensor.
-        self.mtp_kv.inner.free_gpu(gpu);
+        let _ = self.mtp_kv.inner.free_gpu(gpu);
     }
 }
 
@@ -1122,14 +1126,51 @@ fn assemble_greedy_accept_from_gpu_result(
 
 /// DS4-style Qwen MTP prefill fill.
 ///
-/// Runs trunk prefill once while capturing post-output-norm hidden for every
+/// Runs trunk prefill while capturing post-output-norm hidden for every
 /// prompt token, then runs the MTP block-only path over those same prompt
 /// positions. The MTP layer enters decode with a warm private KV cache instead
 /// of starting at the first generated token.
+///
+/// Trunk prefill is split into `<= PREFILL_MAX_BATCH` committed chunks so
+/// adaptive-KV (and similar) controllers can run `maybe_downshift` between
+/// chunks at the exact committed trunk position. Without that boundary the
+/// internal `forward_prefill_batch` loop would write past the current-tier
+/// capacity (adaptive start `side_cap`) before any downshift could fire —
+/// post-prefill-only downshift is insufficient when prompt_len > start cap.
+///
+/// MTP private-cache offsets stay absolute: each chunk fills MTP KV at
+/// `start_pos + off + i` (same schedule as the trunk), so multi-chunk prefill
+/// is position-identical to a single whole-prompt fill. Non-adaptive callers
+/// keep the same end state: full trunk KV + full MTP private KV + last-token logits.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TrunkSpinePrefillTimings {
     pub trunk_prefill_secs: f64,
     pub mtp_prompt_fill_secs: f64,
+}
+
+/// Absolute trunk positions at which a multi-chunk MTP prefill has committed
+/// KV after each `<= chunk_max` slice. Empty when `prompt_len == 0`.
+///
+/// Used by adaptive serve hooks and unit tests so downshift sites stay locked
+/// to the same schedule the prefill helper actually writes.
+pub fn mtp_prefill_committed_boundaries(
+    prompt_len: usize,
+    start_pos: usize,
+    chunk_max: usize,
+) -> Vec<usize> {
+    debug_assert!(chunk_max >= 1);
+    let chunk_max = chunk_max.max(1);
+    if prompt_len == 0 {
+        return Vec::new();
+    }
+    let mut out = Vec::with_capacity(prompt_len.div_ceil(chunk_max));
+    let mut off = 0usize;
+    while off < prompt_len {
+        let end = (off + chunk_max).min(prompt_len);
+        out.push(start_pos + end);
+        off = end;
+    }
+    out
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1141,6 +1182,38 @@ pub fn prefill_trunk_and_mtp_cache(
     prompt_tokens: &[u32],
     start_pos: usize,
 ) -> HipResult<TrunkSpinePrefillTimings> {
+    // No-op boundary: same final state as the historical single-call path.
+    prefill_trunk_and_mtp_cache_with_boundary(
+        gpu,
+        target,
+        head,
+        state,
+        prompt_tokens,
+        start_pos,
+        |_gpu, _target, _committed_pos| Ok(()),
+    )
+}
+
+/// Like [`prefill_trunk_and_mtp_cache`], but invokes `on_committed_boundary`
+/// after each trunk+MTP chunk commits, with the exclusive end position of the
+/// committed prefix (`start_pos + tokens_written_so_far`).
+///
+/// The callback runs while `target.kv_cache` holds the just-written prefix and
+/// before the next chunk may write past the current-tier capacity. Failures
+/// propagate and abort the remaining prefill (caller must free MTP state).
+#[allow(clippy::too_many_arguments)]
+pub fn prefill_trunk_and_mtp_cache_with_boundary<F>(
+    gpu: &mut Gpu,
+    target: &mut ModelSlot,
+    head: &Qwen35MtpHead,
+    state: &mut MtpSpecState,
+    prompt_tokens: &[u32],
+    start_pos: usize,
+    mut on_committed_boundary: F,
+) -> HipResult<TrunkSpinePrefillTimings>
+where
+    F: FnMut(&mut Gpu, &mut ModelSlot, usize) -> HipResult<()>,
+{
     if prompt_tokens.is_empty() {
         return Ok(TrunkSpinePrefillTimings::default());
     }
@@ -1148,39 +1221,60 @@ pub fn prefill_trunk_and_mtp_cache(
     let dim = target.config.dim;
     let dim_bytes = dim * 4;
     let prompt_hidden = gpu.alloc_tensor(&[prompt_tokens.len() * dim], DType::F32)?;
+    // Match adaptive margin / AR daemon chunking. Internal forward_prefill_batch
+    // also caps at this size; externalizing the loop exposes commit boundaries.
+    let chunk_max = qwen35::PREFILL_MAX_BATCH.max(1);
 
     let result = (|| -> HipResult<TrunkSpinePrefillTimings> {
-        let t_trunk = Instant::now();
-        qwen35::forward_prefill_batch(
-            gpu,
-            &target.weights,
-            &target.config,
-            prompt_tokens,
-            start_pos,
-            &mut target.kv_cache,
-            &mut target.dn_state,
-            &target.scratch,
-            None,
-            Some(&prompt_hidden),
-            None,
-            None,
-        )?;
-        let trunk_prefill_secs = t_trunk.elapsed().as_secs_f64();
+        let mut trunk_prefill_secs = 0.0f64;
+        let mut mtp_prompt_fill_secs = 0.0f64;
+        let mut off = 0usize;
+        while off < prompt_tokens.len() {
+            let end = (off + chunk_max).min(prompt_tokens.len());
+            let chunk = &prompt_tokens[off..end];
+            let chunk_start_pos = start_pos + off;
+            let committed_pos = start_pos + end;
 
-        let t_mtp_fill = Instant::now();
-        for (i, &token) in prompt_tokens.iter().enumerate() {
-            let hidden_row = prompt_hidden.sub_offset(i * dim, dim);
-            mtp_head::mtp_head_forward_block_only(
+            // Per-chunk hidden destination: row-major slice of the full prompt buffer.
+            let chunk_hidden = prompt_hidden.sub_offset(off * dim, chunk.len() * dim);
+
+            let t_trunk = Instant::now();
+            qwen35::forward_prefill_batch(
                 gpu,
-                head,
-                &state.mtp_scratch,
-                &mut state.mtp_kv,
-                token,
-                &hidden_row,
-                None,
-                start_pos + i,
                 &target.weights,
+                &target.config,
+                chunk,
+                chunk_start_pos,
+                &mut target.kv_cache,
+                &mut target.dn_state,
+                &target.scratch,
+                None,
+                Some(&chunk_hidden),
+                None,
+                None,
             )?;
+            trunk_prefill_secs += t_trunk.elapsed().as_secs_f64();
+
+            let t_mtp_fill = Instant::now();
+            for (i, &token) in chunk.iter().enumerate() {
+                let hidden_row = prompt_hidden.sub_offset((off + i) * dim, dim);
+                mtp_head::mtp_head_forward_block_only(
+                    gpu,
+                    head,
+                    &state.mtp_scratch,
+                    &mut state.mtp_kv,
+                    token,
+                    &hidden_row,
+                    None,
+                    chunk_start_pos + i,
+                    &target.weights,
+                )?;
+            }
+            mtp_prompt_fill_secs += t_mtp_fill.elapsed().as_secs_f64();
+
+            // Committed boundary: trunk + MTP private KV now cover [0, committed_pos).
+            on_committed_boundary(gpu, target, committed_pos)?;
+            off = end;
         }
 
         let last = prompt_tokens.len() - 1;
@@ -1191,7 +1285,6 @@ pub fn prefill_trunk_and_mtp_cache(
             last * dim_bytes,
             dim_bytes,
         )?;
-        let mtp_prompt_fill_secs = t_mtp_fill.elapsed().as_secs_f64();
         Ok(TrunkSpinePrefillTimings {
             trunk_prefill_secs,
             mtp_prompt_fill_secs,
@@ -1670,7 +1763,10 @@ pub fn spec_step_mtp(
     // HIPFIRE_MTP_TAPE_REPLAY=0 forces the original full-replay path (A/B gate).
     let use_tape_replay = tape_captured
         && advance >= 2
-        && hipfire_config::developer_var("HIPFIRE_MTP_TAPE_REPLAY").ok().as_deref() != Some("0");
+        && hipfire_config::developer_var("HIPFIRE_MTP_TAPE_REPLAY")
+            .ok()
+            .as_deref()
+            != Some("0");
     state.trunk_snap.restore_to(&mut target.dn_state, gpu)?;
     if use_tape_replay {
         // Batched verify populated the tape this cycle — cheap GDN-only replay.
@@ -2421,7 +2517,10 @@ pub fn spec_step_mtp_compressed_serial(
         (true, false) => DraftMode::Greedy,
     };
     let use_p_min = matches!(draft_mode, DraftMode::PMin { .. });
-    let use_sampling = matches!(draft_mode, DraftMode::Sampled | DraftMode::SampledPMin { .. });
+    let use_sampling = matches!(
+        draft_mode,
+        DraftMode::Sampled | DraftMode::SampledPMin { .. }
+    );
     let use_sampled_pmin = matches!(draft_mode, DraftMode::SampledPMin { .. });
     let log_p_min = match draft_mode {
         DraftMode::PMin { log_p_min } | DraftMode::SampledPMin { log_p_min } => log_p_min,
@@ -3260,6 +3359,46 @@ pub fn spec_step_mtp_compressed_serial(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mtp_prefill_boundaries_chunk_at_prefill_max_batch() {
+        let b = mtp_prefill_committed_boundaries(600, 0, qwen35::PREFILL_MAX_BATCH);
+        assert_eq!(
+            b,
+            vec![256, 512, 600],
+            "adaptive maybe_downshift must see every committed end ≤ PREFILL_MAX_BATCH apart"
+        );
+        // Empty prompt → no boundaries (no KV writes).
+        assert!(mtp_prefill_committed_boundaries(0, 0, qwen35::PREFILL_MAX_BATCH).is_empty());
+        // start_pos offset is absolute trunk position.
+        assert_eq!(
+            mtp_prefill_committed_boundaries(300, 10, 256),
+            vec![266, 310]
+        );
+        // Single short chunk → one boundary at full length.
+        assert_eq!(
+            mtp_prefill_committed_boundaries(40, 0, qwen35::PREFILL_MAX_BATCH),
+            vec![40]
+        );
+    }
+
+    #[test]
+    fn mtp_prefill_boundaries_never_exceed_chunk_stride() {
+        let chunk = qwen35::PREFILL_MAX_BATCH;
+        let bounds = mtp_prefill_committed_boundaries(10_000, 0, chunk);
+        let mut prev = 0usize;
+        for &pos in &bounds {
+            assert!(pos > prev);
+            assert!(
+                pos - prev <= chunk,
+                "boundary gap {} exceeds chunk_max {}",
+                pos - prev,
+                chunk
+            );
+            prev = pos;
+        }
+        assert_eq!(*bounds.last().unwrap(), 10_000);
+    }
 
     #[test]
     fn trunk_spine_verify_tokens_are_seed_plus_candidates() {

--- a/crates/hipfire-arch-qwen35/src/pflash.rs
+++ b/crates/hipfire-arch-qwen35/src/pflash.rs
@@ -239,7 +239,7 @@ impl PflashState {
             m.free_gpu(gpu);
         }
         if let Some(kv) = self.drafter_kv.take() {
-            kv.free_gpu(gpu);
+            let _ = kv.free_gpu(gpu);
         }
         self.drafter_tokenizer = None;
         self.drafter_loaded = false;
@@ -475,7 +475,9 @@ impl DrafterKvMode {
                  use fwht3 (similar throughput, better scorer accuracy)"
             ),
             Some(other) => {
-                panic!("speculation.prefill.drafter_kv={other:?} not in {{q8, fwht4, fwht3, fwht2}}")
+                panic!(
+                    "speculation.prefill.drafter_kv={other:?} not in {{q8, fwht4, fwht3, fwht2}}"
+                )
             }
         }
     }

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -4825,6 +4825,8 @@ fn forward_from_x_gpu(
     kv_cache: &mut llama::KvCache,
     dn_state: &mut DeltaNetState,
 ) -> HipResult<GpuTensor> {
+    let required_tokens = checked_kv_end(pos, 1, "forward_from_x_gpu")?;
+    kv_cache.ensure_mapped_capacity(gpu, required_tokens)?;
     let dim = config.dim;
 
     // Allocate a temporary scratch bundle. repeat_window=1 (unused in this path).
@@ -5277,6 +5279,15 @@ impl Qwen35ScratchSet {
     }
 }
 
+fn checked_kv_end(start_pos: usize, token_count: usize, site: &str) -> HipResult<usize> {
+    start_pos.checked_add(token_count).ok_or_else(|| {
+        HipError::new(
+            0,
+            &format!("{site}: KV token range overflow ({start_pos} + {token_count})"),
+        )
+    })
+}
+
 /// Zero-alloc forward pass using pre-allocated scratch buffers.
 /// Logits stay on GPU in scratch.logits. Returns nothing — caller uses scratch.logits.
 pub fn forward_scratch(
@@ -5289,6 +5300,10 @@ pub fn forward_scratch(
     dn_state: &mut DeltaNetState,
     scratch: &Qwen35Scratch,
 ) -> HipResult<()> {
+    let required_tokens = checked_kv_end(pos, 1, "forward_scratch")?;
+    // Grow before any possible AR graph capture/replay. Stable virtual
+    // addresses keep existing graph pointer arguments valid.
+    kv_cache.ensure_mapped_capacity(gpu, required_tokens)?;
     let dim = config.dim;
     // hipGraph capture for MoE was previously gated off-by-default behind
     // HIPFIRE_GRAPH_MOE=1 because of a known drift bug (task #100): under
@@ -6188,6 +6203,10 @@ pub fn forward_prefill_batch_single_chunk_captured_opts(
         n,
         pbs.max_batch
     );
+    let required_tokens = checked_kv_end(start_pos, n, "captured prefill")?;
+    // This entry may already be inside graph capture, so it must only validate
+    // capacity preflighted by its caller.
+    kv_cache.require_mapped_capacity(required_tokens)?;
 
     // Defense-in-depth: this entry point bypasses the eligibility check
     // in `forward_prefill_batch_with_pbs`, so the caller is responsible
@@ -6514,6 +6533,8 @@ pub fn forward_prefill_batch_with_pbs_opts(
     if n == 0 {
         return Ok(());
     }
+    let required_tokens = checked_kv_end(start_pos, n, "forward_prefill_batch")?;
+    kv_cache.ensure_mapped_capacity(gpu, required_tokens)?;
 
     // Cross-path safety: refuse MQ3 / MQ3-Lloyd weights inside any MoE
     // layer (attention OR FFN), mirroring the captured-path guard at
@@ -8478,6 +8499,8 @@ fn forward_prefill_chunk(
     let n = tokens.len();
     debug_assert!(n > 0);
     debug_assert!(n <= pbs.max_batch);
+    let required_tokens = checked_kv_end(start_pos, n, "forward_prefill_chunk")?;
+    kv_cache.require_mapped_capacity(required_tokens)?;
     debug_assert!(
         routed_out.is_none()
             || band
@@ -12136,6 +12159,8 @@ pub fn forward_scratch_with_hidden(
     scratch: &Qwen35Scratch,
     hidden_rb: &mut HiddenStateRingBuffer,
 ) -> HipResult<()> {
+    let required_tokens = checked_kv_end(pos, 1, "forward_scratch_with_hidden")?;
+    kv_cache.ensure_mapped_capacity(gpu, required_tokens)?;
     let dim = config.dim;
     let pos_i32 = pos as i32;
     gpu.hip
@@ -12182,6 +12207,8 @@ pub fn forward_scratch_embed(
     dn_state: &mut DeltaNetState,
     scratch: &Qwen35Scratch,
 ) -> HipResult<()> {
+    let required_tokens = checked_kv_end(pos, 1, "forward_scratch_embed")?;
+    kv_cache.ensure_mapped_capacity(gpu, required_tokens)?;
     let pos_i32 = pos as i32;
     gpu.hip
         .memcpy_htod(&scratch.pos_buf, &pos_i32.to_ne_bytes())?;

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -14,25 +14,25 @@ use hipfire_dispatch::families::kv_tier::{KvTierInputs, KvTierPlan};
 use hipfire_dispatch::pipeline::superop::{
     self, ForwardBindings, LayerProgram, OpBinding, OpFlavor, SuperOp, SuperOpKind, WeightSlot,
 };
-use hipfire_dispatch::pipeline::{GemvInput, Step, execute_steps};
+use hipfire_dispatch::pipeline::{execute_steps, GemvInput, Step};
 use hipfire_dispatch::types::dtype_rotation_plan;
 use hipfire_dispatch::types::{DispatchError, RotationPlan};
 use hipfire_runtime::hfq::{HfqFile, HfqTensorInfo};
 use hipfire_runtime::llama::{
-    self, EmbeddingFormat, ParoRotation, WeightTensor, f16_to_f32, fused_rmsnorm_rotate_for_mq,
-    fused_rmsnorm_rotate_mq_batched_for, fused_silu_mul_rotate_mq_batched_for,
-    rotate_x_mq_batched_for, weight_gemv_prerotated, weight_gemv_swiglu_residual,
+    self, f16_to_f32, fused_rmsnorm_rotate_for_mq, fused_rmsnorm_rotate_mq_batched_for,
+    fused_silu_mul_rotate_mq_batched_for, rotate_x_mq_batched_for, weight_gemv_prerotated,
+    weight_gemv_swiglu_residual, EmbeddingFormat, ParoRotation, WeightTensor,
 };
-use hipfire_runtime::model_load::{LoadedWeights, WeightSource, load_weights as rt_load_weights};
+use hipfire_runtime::model_load::{load_weights as rt_load_weights, LoadedWeights, WeightSource};
 use hipfire_runtime::model_source::ModelSource;
 use hipfire_runtime::multi_gpu::Gpus;
 use hipfire_runtime::paro::{paro_load_norm, paro_text_prefix};
 use hipfire_runtime::tp_shard::ShardConfig;
 use hipfire_runtime::weight_backend::{
-    HfqBackend, ParoBackend, dequant_norm, dequant_weight_raw, load_awq_scale_for, load_embedding,
-    resolve_lm_head, reupload_f16_as_f32,
+    dequant_norm, dequant_weight_raw, load_awq_scale_for, load_embedding, resolve_lm_head,
+    reupload_f16_as_f32, HfqBackend, ParoBackend,
 };
-use hipfire_runtime::{MmqScreenable, screen_weight_tensor};
+use hipfire_runtime::{screen_weight_tensor, MmqScreenable};
 use rdna_compute::{DType, Gpu, GpuTensor};
 use serde::Deserialize;
 
@@ -418,14 +418,12 @@ fn from_config_value(config: &serde_json::Value) -> Result<Qwen35Config, String>
 /// Only the HFQ MoE path (`load_moe_ffn`) honors the keep-map; the
 /// ParoQuant path does not (see `paro_load_moe_ffn`).
 pub fn apply_reap_plan(config: &mut Qwen35Config) -> Result<(), String> {
-    if let Some(plan) =
-        hipfire_reap::plan::ReapPlan::from_config(
-            "qwen35",
-            None,
-            config.n_layers,
-            config.num_experts,
-        )?
-    {
+    if let Some(plan) = hipfire_reap::plan::ReapPlan::from_config(
+        "qwen35",
+        None,
+        config.n_layers,
+        config.num_experts,
+    )? {
         config.num_experts = plan.kept_per_layer();
         config.reap_keep = Some(std::sync::Arc::new(plan));
     }
@@ -2893,7 +2891,11 @@ fn load_any_as_f32(hfq: &HfqFile, gpu: &mut Gpu, name: &str, n: usize) -> HipRes
             #[inline]
             fn e2m1(n: u8) -> f32 {
                 let m = E2M1_MAG[(n & 0x7) as usize];
-                if (n & 0x8) != 0 { -m } else { m }
+                if (n & 0x8) != 0 {
+                    -m
+                } else {
+                    m
+                }
             }
             // E4M3 (unsigned scale, bias 7, 3 mantissa) — bit-identical to the
             // quantizer `e4m3_scale_decode` and the gfx942 kernel decode.
@@ -2974,7 +2976,11 @@ fn load_any_as_f32(hfq: &HfqFile, gpu: &mut Gpu, name: &str, n: usize) -> HipRes
                     e = p7 | lsb;
                 }
                 let c = (e as i32 - 7) as f32;
-                if coset == 1 { c + 0.5 } else { c }
+                if coset == 1 {
+                    c + 0.5
+                } else {
+                    c
+                }
             }
             const QUANT_STEP: f32 = 0.88;
             let row_bytes = 16 + 17 * (n / 32);
@@ -3043,7 +3049,11 @@ fn load_any_as_f32(hfq: &HfqFile, gpu: &mut Gpu, name: &str, n: usize) -> HipRes
                     e = p7 | lsb;
                 }
                 let c = (e as i32 - 7) as f32;
-                if coset == 1 { c + 0.5 } else { c }
+                if coset == 1 {
+                    c + 0.5
+                } else {
+                    c
+                }
             }
             const QUANT_STEP_SOA: f32 = 0.88;
             // Decode assuming n = k_row; figure out m_rows from total bytes.
@@ -4094,7 +4104,10 @@ pub(crate) fn load_moe_ffn(
     // (garbage). Expect incoherent output when set on an AWQ file; that
     // *confirms* the indexed AWQ kernel is the firing path. The real
     // AWQ-vs-plain A/B uses two separately quantized files.
-    let moe_awq_enabled = hipfire_config::developer_var("HIPFIRE_MOE_AWQ").ok().as_deref() != Some("0");
+    let moe_awq_enabled = hipfire_config::developer_var("HIPFIRE_MOE_AWQ")
+        .ok()
+        .as_deref()
+        != Some("0");
     let awq_present = experts
         .iter()
         .filter(|e| e.down.awq_scale.is_some())
@@ -4519,8 +4532,12 @@ static EXPERT_STATS: std::sync::Mutex<
 > = std::sync::Mutex::new(None);
 static EXPERT_STATS_ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
 fn expert_stats_enabled() -> bool {
-    *EXPERT_STATS_ON
-        .get_or_init(|| hipfire_config::developer_var("HIPFIRE_MOE_EXPERT_STATS").ok().as_deref() == Some("1"))
+    *EXPERT_STATS_ON.get_or_init(|| {
+        hipfire_config::developer_var("HIPFIRE_MOE_EXPERT_STATS")
+            .ok()
+            .as_deref()
+            == Some("1")
+    })
 }
 fn capture_expert_stats(
     gpu: &Gpu,
@@ -5105,7 +5122,11 @@ impl Qwen35Scratch {
                 _ => {
                     let graph_capable_arch =
                         gpu.arch.starts_with("gfx12") || gpu.arch.starts_with("gfx11");
-                    if graph_capable_arch { 2 } else { 1 }
+                    if graph_capable_arch {
+                        2
+                    } else {
+                        1
+                    }
                 }
             },
 
@@ -5161,7 +5182,11 @@ impl Qwen35Scratch {
                 // error). Idempotent if already computed.
                 gpu.ensure_mq_signs()?;
             }
-            if hipfire_config::developer_var("HIPFIRE_PREFILL_REUSE_PBS").ok().as_deref() == Some("1") {
+            if hipfire_config::developer_var("HIPFIRE_PREFILL_REUSE_PBS")
+                .ok()
+                .as_deref()
+                == Some("1")
+            {
                 let max_batch = hipfire_config::developer_var("HIPFIRE_PREFILL_MAX_BATCH")
                     .ok()
                     .and_then(|v| v.parse::<usize>().ok())
@@ -5285,6 +5310,17 @@ fn checked_kv_end(start_pos: usize, token_count: usize, site: &str) -> HipResult
             0,
             &format!("{site}: KV token range overflow ({start_pos} + {token_count})"),
         )
+    })
+}
+
+#[inline]
+fn ar_graph_trace_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        hipfire_config::developer_var("HIPFIRE_AR_GRAPH_TRACE")
+            .ok()
+            .as_deref()
+            == Some("1")
     })
 }
 
@@ -5489,6 +5525,9 @@ pub fn forward_scratch(
             .memcpy_htod(&scratch.pos_buf, &pos_i32.to_ne_bytes())?;
         gpu.graphs
             .graph_launch(&gpu.hip, gpu.device_id, gpu.active_stream.as_ref().unwrap())?;
+        if ar_graph_trace_enabled() {
+            eprintln!("[qwen-ar-graph] replay pos={pos}");
+        }
     } else if use_graph && gpu.graphs.ar_forward_kernel_dirty {
         // ── Direct path (kernel-dirty): kernels are dirty (init or post-
         // model-load). Capture would trip "hipMalloc not permitted under
@@ -5523,6 +5562,9 @@ pub fn forward_scratch(
         )?;
         gpu.graphs
             .graph_launch(&gpu.hip, gpu.device_id, gpu.active_stream.as_ref().unwrap())?;
+        if ar_graph_trace_enabled() {
+            eprintln!("[qwen-ar-graph] capture pos={pos}");
+        }
         // Intra-generate replay (2026-06-12): promote this fresh capture to the
         // replay graph immediately so the NEXT token replays (cheap: pos memcpy
         // + graph_launch) instead of re-capturing + re-instantiating every
@@ -6351,7 +6393,10 @@ pub fn forward_prefill_batch_single_chunk_captured_opts(
     // Without this guard, a captured call would reach the dispatch arms
     // and try to load gfx12 kernels that are still community-CI-pending.
     let arch_is_gfx12 = matches!(arch, "gfx1200" | "gfx1201");
-    let lloyd_gfx12_optin = hipfire_config::developer_var("HIPFIRE_LLOYD_GFX12").ok().as_deref() == Some("1");
+    let lloyd_gfx12_optin = hipfire_config::developer_var("HIPFIRE_LLOYD_GFX12")
+        .ok()
+        .as_deref()
+        == Some("1");
     if lloyd_in_dense && arch_is_gfx12 && !lloyd_gfx12_optin {
         return Err(hip_bridge::HipError::new(
             0,
@@ -6934,7 +6979,10 @@ fn is_batchable_la(dt: DType, arch: &str) -> bool {
     // flipped) in a follow-up commit.
     let lloyd_mq3_with_gfx12_wmma = matches!(dt, DType::MQ3G256Lloyd)
         && matches!(arch, "gfx1200" | "gfx1201")
-        && hipfire_config::developer_var("HIPFIRE_LLOYD_GFX12").ok().as_deref() == Some("1");
+        && hipfire_config::developer_var("HIPFIRE_LLOYD_GFX12")
+            .ok()
+            .as_deref()
+            == Some("1");
 
     // Lloyd-MQ4 (MQ4G256Lloyd) on gfx11: shipped as part of issue #182.
     // Uses the gemm_*_mq4g256_lloyd_wmma family; group stride differs
@@ -6955,7 +7003,10 @@ fn is_batchable_la(dt: DType, arch: &str) -> bool {
     // Lloyd-MQ4 on gfx12 (RDNA4): same opt-in gate as Lloyd-MQ3.
     let lloyd_mq4_with_gfx12_wmma = matches!(dt, DType::MQ4G256Lloyd)
         && matches!(arch, "gfx1200" | "gfx1201")
-        && hipfire_config::developer_var("HIPFIRE_LLOYD_GFX12").ok().as_deref() == Some("1");
+        && hipfire_config::developer_var("HIPFIRE_LLOYD_GFX12")
+            .ok()
+            .as_deref()
+            == Some("1");
 
     // MFP4G32E8 on gfx11/gfx1151/gfx12: the mfp4-E8 A3B model takes the
     // batched-prefill path (FWHT-rotated activations + dequant→F16 GEMM for
@@ -6981,7 +7032,10 @@ fn is_batchable_la(dt: DType, arch: &str) -> bool {
                 | "gfx1200"
                 | "gfx1201"
         )
-        && hipfire_config::developer_var("HIPFIRE_E8_GFX12").ok().as_deref() == Some("1");
+        && hipfire_config::developer_var("HIPFIRE_E8_GFX12")
+            .ok()
+            .as_deref()
+            == Some("1");
 
     mq3_uniform_with_wmma
         || mq3_uniform_with_gfx10_scalar
@@ -7323,7 +7377,9 @@ pub fn prefill_batch_pbs_eligible(
     let moe_topk_ok =
         moe_prefill_topk_shape_supported(config.num_experts_per_tok, config.num_experts);
     let admit_mq6 = mq6_batched_admit_enabled_from_env(
-        hipfire_config::developer_var("HIPFIRE_MOE_MQ6_ADMIT").ok().as_deref(),
+        hipfire_config::developer_var("HIPFIRE_MOE_MQ6_ADMIT")
+            .ok()
+            .as_deref(),
         arch,
     );
     let has_dn = weights
@@ -7375,7 +7431,11 @@ pub fn prefill_batch_pbs_eligible(
         // A3B engine policy quantizes attention as Q8 (admitted alongside MQ4).
         && all_dtypes_ok;
     // HIPFIRE_DEBUG_BATCH=1: print per-component eligibility to stderr.
-    if hipfire_config::developer_var("HIPFIRE_DEBUG_BATCH").ok().as_deref() == Some("1") {
+    if hipfire_config::developer_var("HIPFIRE_DEBUG_BATCH")
+        .ok()
+        .as_deref()
+        == Some("1")
+    {
         eprintln!(
             "[hipfire::batch_eligible] result={result} \
              arch={arch} n={n} n>={MIN_BATCH}={} \
@@ -7436,7 +7496,9 @@ fn q8_prefill_wmma_enabled_from_env(value: Option<&str>, arch: &str, has_wmma: b
 
 fn q8_prefill_wmma_enabled(gpu: &Gpu) -> bool {
     q8_prefill_wmma_enabled_from_env(
-        hipfire_config::developer_var("HIPFIRE_Q8_PREFILL_WMMA").ok().as_deref(),
+        hipfire_config::developer_var("HIPFIRE_Q8_PREFILL_WMMA")
+            .ok()
+            .as_deref(),
         gpu.arch.as_str(),
         gpu.arch_caps.has_wmma(),
     )
@@ -7462,7 +7524,10 @@ fn moe_ffn_batched_admissible(ffn: &MoeFfnWeights, admit_mq6: bool, arch: &str) 
             | "gfx1152"
             | "gfx1200"
             | "gfx1201"
-    ) && hipfire_config::developer_var("HIPFIRE_E8_GFX12").ok().as_deref() == Some("1");
+    ) && hipfire_config::developer_var("HIPFIRE_E8_GFX12")
+        .ok()
+        .as_deref()
+        == Some("1");
 
     // PARO admit is default-on. Set HIPFIRE_PARO_BATCHED=0 to force the old
     // fallback path while bisecting or debugging.
@@ -7473,7 +7538,11 @@ fn moe_ffn_batched_admissible(ffn: &MoeFfnWeights, admit_mq6: bool, arch: &str) 
     // .claude/plans/magical-marinating-hippo.md.
     static PARO_ADMIT: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     let admit_paro = *PARO_ADMIT.get_or_init(|| {
-        paro_batched_admit_enabled_from_env(hipfire_config::developer_var("HIPFIRE_PARO_BATCHED").ok().as_deref())
+        paro_batched_admit_enabled_from_env(
+            hipfire_config::developer_var("HIPFIRE_PARO_BATCHED")
+                .ok()
+                .as_deref(),
+        )
     });
 
     moe_ffn_batched_admissible_for_dtypes(&dtypes, admit_mq6, admit_paro, admit_e8)
@@ -13792,8 +13861,8 @@ fn q35_superop(kind: SuperOpKind, code: u32) -> SuperOp {
 /// SEQUENCE mirrors the matching hand arm in `forward_scratch_layers` exactly
 /// (per the decode-forward variant map). Pure → unit-testable.
 fn lower_variant(v: Q35Variant) -> LayerProgram {
-    use SuperOpKind::{Attend, Moe, Norm, Proj, Recurrent, ResidualGemv};
     use q35_op::*;
+    use SuperOpKind::{Attend, Moe, Norm, Proj, Recurrent, ResidualGemv};
     match v {
         Q35Variant::DeltaNet => vec![
             q35_superop(Proj, PROJ_QKVZA),
@@ -14630,7 +14699,12 @@ impl<'a> ForwardBindings for Qwen35Bindings<'a> {
 /// (still present in forward_scratch_layers); any other value (or unset) → lowered.
 fn forward_lowered_enabled() -> bool {
     static F: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *F.get_or_init(|| hipfire_config::developer_var("HIPFIRE_FORWARD_LOWERED").ok().as_deref() != Some("0"))
+    *F.get_or_init(|| {
+        hipfire_config::developer_var("HIPFIRE_FORWARD_LOWERED")
+            .ok()
+            .as_deref()
+            != Some("0")
+    })
 }
 
 /// Exact gfx1151 admission gate for its certified Radiowave decode bundle.
@@ -14696,8 +14770,12 @@ fn gated_norm_mq_rotate_enabled(
 /// the established multi-dispatch path.
 fn qwen35_fa_prep_enabled(gpu: &Gpu, config: &Qwen35Config) -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let enabled = *ENABLED
-        .get_or_init(|| hipfire_config::developer_var("HIPFIRE_QWEN35_FA_PREP_FUSE").ok().as_deref() != Some("0"));
+    let enabled = *ENABLED.get_or_init(|| {
+        hipfire_config::developer_var("HIPFIRE_QWEN35_FA_PREP_FUSE")
+            .ok()
+            .as_deref()
+            != Some("0")
+    });
     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
     enabled
         && (gpu.arch_caps.is_gfx1100() || gfx1151_radiowave_fusions_enabled(gpu))
@@ -14743,8 +14821,12 @@ fn qkvza_scalar_prep_enabled(
     w_alpha: &WeightTensor,
 ) -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let enabled = *ENABLED
-        .get_or_init(|| hipfire_config::developer_var("HIPFIRE_QKVZA_SCALAR_PREP").ok().as_deref() == Some("1"));
+    let enabled = *ENABLED.get_or_init(|| {
+        hipfire_config::developer_var("HIPFIRE_QKVZA_SCALAR_PREP")
+            .ok()
+            .as_deref()
+            == Some("1")
+    });
     let dtype = wqkv.gpu_dtype;
     enabled
         && gpu.arch_caps.is_gfx1100()
@@ -14768,8 +14850,12 @@ fn conv_scalar_prep_enabled(
     quant: StateQuant,
 ) -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let enabled = *ENABLED
-        .get_or_init(|| hipfire_config::developer_var("HIPFIRE_CONV_SCALAR_PREP").ok().as_deref() == Some("1"));
+    let enabled = *ENABLED.get_or_init(|| {
+        hipfire_config::developer_var("HIPFIRE_CONV_SCALAR_PREP")
+            .ok()
+            .as_deref()
+            == Some("1")
+    });
     let shape = hipfire_config::developer_var("HIPFIRE_CONV_QKNORM_SHAPE").ok();
     enabled
         && gpu.arch_caps.is_gfx1100()
@@ -15213,12 +15299,13 @@ pub fn forward_prefill_batch_ep(
 
     let ep_timing = hipfire_config::developer_var("HIPFIRE_EP_PREFILL_TIMING").is_ok();
     let ep_skip_ar = hipfire_config::developer_var("HIPFIRE_EP_SKIP_ALLREDUCE").is_ok(); // DIAGNOSTIC ONLY (wrong output)
-    // Peer-direct all-reduce (bypass RCCL): the routed-partial sum goes through
-    // Gpus::all_reduce_sum_f32_peer (direct P2P copy + local add), which is ~1 ms
-    // vs RCCL's ~40 ms/call on hiptrx (gfx1201, PCIe). DEFAULT ON; opt back to
-    // RCCL with HIPFIRE_EP_PEER_ALLREDUCE=0. The peer temps live in Gpus (shared
-    // with TP), lazily sized to the largest count seen.
-    let ep_peer_ar = hipfire_config::developer_var("HIPFIRE_EP_PEER_ALLREDUCE").as_deref() != Ok("0");
+                                                                                         // Peer-direct all-reduce (bypass RCCL): the routed-partial sum goes through
+                                                                                         // Gpus::all_reduce_sum_f32_peer (direct P2P copy + local add), which is ~1 ms
+                                                                                         // vs RCCL's ~40 ms/call on hiptrx (gfx1201, PCIe). DEFAULT ON; opt back to
+                                                                                         // RCCL with HIPFIRE_EP_PEER_ALLREDUCE=0. The peer temps live in Gpus (shared
+                                                                                         // with TP), lazily sized to the largest count seen.
+    let ep_peer_ar =
+        hipfire_config::developer_var("HIPFIRE_EP_PEER_ALLREDUCE").as_deref() != Ok("0");
     let mut t_chunk = 0.0f64;
     let mut t_ar = 0.0f64;
     let mut t_add = 0.0f64;

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -554,6 +554,7 @@ impl ModelSlot {
             scratch,
             kv_cache,
             dn_state,
+            kv_adaptive: _,
         } = bundle;
         Ok(Self {
             name: String::from("target"),
@@ -579,6 +580,8 @@ impl ModelSlot {
             scratch: self.scratch,
             kv_cache: self.kv_cache,
             dn_state: self.dn_state,
+            // Controller lives on LoadedModel, not ModelSlot.
+            kv_adaptive: None,
         }
     }
 }
@@ -1109,7 +1112,10 @@ impl GdnTape {
         dn_state: &mut qwen35::DeltaNetState,
         n_steps: usize,
     ) -> HipResult<()> {
-        let graph_enabled = hipfire_config::developer_var("HIPFIRE_REPLAY_GRAPH").ok().as_deref() == Some("1");
+        let graph_enabled = hipfire_config::developer_var("HIPFIRE_REPLAY_GRAPH")
+            .ok()
+            .as_deref()
+            == Some("1");
         let can_graph = graph_enabled && gpu.active_stream.is_some();
 
         if can_graph && gpu.graphs.replay_has_graph(n_steps) {
@@ -1300,7 +1306,6 @@ impl GdnTape {
         }
         Ok(())
     }
-
 }
 
 impl DeltaNetTape {
@@ -2233,7 +2238,8 @@ fn verify_dflash_block_inner(
     // shapes. sub_offset returns a non-owning view; do NOT free these.
     let final_hidden = verify_scratch.final_hidden.sub_offset(0, b * dim);
     let tree_verify_present = tree_verify.is_some();
-    let moe_lmhead_graph_env = hipfire_config::developer_var("HIPFIRE_DFLASH_MOE_VERIFY_GRAPH_LMHEAD").ok();
+    let moe_lmhead_graph_env =
+        hipfire_config::developer_var("HIPFIRE_DFLASH_MOE_VERIFY_GRAPH_LMHEAD").ok();
     let moe_lmhead_graph_ok =
         dflash_moe_verify_graph_lmhead_eligible(
             target.config.num_experts,
@@ -2279,8 +2285,10 @@ fn verify_dflash_block_inner(
     // the parent_indices-driven conv1d path. DO NOT ENABLE in production.
     //
     // Gate kept live so the next session can bisect without re-plumbing.
-    let tree_graph_enabled =
-        hipfire_config::developer_var("HIPFIRE_VERIFY_GRAPH_TREE").ok().as_deref() == Some("1");
+    let tree_graph_enabled = hipfire_config::developer_var("HIPFIRE_VERIFY_GRAPH_TREE")
+        .ok()
+        .as_deref()
+        == Some("1");
     if tree_graph_enabled && tree_verify_present {
         static WARNED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
         if !WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
@@ -2300,7 +2308,10 @@ fn verify_dflash_block_inner(
     // the tiled crossover landed 2026-06-09) is intentionally NOT reinstated: it
     // would skip a verify-graph that now replays fine and forfeit the long-context
     // spec speedup.
-    let verify_graph_ok = hipfire_config::developer_var("HIPFIRE_VERIFY_GRAPH").ok().as_deref() != Some("0")
+    let verify_graph_ok = hipfire_config::developer_var("HIPFIRE_VERIFY_GRAPH")
+        .ok()
+        .as_deref()
+        != Some("0")
         && tree_ok_for_graph
         && matches!(
             target.weights.embd_format,
@@ -2313,7 +2324,10 @@ fn verify_dflash_block_inner(
     // (HIPFIRE_VERIFY_GRAPH_TIMING=1). Two device-sync points bracket the
     // forward + lm_head; the recorded mode tag distinguishes replay vs
     // warmup-direct vs first-capture vs no-graph-eligible.
-    let vg_timing = hipfire_config::developer_var("HIPFIRE_VERIFY_GRAPH_TIMING").ok().as_deref() == Some("1");
+    let vg_timing = hipfire_config::developer_var("HIPFIRE_VERIFY_GRAPH_TIMING")
+        .ok()
+        .as_deref()
+        == Some("1");
     let mut vg_mode = "direct";
     let vg_t0 = if vg_timing {
         gpu.hip.device_synchronize()?;
@@ -2885,8 +2899,12 @@ pub fn spec_step_dflash(
     // use only for diagnostics. When disabled, zero cost beyond a handful
     // of Instant::now() calls.
     static PHASE_ON_ENV: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let phase_on = *PHASE_ON_ENV
-        .get_or_init(|| hipfire_config::developer_var("HIPFIRE_SPEC_PHASES").ok().as_deref() == Some("1"));
+    let phase_on = *PHASE_ON_ENV.get_or_init(|| {
+        hipfire_config::developer_var("HIPFIRE_SPEC_PHASES")
+            .ok()
+            .as_deref()
+            == Some("1")
+    });
     if phase_on {
         gpu.hip.device_synchronize()?;
     }
@@ -2932,7 +2950,10 @@ pub fn spec_step_dflash(
     static LOGIT_DUMP_ENV: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     let logit_dump_active = !use_temp_sampling
         && *LOGIT_DUMP_ENV.get_or_init(|| {
-            hipfire_config::developer_var("HIPFIRE_DFLASH_LOGIT_DUMP").ok().as_deref() == Some("1")
+            hipfire_config::developer_var("HIPFIRE_DFLASH_LOGIT_DUMP")
+                .ok()
+                .as_deref()
+                == Some("1")
         });
     let host_path_active = rp_active || ngram_block_active || logit_dump_active;
     // HIPFIRE_DFLASH_FAST_SAMPLE (default ON, opt out with =0): in the temp>0
@@ -2947,7 +2968,8 @@ pub fn spec_step_dflash(
     // borderline `u*p_d <= p_t` accept) — validated coherent across genres
     // (no attractors), so default-on. Greedy path (temp==0) is never affected.
     let fast_sample_active = use_temp_sampling && gpu.flags.dflash_fast_sample;
-    let draft_ffn_graph_env = hipfire_config::developer_var("HIPFIRE_DFLASH_MOE_DRAFT_FFN_GRAPH").ok();
+    let draft_ffn_graph_env =
+        hipfire_config::developer_var("HIPFIRE_DFLASH_MOE_DRAFT_FFN_GRAPH").ok();
     let draft_ffn_graph = dflash_moe_draft_ffn_graph_eligible(
         target.config.num_experts,
         ctx_slice.is_some(),
@@ -3261,23 +3283,13 @@ pub fn spec_step_dflash(
                 let pat_dev = gpu.alloc_tensor(&[batch], rdna_compute::DType::F32)?;
                 let seed_u32 = (*rng_state >> 32) as u32 ^ (*rng_state as u32);
                 gpu.batched_categorical_sample_f32(
-                    &probs_dev,
-                    &tau_dev,
-                    &z_dev,
-                    &tok_dev,
-                    &pat_dev,
-                    vocab,
-                    batch,
-                    seed_u32,
+                    &probs_dev, &tau_dev, &z_dev, &tok_dev, &pat_dev, vocab, batch, seed_u32,
                 )?;
                 // Download only tokens + probs: batch×8 bytes total.
                 let mut raw_tok = vec![0i32; batch];
                 {
                     let bytes: &mut [u8] = unsafe {
-                        std::slice::from_raw_parts_mut(
-                            raw_tok.as_mut_ptr() as *mut u8,
-                            batch * 4,
-                        )
+                        std::slice::from_raw_parts_mut(raw_tok.as_mut_ptr() as *mut u8, batch * 4)
                     };
                     gpu.hip.memcpy_dtoh(bytes, &tok_dev.buf)?;
                 }
@@ -3559,7 +3571,7 @@ pub fn spec_step_dflash(
             let z_d_dev = c8_draft_z_dev.as_ref().unwrap();
 
             let out_dev = gpu.alloc_tensor(&[4], rdna_compute::DType::F32)?; // 4×i32 via f32 slot
-            // kernel's b parameter = number of draft comparison positions = b-1
+                                                                             // kernel's b parameter = number of draft comparison positions = b-1
             let draft_b = b - 1;
             let rng_seed = (*rng_state >> 32) as u32 ^ (*rng_state as u32);
             gpu.chain_accept_spec_f32(
@@ -3581,9 +3593,8 @@ pub fn spec_step_dflash(
             // Download 16 bytes: {accept_len, bonus_token, rejected_at, new_rng}
             let mut out_raw = [0i32; 4];
             {
-                let bytes: &mut [u8] = unsafe {
-                    std::slice::from_raw_parts_mut(out_raw.as_mut_ptr() as *mut u8, 16)
-                };
+                let bytes: &mut [u8] =
+                    unsafe { std::slice::from_raw_parts_mut(out_raw.as_mut_ptr() as *mut u8, 16) };
                 gpu.hip.memcpy_dtoh(bytes, &out_dev.buf)?;
             }
             accept_len = out_raw[0] as usize;
@@ -3692,8 +3703,7 @@ pub fn spec_step_dflash(
                         }
                     }
                     let u2 = xorshift_next_unit(rng_state);
-                    rejected_bonus =
-                        Some(sample_residual(&target_probs, &draft_softmaxes[i], u2));
+                    rejected_bonus = Some(sample_residual(&target_probs, &draft_softmaxes[i], u2));
                     break;
                 }
             }
@@ -3797,11 +3807,21 @@ pub fn spec_step_dflash(
     }
 
     // Free C8 device tensors now that accept is resolved.
-    if let Some(t) = c8_draft_probs_dev { let _ = gpu.free_tensor(t); }
-    if let Some(t) = c8_draft_tau_dev { let _ = gpu.free_tensor(t); }
-    if let Some(t) = c8_draft_z_dev { let _ = gpu.free_tensor(t); }
-    if let Some(t) = c8_draft_tokens_dev { let _ = gpu.free_tensor(t); }
-    if let Some(t) = c8_draft_p_at_token_dev { let _ = gpu.free_tensor(t); }
+    if let Some(t) = c8_draft_probs_dev {
+        let _ = gpu.free_tensor(t);
+    }
+    if let Some(t) = c8_draft_tau_dev {
+        let _ = gpu.free_tensor(t);
+    }
+    if let Some(t) = c8_draft_z_dev {
+        let _ = gpu.free_tensor(t);
+    }
+    if let Some(t) = c8_draft_tokens_dev {
+        let _ = gpu.free_tensor(t);
+    }
+    if let Some(t) = c8_draft_p_at_token_dev {
+        let _ = gpu.free_tensor(t);
+    }
 
     // ── 7b. Seed-prediction oracle (Task #93 Phase B) ───────────────────
     // Three position-based proxies for the next cycle's `seed_token`
@@ -3833,7 +3853,11 @@ pub fn spec_step_dflash(
     if rej_proxy.is_none() {
         SEED_ORACLE_FULLACCEPT.fetch_add(1, Ordering::Relaxed);
     }
-    if hipfire_config::developer_var("HIPFIRE_DFLASH_SEED_ORACLE").ok().as_deref() == Some("1") {
+    if hipfire_config::developer_var("HIPFIRE_DFLASH_SEED_ORACLE")
+        .ok()
+        .as_deref()
+        == Some("1")
+    {
         let s = read_seed_oracle_stats();
         let denom = s.total.max(1) as f32;
         eprintln!(
@@ -4415,7 +4439,12 @@ fn run_dflash_draft_for_topk_gpu(
             let positions_q: Vec<i32> = (position as i32..(position + b) as i32).collect();
             let positions_k: Vec<i32> = (ctx_start as i32..(position + b) as i32).collect();
             let th_offset = ctx_start * ne * h;
-            (positions_q, positions_k, Some(&host_slice[th_offset..]), effective_ctx_len)
+            (
+                positions_q,
+                positions_k,
+                Some(&host_slice[th_offset..]),
+                effective_ctx_len,
+            )
         } else {
             // GPU-resident path: scratch.target_hidden already contains all rows
             // via D2D scatter (Stage 1); thlog tracks uploaded_rows + abs_positions.
@@ -5201,7 +5230,11 @@ pub fn spec_step_ddtree_batched(
     // Dual-path proof: download the GPU mask and compare byte-for-byte with
     // the host mask_host computed by linearize_tree_with_parents above.
     // Off by default (costs one D2H per cycle).
-    if hipfire_config::developer_var("HIPFIRE_DDTREE_ASSERT_MASK").ok().as_deref() == Some("1") {
+    if hipfire_config::developer_var("HIPFIRE_DDTREE_ASSERT_MASK")
+        .ok()
+        .as_deref()
+        == Some("1")
+    {
         // Synchronize so the kernel has finished writing before the D2H.
         gpu.hip.device_synchronize()?;
         let n_floats = big_n * big_n;
@@ -5365,7 +5398,10 @@ pub fn spec_step_ddtree_batched(
     // verify to fix KV cache entries at committed slots (topk>1 siblings
     // at same depth otherwise race and the LAST write wins regardless of
     // which sibling was committed).
-    let force_slow = hipfire_config::developer_var("HIPFIRE_DDTREE_FORCE_SLOW").ok().as_deref() == Some("1");
+    let force_slow = hipfire_config::developer_var("HIPFIRE_DDTREE_FORCE_SLOW")
+        .ok()
+        .as_deref()
+        == Some("1");
     let spine_accept = accepted_node_indices
         .iter()
         .enumerate()
@@ -5384,7 +5420,11 @@ pub fn spec_step_ddtree_batched(
     } else if !force_slow {
         DDTREE_SLOW_COUNT.with(|c| c.set(c.get() + 1));
     }
-    if hipfire_config::developer_var("HIPFIRE_DDTREE_TAPE_DUMP").ok().as_deref() == Some("1") {
+    if hipfire_config::developer_var("HIPFIRE_DDTREE_TAPE_DUMP")
+        .ok()
+        .as_deref()
+        == Some("1")
+    {
         let fast = DDTREE_FAST_COUNT.with(|c| c.get());
         let slow = DDTREE_SLOW_COUNT.with(|c| c.get());
         eprintln!(

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -2208,6 +2208,16 @@ fn verify_dflash_block_inner(
     let b = draft_tokens.len();
     let vocab = target.config.vocab_size;
     let dim = target.config.dim;
+    let required_tokens = start_pos.checked_add(b).ok_or_else(|| {
+        hip_bridge::HipError::new(
+            0,
+            &format!("DFlash verify KV token range overflow ({start_pos} + {b})"),
+        )
+    })?;
+    // Verify replay bypasses the regular qwen35 forward wrappers.
+    target
+        .kv_cache
+        .ensure_mapped_capacity(gpu, required_tokens)?;
 
     assert!(
         b <= verify_scratch.max_n,

--- a/crates/hipfire-arch-qwen35/tests/pp_parity.rs
+++ b/crates/hipfire-arch-qwen35/tests/pp_parity.rs
@@ -107,7 +107,7 @@ fn run_pp1(path: &str, prompt: &[u32]) -> Vec<u32> {
     }
     scratch.free_gpu(&mut gpu);
     dn.free_gpu(&mut gpu);
-    kv.free_gpu(&mut gpu);
+    let _ = kv.free_gpu(&mut gpu);
     weights.free_gpu(&mut gpu);
     gpu.drain_pool();
     tokens

--- a/crates/hipfire-cli/src/main.rs
+++ b/crates/hipfire-cli/src/main.rs
@@ -1859,6 +1859,9 @@ fn run_command(paths: &Paths, args: RunArgs) -> Result<()> {
         .clone()
         .unwrap_or(config_string(&resolved, "speculation.mode")?);
     apply_speculation_selector(&mut params, &selector)?;
+    // Final effective selector wins: re-project inherited draft only when DFlash
+    // remains enabled (config-off + `run --spec dflash` must still carry draft).
+    project_dflash_draft(&mut params);
     if let Some(draft) = &args.model_draft {
         params["draft"] = serde_json::json!(draft.display().to_string());
         if args.speculation.is_none() {
@@ -3652,7 +3655,8 @@ fn completion_timings(completion: &Completion) -> serde_json::Value {
         "decode_tok_s": done.get("decode_tok_s").or_else(|| done.get("tok_s")),
         "tau": done.get("tau"),
         "cycles": done.get("cycles"),
-        "dflash": done.get("dflash").or_else(|| done.get("mtp")),
+        "dflash": done.get("dflash"),
+        "mtp": done.get("mtp"),
     })
 }
 
@@ -4150,7 +4154,26 @@ fn load_params(
     });
     let selector = config_string(resolved, "speculation.mode")?;
     apply_speculation_selector(&mut params, &selector)?;
+    project_dflash_draft(&mut params);
     Ok(params)
+}
+
+/// Project inherited `HIPFIRE_DFLASH_DRAFT` after the effective speculation selector.
+///
+/// Call only once final `dflash_mode` is known. Config-off must not carry a draft;
+/// a later CLI selector (e.g. `run --spec dflash`) can opt back in here.
+fn project_dflash_draft(params: &mut serde_json::Value) {
+    if params["dflash_mode"].as_str() == Some("off") {
+        if let Some(obj) = params.as_object_mut() {
+            obj.remove("draft");
+        }
+        return;
+    }
+    if let Ok(draft) = env::var("HIPFIRE_DFLASH_DRAFT") {
+        if !draft.is_empty() {
+            params["draft"] = serde_json::json!(draft);
+        }
+    }
 }
 
 fn apply_speculation_selector(params: &mut serde_json::Value, selector: &str) -> Result<()> {
@@ -6273,6 +6296,123 @@ mod tests {
         let params =
             load_params(&defaults, None, &model_path, 64, Some("q8"), Some("vmm")).unwrap();
         assert_eq!(params["kv_backend"], "vmm");
+    }
+
+    #[test]
+    fn load_params_forwards_dflash_draft_from_environment() {
+        struct EnvRestore(Option<std::ffi::OsString>);
+
+        impl Drop for EnvRestore {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(value) => env::set_var("HIPFIRE_DFLASH_DRAFT", value),
+                    None => env::remove_var("HIPFIRE_DFLASH_DRAFT"),
+                }
+            }
+        }
+
+        let _restore = EnvRestore(env::var_os("HIPFIRE_DFLASH_DRAFT"));
+        let draft = "/tmp/qwen35-9b-dflash-mq4.hfq";
+        env::set_var("HIPFIRE_DFLASH_DRAFT", draft);
+
+        let mut explicit = ConfigLayer::default();
+        explicit.set_cli("speculation.mode", "dflash").unwrap();
+        let resolved = resolve([NamedLayer {
+            source: ConfigSource::OneShot {
+                argument: "speculation.mode=dflash".into(),
+            },
+            layer: explicit,
+        }])
+        .unwrap();
+        let model_path = PathBuf::from("/tmp/test-model.mq4");
+
+        let params = load_params(&resolved, None, &model_path, 64, Some("q8"), None).unwrap();
+        assert_eq!(params["draft"], draft);
+    }
+
+    #[test]
+    fn run_spec_dflash_projects_inherited_draft_after_config_off() {
+        // Reviewer case: resolved config leaves DFlash off, but an inherited
+        // HIPFIRE_DFLASH_DRAFT is present and `run --spec dflash` re-enables
+        // DFlash after load_params. Draft must land on the final load params.
+        struct EnvRestore(Option<std::ffi::OsString>);
+
+        impl Drop for EnvRestore {
+            fn drop(&mut self) {
+                match &self.0 {
+                    Some(value) => env::set_var("HIPFIRE_DFLASH_DRAFT", value),
+                    None => env::remove_var("HIPFIRE_DFLASH_DRAFT"),
+                }
+            }
+        }
+
+        let _restore = EnvRestore(env::var_os("HIPFIRE_DFLASH_DRAFT"));
+        let draft = "/tmp/qwen35-9b-dflash-mq4.hfq";
+        env::set_var("HIPFIRE_DFLASH_DRAFT", draft);
+
+        let mut explicit = ConfigLayer::default();
+        explicit.set_cli("speculation.mode", "off").unwrap();
+        let resolved = resolve([NamedLayer {
+            source: ConfigSource::OneShot {
+                argument: "speculation.mode=off".into(),
+            },
+            layer: explicit,
+        }])
+        .unwrap();
+        let model_path = PathBuf::from("/tmp/test-model.mq4");
+
+        // load_params alone must not carry the draft while config mode is off.
+        let mut params = load_params(&resolved, None, &model_path, 64, Some("q8"), None).unwrap();
+        assert_eq!(params["dflash_mode"], "off");
+        assert!(
+            params.get("draft").is_none(),
+            "config-off load_params must not project HIPFIRE_DFLASH_DRAFT"
+        );
+
+        // Final run-path selector: CLI `--spec dflash` then project inherited draft.
+        apply_speculation_selector(&mut params, "dflash").unwrap();
+        project_dflash_draft(&mut params);
+        assert_eq!(params["dflash_mode"], "on");
+        assert_eq!(params["draft"], draft);
+
+        // Final off must clear any previously projected draft.
+        apply_speculation_selector(&mut params, "off").unwrap();
+        project_dflash_draft(&mut params);
+        assert_eq!(params["dflash_mode"], "off");
+        assert!(
+            params.get("draft").is_none(),
+            "final off must drop projected HIPFIRE_DFLASH_DRAFT"
+        );
+    }
+
+    #[test]
+    fn completion_timings_preserves_speculator_identity() {
+        let completion = |done| Completion {
+            id: "req-test".into(),
+            created: 0,
+            model: "test-model".into(),
+            content: String::new(),
+            reasoning_content: String::new(),
+            preserve_thinking: false,
+            tool_calls: Vec::new(),
+            done,
+        };
+
+        let dflash = completion_timings(&completion(serde_json::json!({
+            "dflash": true,
+            "tau": 3.5,
+            "cycles": 4,
+        })));
+        assert_eq!(dflash["dflash"], true);
+        assert!(dflash["mtp"].is_null());
+
+        let mtp = completion_timings(&completion(serde_json::json!({
+            "mtp": true,
+            "tau": 2.0,
+            "cycles": 6,
+        })));
+        assert!(mtp["dflash"].is_null());
+        assert_eq!(mtp["mtp"], true);
     }
 
     #[test]

--- a/crates/hipfire-cli/src/main.rs
+++ b/crates/hipfire-cli/src/main.rs
@@ -309,6 +309,9 @@ struct RunArgs {
     #[arg(long)]
     /// One-shot KV format override for this model load.
     kv_mode: Option<String>,
+    #[arg(long, value_parser = ["contiguous", "vmm"])]
+    /// One-shot KV storage backend override for this model load.
+    kv_backend: Option<String>,
     /// Select one speculative mechanism: off, auto, ngram, dflash, mtp, or dspark.
     #[arg(long = "spec", alias = "speculation")]
     speculation: Option<String>,
@@ -387,6 +390,8 @@ struct BenchArgs {
     warmups: usize,
     #[arg(long)]
     kv_mode: Option<String>,
+    #[arg(long, value_parser = ["contiguous", "vmm"])]
+    kv_backend: Option<String>,
     #[arg(long)]
     redline: bool,
     /// Prompt words for the standard benchmark.
@@ -472,6 +477,9 @@ struct ServeArgs {
     /// KV cache mode for models loaded by this service.
     #[arg(long)]
     kv_mode: Option<String>,
+    /// KV storage backend for models loaded by this service.
+    #[arg(long, value_parser = ["contiguous", "vmm"])]
+    kv_backend: Option<String>,
     /// Idle model-unload timeout in seconds; zero disables eviction.
     #[arg(long, value_parser = clap::value_parser!(u64).range(0..=86400))]
     idle_timeout: Option<u64>,
@@ -1806,6 +1814,7 @@ fn run_command(paths: &Paths, args: RunArgs) -> Result<()> {
     let force_local = process_truthy("HIPFIRE_LOCAL")
         || args.image.is_some()
         || args.kv_mode.is_some()
+        || args.kv_backend.is_some()
         || args.speculation.is_some()
         || args.model_draft.is_some()
         || args.draft_max.is_some()
@@ -1843,6 +1852,7 @@ fn run_command(paths: &Paths, args: RunArgs) -> Result<()> {
         &model_path,
         max_tokens,
         args.kv_mode.as_deref(),
+        args.kv_backend.as_deref(),
     )?;
     let selector = args
         .speculation
@@ -2059,6 +2069,7 @@ fn chat_command(paths: &Paths, args: ChatArgs) -> Result<()> {
             detach: true,
             no_prewarm: true,
             kv_mode: None,
+            kv_backend: None,
             idle_timeout: None,
             tp: None,
             foreground_child: false,
@@ -2164,6 +2175,7 @@ struct ServeRuntime {
     current_max_seq: u64,
     cache_capable: bool,
     kv_override: Option<String>,
+    kv_backend_override: Option<String>,
     tp: Option<u64>,
 }
 
@@ -2629,6 +2641,9 @@ fn detach_serve(paths: &Paths, args: &ServeArgs, host: &str, port: u16) -> Resul
     if let Some(mode) = &args.kv_mode {
         command.arg("--kv-mode").arg(mode);
     }
+    if let Some(backend) = &args.kv_backend {
+        command.arg("--kv-backend").arg(backend);
+    }
     if let Some(seconds) = args.idle_timeout {
         command.arg("--idle-timeout").arg(seconds.to_string());
     }
@@ -2717,6 +2732,7 @@ fn serve_foreground(
             current_max_seq: 0,
             cache_capable: false,
             kv_override: args.kv_mode.clone(),
+            kv_backend_override: args.kv_backend.clone(),
             tp: args.tp,
         }),
         meta: Mutex::new(ServeMeta {
@@ -3336,6 +3352,7 @@ impl ServeRuntime {
                 &path,
                 max_tokens,
                 self.kv_override.as_deref(),
+                self.kv_backend_override.as_deref(),
             )?;
             if let Some(tp) = self.tp {
                 params["tp"] = serde_json::json!(tp);
@@ -4064,6 +4081,7 @@ fn load_params(
     model_path: &Path,
     max_tokens: u64,
     kv_override: Option<&str>,
+    kv_backend_override: Option<&str>,
 ) -> Result<serde_json::Value> {
     let configured_max_seq = config_u64(resolved, "memory.max_seq")?;
     let max_seq = configured_max_seq.max(max_tokens.saturating_add(1024));
@@ -4077,6 +4095,14 @@ fn load_params(
     field("memory.kv_cache")
         .expect("schema field")
         .parse_cli(&kv_mode)?;
+    let kv_backend = kv_backend_override
+        .map(str::to_owned)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "contiguous".into())
+        .to_ascii_lowercase();
+    if !matches!(kv_backend.as_str(), "contiguous" | "vmm") {
+        bail!("--kv-backend must be contiguous or vmm");
+    }
     let mut cask_sidecar = config_string(resolved, "memory.cask.sidecar")?;
     if cask_sidecar.is_empty() && config_bool(resolved, "memory.cask.auto_attach")? {
         if let Some(sidecar) = entry.and_then(|entry| entry.triattn.as_ref()) {
@@ -4092,6 +4118,7 @@ fn load_params(
     let mut params = serde_json::json!({
         "max_seq": max_seq,
         "kv_mode": kv_mode,
+        "kv_backend": kv_backend,
         "kv_adaptive": config_string(resolved, "memory.kv_adaptive")?,
         "dflash_mode": config_string(resolved, "speculation.dflash")?,
         "dflash_adaptive_b": config_bool(resolved, "speculation.dflash_adaptive_b")?,
@@ -4669,6 +4696,7 @@ fn open_bench_engine(
         &path,
         max_tokens,
         args.kv_mode.as_deref(),
+        args.kv_backend.as_deref(),
     )?;
     if args.matrix || args.redline {
         let requested = longest_prefill.max(longest_decode).saturating_add(32);
@@ -4899,6 +4927,7 @@ fn profile_command(paths: &Paths, args: ProfileArgs) -> Result<()> {
             sustained_ctx: vec![128],
             warmups: 1,
             kv_mode: None,
+            kv_backend: None,
             redline: false,
             prompt: Vec::new(),
         };
@@ -6216,7 +6245,7 @@ mod tests {
         fs::write(&sidecar_path, b"sidecar").unwrap();
 
         let defaults = resolve(Vec::<NamedLayer>::new()).unwrap();
-        let params = load_params(&defaults, Some(entry), &model_path, 64, None).unwrap();
+        let params = load_params(&defaults, Some(entry), &model_path, 64, None, None).unwrap();
         assert_eq!(params["cask"], false);
         assert_eq!(params["cask_sidecar"], "");
         assert_eq!(params["prefill_compression"], "off");
@@ -6230,11 +6259,20 @@ mod tests {
             layer: explicit,
         }])
         .unwrap();
-        let params = load_params(&enabled, Some(entry), &model_path, 64, None).unwrap();
+        let params = load_params(&enabled, Some(entry), &model_path, 64, None, None).unwrap();
         assert_eq!(params["cask"], false);
         assert_eq!(params["cask_sidecar"], sidecar_path.display().to_string());
         assert_eq!(params["prefill_compression"], "off");
         fs::remove_dir_all(&paths.root).unwrap();
+    }
+
+    #[test]
+    fn load_params_forwards_explicit_vmm_backend() {
+        let defaults = resolve(Vec::<NamedLayer>::new()).unwrap();
+        let model_path = PathBuf::from("/tmp/test-model.mq4");
+        let params =
+            load_params(&defaults, None, &model_path, 64, Some("q8"), Some("vmm")).unwrap();
+        assert_eq!(params["kv_backend"], "vmm");
     }
 
     #[test]
@@ -6834,6 +6872,8 @@ mod tests {
             "11520",
             "--kv-mode",
             "q8",
+            "--kv-backend",
+            "vmm",
             "--idle-timeout",
             "0",
             "--tp",
@@ -6845,6 +6885,7 @@ mod tests {
         };
         assert_eq!(args.positionals.len(), 3);
         assert_eq!(args.kv_mode.as_deref(), Some("q8"));
+        assert_eq!(args.kv_backend.as_deref(), Some("vmm"));
         assert_eq!(args.idle_timeout, Some(0));
         assert_eq!(args.tp, Some(2));
     }

--- a/crates/hipfire-loader/src/carriers.rs
+++ b/crates/hipfire-loader/src/carriers.rs
@@ -11,6 +11,7 @@ use crate::{
     ModelState,
 };
 use hipfire_arch_minimax::{config_from_safetensors, load_weights_from_safetensors, MiniMaxState};
+use hipfire_runtime::kv_backend::KvBackend;
 use hipfire_runtime::loader_api::{LoadCtx, ModelSource};
 use hipfire_runtime::model_source::ModelSource as _;
 use hipfire_runtime::spec::{InPlaceGuard, SpecEmit, SpecEmitCtx, SpecTargetGuard};
@@ -328,6 +329,18 @@ impl Carrier for Qwen35Carrier {
         matches!(arch_id, 5 | 6)
     }
     fn load(&self, src: ModelSource, ctx: &mut LoadCtx) -> Result<LoadedModel, String> {
+        if ctx.kv_backend == KvBackend::Vmm && ctx.pp > 1 {
+            return Err(
+                "qwen35: KV backend 'vmm' currently requires pp=1; use 'contiguous' for pipeline parallelism"
+                    .into(),
+            );
+        }
+        if ctx.kv_backend == KvBackend::Vmm && ctx.cask.sidecar.is_some() {
+            return Err(
+                "qwen35: KV backend 'vmm' does not yet support CASK/TriAttention eviction; disable the sidecar or use 'contiguous'"
+                    .into(),
+            );
+        }
         // Dir + pp>1: early return before any diagnostics/meta resolution,
         // preserving the original error string and preventing tokenizer work.
         if ctx.pp > 1 {
@@ -432,8 +445,9 @@ impl Carrier for Qwen35Carrier {
                     max_seq: ctx.max_seq,
                     physical_cap: Some(ctx.max_seq),
                 };
-                let kv_cache = hipfire_runtime::llama::KvCache::from_mode(
+                let kv_cache = hipfire_runtime::llama::KvCache::from_mode_with_backend(
                     mode,
+                    ctx.kv_backend,
                     hipfire_runtime::llama::KvTarget::Single(ctx.gpu),
                     &dims,
                 )

--- a/crates/hipfire-loader/src/carriers.rs
+++ b/crates/hipfire-loader/src/carriers.rs
@@ -286,6 +286,8 @@ fn load_qwen35_pp(
         scratch: single_scratch,
         kv_cache: kv,
         dn_state: dn,
+        // Adaptive is single-GPU only; PP path never engages the controller.
+        kv_adaptive: None,
     };
     Ok(LoadedModel {
         state: Some(ModelState::Qwen35(bundle)),
@@ -395,8 +397,21 @@ impl Carrier for Qwen35Carrier {
                     }
                 };
 
-                let bundle =
-                    hipfire_arch_qwen35::load_qwen35_bundle(ModelSource::Hfq(hfq_file), ctx)?;
+                // Trunk bundle after optional VL upload. On bundle failure, reclaim
+                // any vision weights already on-device (HFQ is single-pass: VL must
+                // load from the same file before the carrier consumes it).
+                let bundle = match hipfire_arch_qwen35::load_qwen35_bundle(
+                    ModelSource::Hfq(hfq_file),
+                    ctx,
+                ) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        if let Some(vw) = vision_weights {
+                            vw.free_gpu(ctx.gpu);
+                        }
+                        return Err(e);
+                    }
+                };
                 finish_qwen35_load(
                     bundle,
                     meta.tokenizer,
@@ -417,17 +432,30 @@ impl Carrier for Qwen35Carrier {
                 if ctx.cask.sidecar.is_some() {
                     eprintln!("  warning: CASK eviction is not supported for safetensors Dir sources; eviction sidecar ignored");
                 }
-                let mut paro_source =
-                    hipfire_arch_qwen35::qwen35::ParoSource::new(&source, &config)
-                        .map_err(|e| format!("ParoSource::new: {e:?}"))?;
-                let paro_layout = hipfire_arch_qwen35::qwen35::Layout::single(config.n_layers);
-                let weights = hipfire_arch_qwen35::qwen35::load_weights(
-                    &mut paro_source,
-                    std::slice::from_mut(ctx.gpu),
-                    &paro_layout,
-                )
-                .map_err(|e| format!("load_weights: {e:?}"))?;
-                hipfire_runtime::maybe_screen_mmq(&weights, ctx.gpu);
+                // CPU-only before any GPU ownership (parity with HFQ carrier).
+                let dn_quant = crate::parse_state_quant(ctx.state_quant_override)
+                    .map_err(|e| format!("{e}"))?;
+                eprintln!(
+                    "  DeltaNet state quant: {}",
+                    if dn_quant == hipfire_arch_qwen35::qwen35::StateQuant::FP32 {
+                        "FP32"
+                    } else if dn_quant == hipfire_arch_qwen35::qwen35::StateQuant::Q4 {
+                        "Q4"
+                    } else {
+                        "Q8"
+                    }
+                );
+                if config.dim < 2048 && dn_quant != hipfire_arch_qwen35::qwen35::StateQuant::FP32 {
+                    eprintln!(
+                        "  warning: model dim={} (<2048); FP32 DeltaNet state is recommended for small models (current: {})",
+                        config.dim,
+                        if dn_quant == hipfire_arch_qwen35::qwen35::StateQuant::Q4 {
+                            "Q4"
+                        } else {
+                            "Q8"
+                        }
+                    );
+                }
                 let is_kv_layer: Vec<bool> = config
                     .layer_types
                     .iter()
@@ -445,44 +473,64 @@ impl Carrier for Qwen35Carrier {
                     max_seq: ctx.max_seq,
                     physical_cap: Some(ctx.max_seq),
                 };
-                let kv_cache = hipfire_runtime::llama::KvCache::from_mode_with_backend(
+
+                let mut paro_source =
+                    hipfire_arch_qwen35::qwen35::ParoSource::new(&source, &config)
+                        .map_err(|e| format!("ParoSource::new: {e:?}"))?;
+                let paro_layout = hipfire_arch_qwen35::qwen35::Layout::single(config.n_layers);
+                let weights = hipfire_arch_qwen35::qwen35::load_weights(
+                    &mut paro_source,
+                    std::slice::from_mut(ctx.gpu),
+                    &paro_layout,
+                )
+                .map_err(|e| format!("load_weights: {e:?}"))?;
+                hipfire_runtime::maybe_screen_mmq(&weights, ctx.gpu);
+
+                // Staged GPU free on every post-weight error (VMM arenas via free_gpu).
+                let kv_cache = match hipfire_runtime::llama::KvCache::from_mode_with_backend(
                     mode,
                     ctx.kv_backend,
                     hipfire_runtime::llama::KvTarget::Single(ctx.gpu),
                     &dims,
-                )
-                .map_err(|e| format!("KvCache: {e}"))?;
-
-                let dn_quant = crate::parse_state_quant(ctx.state_quant_override)
-                    .map_err(|e| format!("{e}"))?;
-                eprintln!(
-                    "  DeltaNet state quant: {}",
-                    if dn_quant == hipfire_arch_qwen35::qwen35::StateQuant::FP32 {
-                        "FP32"
-                    } else if dn_quant == hipfire_arch_qwen35::qwen35::StateQuant::Q4 {
-                        "Q4"
-                    } else {
-                        "Q8"
+                ) {
+                    Ok(k) => k,
+                    Err(e) => {
+                        weights.free_gpu(ctx.gpu);
+                        return Err(format!("KvCache: {e}"));
                     }
-                );
-                if config.dim < 2048 && dn_quant != hipfire_arch_qwen35::qwen35::StateQuant::FP32 {
-                    eprintln!(
-                        "  warning: model dim={} (<2048); FP32 DeltaNet state is recommended for small models (current: {})",
-                        config.dim,
-                        if dn_quant == hipfire_arch_qwen35::qwen35::StateQuant::Q4 { "Q4" } else { "Q8" }
-                    );
-                }
-                let dn_state = hipfire_arch_qwen35::qwen35::DeltaNetState::new_with_quant(
+                };
+
+                let dn_state = match hipfire_arch_qwen35::qwen35::DeltaNetState::new_with_quant(
                     ctx.gpu, &config, dn_quant,
-                )
-                .map_err(|e| format!("DeltaNetState::new_with_quant: {e:?}"))?;
-                let scratch = hipfire_arch_qwen35::qwen35::Qwen35Scratch::new_with_kv_max(
+                ) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        let mut note = format!("DeltaNetState::new_with_quant: {e:?}");
+                        if let Err(fe) = kv_cache.free_gpu(ctx.gpu) {
+                            note = format!("{note}; cleanup also failed: {fe}");
+                        }
+                        weights.free_gpu(ctx.gpu);
+                        return Err(note);
+                    }
+                };
+
+                let scratch = match hipfire_arch_qwen35::qwen35::Qwen35Scratch::new_with_kv_max(
                     ctx.gpu,
                     &config,
                     2048,
                     ctx.max_seq,
-                )
-                .map_err(|e| format!("Qwen35Scratch::new_with_kv_max: {e:?}"))?;
+                ) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        let mut note = format!("Qwen35Scratch::new_with_kv_max: {e:?}");
+                        if let Err(fe) = kv_cache.free_gpu(ctx.gpu) {
+                            note = format!("{note}; cleanup also failed: {fe}");
+                        }
+                        dn_state.free_gpu(ctx.gpu);
+                        weights.free_gpu(ctx.gpu);
+                        return Err(note);
+                    }
+                };
 
                 let bundle = hipfire_arch_qwen35::Qwen35Bundle {
                     config,
@@ -490,6 +538,8 @@ impl Carrier for Qwen35Carrier {
                     scratch,
                     kv_cache,
                     dn_state,
+                    // Dir/safetensors path does not engage adaptive (HFQ carrier only).
+                    kv_adaptive: None,
                 };
                 Ok(LoadedModel {
                     state: Some(ModelState::Qwen35(bundle)),
@@ -696,11 +746,12 @@ impl Carrier for LlamaCarrier {
             // conf_threshold ladder: env > CLI arg > 0.1
             // Default 0.1 (sweep-tuned): 0.5 over-truncates (1.46/7 proposed);
             // 0.1 proposes ~6.94/7, +16.6% prose tok/s / +7.1% code tok/s.
-            let conf_threshold = hipfire_config::developer_var("HIPFIRE_QWEN3_DSPARK_CONF_THRESHOLD")
-                .ok()
-                .and_then(|s| s.parse().ok())
-                .or(ctx.spec.dspark_conf_threshold)
-                .unwrap_or(0.1f32);
+            let conf_threshold =
+                hipfire_config::developer_var("HIPFIRE_QWEN3_DSPARK_CONF_THRESHOLD")
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .or(ctx.spec.dspark_conf_threshold)
+                    .unwrap_or(0.1f32);
 
             eprintln!(
                 "  llama DSpark speculator enabled (sidecar, block={}, conf_threshold={:.2})",
@@ -1020,9 +1071,7 @@ impl Carrier for Deepseek4Carrier {
             let max_n: usize = hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_SPEC_K")
                 .ok()
                 .and_then(|s| s.parse().ok())
-                .or_else(|| {
-                    Some(hipfire_runtime::config::get().mtp_k)
-                })
+                .or_else(|| Some(hipfire_runtime::config::get().mtp_k))
                 .unwrap_or(2);
             let ctx_capacity = config.max_position_embeddings;
             eprintln!("  deepseek4 MTP speculator enabled (in-weights, K={max_n})");

--- a/crates/hipfire-loader/src/lib.rs
+++ b/crates/hipfire-loader/src/lib.rs
@@ -24,6 +24,7 @@ use hipfire_arch_qwen35::Qwen35Bundle;
 use hipfire_arch_qwen35_vl::qwen35_vl;
 use hipfire_runtime::cask::CaskCtx;
 use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::kv_backend::KvBackend;
 use hipfire_runtime::llama;
 use hipfire_runtime::loader_api::{CaskConfig, LoadCtx, ModelSource, SpecLoadCfg};
 use hipfire_runtime::multi_gpu::Gpus;
@@ -1006,7 +1007,39 @@ pub fn load_model(
     spec: SpecLoadCfg,
     gpu: &mut rdna_compute::Gpu,
 ) -> Result<LoadedModel, String> {
+    load_model_with_kv_backend(
+        path,
+        max_seq,
+        draft_path,
+        kv_mode_override,
+        None,
+        kv_adaptive_override,
+        state_quant_override,
+        cask,
+        pp,
+        spec,
+        gpu,
+    )
+}
+
+/// Load a model with an optional per-load KV storage backend override.
+#[allow(clippy::too_many_arguments)]
+pub fn load_model_with_kv_backend(
+    path: &str,
+    max_seq: usize,
+    draft_path: Option<&str>,
+    kv_mode_override: Option<&str>,
+    kv_backend_override: Option<&str>,
+    kv_adaptive_override: Option<&str>,
+    state_quant_override: Option<&str>,
+    cask: &CaskConfig,
+    pp: usize,
+    spec: SpecLoadCfg,
+    gpu: &mut rdna_compute::Gpu,
+) -> Result<LoadedModel, String> {
     let src = ModelSource::from_path(path)?;
+    let kv_backend_raw = kv_backend_override.unwrap_or("contiguous");
+    let kv_backend: KvBackend = kv_backend_raw.parse().map_err(|err| format!("{err}"))?;
 
     // Author-recommended sampling defaults (temp/top_p/top_k from the .hfq's baked
     // `generation_config`). Extract HERE, from the already-open source, BEFORE the
@@ -1098,6 +1131,7 @@ pub fn load_model(
         max_seq,
         draft_path,
         kv_mode_override,
+        kv_backend,
         kv_adaptive_override,
         state_quant_override,
         cask,
@@ -1119,6 +1153,12 @@ pub fn load_model(
             src.describe(),
             carrier.name(),
             other.name()
+        ));
+    }
+    if kv_backend == KvBackend::Vmm && carrier.name() != "qwen35" {
+        return Err(format!(
+            "KV backend 'vmm' currently supports qwen3.5 only (selected carrier: {})",
+            carrier.name()
         ));
     }
     let mut result = carrier.load(src, &mut ctx)?;

--- a/crates/hipfire-loader/src/lib.rs
+++ b/crates/hipfire-loader/src/lib.rs
@@ -628,9 +628,109 @@ pub(crate) fn parse_state_quant(
 
 // ─── Core arch carrier load ─────────────────────────────────────────────
 
+/// Hard-error free for unfinished qwen35 finish path: bundle + optional VL.
+fn rollback_unfinished_qwen35(
+    err: String,
+    bundle: Qwen35Bundle,
+    vision_weights: Option<qwen35_vl::VisionWeights>,
+    gpu: &mut Gpu,
+) -> String {
+    let mut notes = Vec::new();
+    if let Err(c) = hipfire_arch_qwen35::free_qwen35_bundle(bundle, gpu) {
+        notes.push(c);
+    }
+    if let Some(vw) = vision_weights {
+        vw.free_gpu(gpu);
+    }
+    if notes.is_empty() {
+        err
+    } else {
+        format!("{err}; cleanup also failed: {}", notes.join("; "))
+    }
+}
+
+/// CASK / plain eviction setup. Only hard-error stage in finish_qwen35_load
+/// before the bundle is published into LoadedModel.
+fn build_qwen35_eviction(
+    config: &hipfire_arch_qwen35::qwen35::Qwen35Config,
+    physical_cap: usize,
+    ctx: &mut LoadCtx,
+) -> Result<Option<Eviction>, String> {
+    use hipfire_arch_qwen35::qwen35::LayerType;
+    let Some(ref sidecar_path) = ctx.cask.sidecar else {
+        return Ok(None);
+    };
+    let centers = TriAttnCenters::load(Path::new(sidecar_path)).map_err(|e| {
+        use std::io::ErrorKind;
+        let p = Path::new(sidecar_path);
+        let why = match e.kind() {
+            ErrorKind::NotFound if p.symlink_metadata().is_ok() => {
+                format!("dangling symlink (target absent): {sidecar_path}")
+            }
+            ErrorKind::NotFound => format!("file not found: {sidecar_path}"),
+            ErrorKind::InvalidData => format!("bad format ({e}): {sidecar_path}"),
+            ErrorKind::UnexpectedEof => format!("truncated/corrupt sidecar: {sidecar_path}"),
+            _ => format!("read error ({e}): {sidecar_path}"),
+        };
+        format!(
+            "cask sidecar load failed — {why} (regen: hipfire sidecar-gen, or HIPFIRE_CASK_OFF=1)"
+        )
+    })?;
+    let fa_layer_ids: Vec<usize> = config
+        .layer_types
+        .iter()
+        .enumerate()
+        .filter_map(|(i, t)| {
+            if *t == LayerType::FullAttention {
+                Some(i)
+            } else {
+                None
+            }
+        })
+        .collect();
+    if fa_layer_ids.is_empty() {
+        eprintln!("  cask_sidecar set but model has no FullAttention layers — ignoring");
+        return Ok(None);
+    }
+    let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
+    let base = EvictionCtx::new(
+        ctx.gpu,
+        &centers,
+        fa_layer_ids,
+        ctx.cask.budget,
+        ctx.cask.beta,
+        config.n_heads,
+        config.n_kv_heads,
+        config.head_dim,
+        n_rot,
+        config.rope_theta,
+        physical_cap,
+    )
+    .map_err(|e| format!("build EvictionCtx: {e}"))?;
+    if ctx.cask.cask_m_folding {
+        eprintln!(
+            "  eviction: CASK α={:.2} m={} budget={} β={} physical_cap={}",
+            ctx.cask.core_frac, ctx.cask.fold_m, ctx.cask.budget, ctx.cask.beta, physical_cap
+        );
+        Ok(Some(Eviction::Cask(CaskCtx::new(
+            base,
+            ctx.cask.core_frac,
+            ctx.cask.fold_m,
+        ))))
+    } else {
+        eprintln!(
+            "  eviction: TriAttention (plain drop) budget={} β={} physical_cap={}",
+            ctx.cask.budget, ctx.cask.beta, physical_cap
+        );
+        Ok(Some(Eviction::Plain(base)))
+    }
+}
+
 /// Build a `LoadedModel` from a carrier `Bundle`, shared fields, and
 /// eviction/DFlash state. This is the common body for qwen35 dispatch
 /// where eviction and DFlash need per-arch type info.
+///
+/// Hard errors before publish free the bundle and any preloaded VL weights.
 fn finish_qwen35_load(
     bundle: Qwen35Bundle,
     tokenizer: hipfire_runtime::tokenizer::Tokenizer,
@@ -641,139 +741,95 @@ fn finish_qwen35_load(
     vision_config: Option<qwen35_vl::VisionConfig>,
     vision_weights: Option<qwen35_vl::VisionWeights>,
 ) -> Result<LoadedModel, String> {
-    use hipfire_arch_qwen35::qwen35::LayerType;
-    // Extract references for eviction/DFlash setup (borrow, don't move)
+    // ── Eviction (only hard-error stage before publish) ────────────
+    // Built before long-lived borrows so rollback can move `bundle`.
+    let eviction = match build_qwen35_eviction(&bundle.config, physical_cap, ctx) {
+        Ok(e) => e,
+        Err(e) => {
+            return Err(rollback_unfinished_qwen35(
+                e,
+                bundle,
+                vision_weights,
+                ctx.gpu,
+            ));
+        }
+    };
+
+    // Extract references for DFlash/spec setup (borrow, don't move)
     let config = &bundle.config;
     let dn_state = &bundle.dn_state;
-    // ── Eviction ───────────────────────────────────────────────────
-    let eviction = if let Some(ref sidecar_path) = ctx.cask.sidecar {
-        let centers = TriAttnCenters::load(Path::new(sidecar_path)).map_err(|e| {
-            use std::io::ErrorKind;
-            let p = Path::new(sidecar_path);
-            let why = match e.kind() {
-                ErrorKind::NotFound if p.symlink_metadata().is_ok() =>
-                    format!("dangling symlink (target absent): {sidecar_path}"),
-                ErrorKind::NotFound => format!("file not found: {sidecar_path}"),
-                ErrorKind::InvalidData => format!("bad format ({e}): {sidecar_path}"),
-                ErrorKind::UnexpectedEof => format!("truncated/corrupt sidecar: {sidecar_path}"),
-                _ => format!("read error ({e}): {sidecar_path}"),
-            };
-            format!("cask sidecar load failed — {why} (regen: hipfire sidecar-gen, or HIPFIRE_CASK_OFF=1)")
-        })?;
-        let fa_layer_ids: Vec<usize> = config
-            .layer_types
-            .iter()
-            .enumerate()
-            .filter_map(|(i, t)| {
-                if *t == LayerType::FullAttention {
-                    Some(i)
-                } else {
-                    None
-                }
-            })
-            .collect();
-        if fa_layer_ids.is_empty() {
-            eprintln!("  cask_sidecar set but model has no FullAttention layers — ignoring");
-            None
-        } else {
-            let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
-            let base = EvictionCtx::new(
-                ctx.gpu,
-                &centers,
-                fa_layer_ids,
-                ctx.cask.budget,
-                ctx.cask.beta,
-                config.n_heads,
-                config.n_kv_heads,
-                config.head_dim,
-                n_rot,
-                config.rope_theta,
-                physical_cap,
-            )
-            .map_err(|e| format!("build EvictionCtx: {e}"))?;
-            if ctx.cask.cask_m_folding {
-                eprintln!(
-                    "  eviction: CASK α={:.2} m={} budget={} β={} physical_cap={}",
-                    ctx.cask.core_frac,
-                    ctx.cask.fold_m,
-                    ctx.cask.budget,
-                    ctx.cask.beta,
-                    physical_cap
-                );
-                Some(Eviction::Cask(CaskCtx::new(
-                    base,
-                    ctx.cask.core_frac,
-                    ctx.cask.fold_m,
-                )))
-            } else {
-                eprintln!(
-                    "  eviction: TriAttention (plain drop) budget={} β={} physical_cap={}",
-                    ctx.cask.budget, ctx.cask.beta, physical_cap
-                );
-                Some(Eviction::Plain(base))
-            }
-        }
-    } else {
-        None
-    };
+
+    // Adaptive KV cannot combine with generic (DSpark/DFlash/n-gram/bundled-MTP
+    // build_speculator) drafters. Suppress before any GPU drafter alloc; native
+    // qwen35_mtp_head load below is intentionally left alone.
+    let adaptive_blocks_generic_spec = bundle.kv_adaptive.is_some();
+    if adaptive_blocks_generic_spec {
+        eprintln!(
+            "  kv_adaptive engaged — suppressing generic speculator path (DSpark/DFlash/n-gram/bundled MTP-spec)"
+        );
+    }
 
     // ── DSpark sidecar (wins over DFlash/MTP/n-gram) ───────────────
     // The drafter is a dense-qwen3 body (llama crate); it drives the qwen35
     // ModelSlot target via the SpecTarget DSpark capture hooks. Discovered as
     // `<stem>-dspark.<ext>` next to the trunk, independent of ctx.draft_path.
-    let dspark_speculator: Option<Box<dyn hipfire_runtime::spec::Speculator>> = if ctx.spec.dspark
-        != Some(false)
-    {
-        let base = std::path::Path::new(ctx.path);
-        let sidecar_path = match (base.parent(), base.file_stem(), base.extension()) {
-            (Some(parent), Some(stem), Some(ext)) => Some(parent.join(format!(
-                "{}-dspark.{}",
-                stem.to_string_lossy(),
-                ext.to_string_lossy()
-            ))),
-            _ => None,
-        };
-        match sidecar_path.filter(|p| p.exists()) {
-            Some(p) => {
-                eprintln!("  qwen35: opening DSpark sidecar HFQ {p:?}");
-                match hipfire_runtime::hfq::HfqFile::open(&p) {
-                    Ok(mut sidecar) => {
-                        sidecar.drop_mmap();
-                        match hipfire_arch_llama::dspark_body::load_qwen3_dspark(&sidecar, ctx.gpu) {
-                            Ok(Some((dspark_weights, assets))) => {
-                                let block = dspark_weights.cfg.block_size;
-                                // Reduced-vocab drafters (ORNITH) ship a compressed
-                                // lm_head; run_heads reads vocab from lm_head.shape[0].
-                                let vocab = if dspark_weights.cfg.draft_vocab_size > 0 {
-                                    dspark_weights.cfg.draft_vocab_size
-                                } else {
-                                    assets.config.vocab_size
-                                };
-                                let stage_norm = assets.weights.output_norm.shallow_clone();
-                                // upload_raw sets dtype=Raw; the data is F16.
-                                let mut lm_head = assets.weights.output.buf.shallow_clone();
-                                lm_head.dtype = rdna_compute::DType::F16;
-                                lm_head.shape = vec![vocab];
-                                let conf_threshold =
-                                    hipfire_config::developer_var("HIPFIRE_QWEN35_DSPARK_CONF_THRESHOLD")
-                                        .ok()
-                                        .and_then(|s| s.parse().ok())
-                                        .or(ctx.spec.dspark_conf_threshold)
-                                        .unwrap_or(0.1f32);
-                                eprintln!(
+    let dspark_speculator: Option<Box<dyn hipfire_runtime::spec::Speculator>> =
+        if adaptive_blocks_generic_spec {
+            None
+        } else if ctx.spec.dspark != Some(false) {
+            let base = std::path::Path::new(ctx.path);
+            let sidecar_path = match (base.parent(), base.file_stem(), base.extension()) {
+                (Some(parent), Some(stem), Some(ext)) => Some(parent.join(format!(
+                    "{}-dspark.{}",
+                    stem.to_string_lossy(),
+                    ext.to_string_lossy()
+                ))),
+                _ => None,
+            };
+            match sidecar_path.filter(|p| p.exists()) {
+                Some(p) => {
+                    eprintln!("  qwen35: opening DSpark sidecar HFQ {p:?}");
+                    match hipfire_runtime::hfq::HfqFile::open(&p) {
+                        Ok(mut sidecar) => {
+                            sidecar.drop_mmap();
+                            match hipfire_arch_llama::dspark_body::load_qwen3_dspark(
+                                &sidecar, ctx.gpu,
+                            ) {
+                                Ok(Some((dspark_weights, assets))) => {
+                                    let block = dspark_weights.cfg.block_size;
+                                    // Reduced-vocab drafters (ORNITH) ship a compressed
+                                    // lm_head; run_heads reads vocab from lm_head.shape[0].
+                                    let vocab = if dspark_weights.cfg.draft_vocab_size > 0 {
+                                        dspark_weights.cfg.draft_vocab_size
+                                    } else {
+                                        assets.config.vocab_size
+                                    };
+                                    let stage_norm = assets.weights.output_norm.shallow_clone();
+                                    // upload_raw sets dtype=Raw; the data is F16.
+                                    let mut lm_head = assets.weights.output.buf.shallow_clone();
+                                    lm_head.dtype = rdna_compute::DType::F16;
+                                    lm_head.shape = vec![vocab];
+                                    let conf_threshold = hipfire_config::developer_var(
+                                        "HIPFIRE_QWEN35_DSPARK_CONF_THRESHOLD",
+                                    )
+                                    .ok()
+                                    .and_then(|s| s.parse().ok())
+                                    .or(ctx.spec.dspark_conf_threshold)
+                                    .unwrap_or(0.1f32);
+                                    eprintln!(
                                     "  qwen35 DSpark enabled (block={}, target_layers={:?}, draft_vocab={}, conf={:.2})",
                                     block,
                                     dspark_weights.cfg.target_layer_ids,
                                     vocab,
                                     conf_threshold
                                 );
-                                match hipfire_arch_llama::dspark_body::build_qwen3_dspark_body(
-                                    assets,
-                                    &dspark_weights.cfg,
-                                    ctx.gpu,
-                                ) {
-                                    Ok(body) => {
-                                        Some(hipfire_runtime::dspark_core::build_dspark_speculator(
+                                    match hipfire_arch_llama::dspark_body::build_qwen3_dspark_body(
+                                        assets,
+                                        &dspark_weights.cfg,
+                                        ctx.gpu,
+                                    ) {
+                                        Ok(body) => {
+                                            Some(hipfire_runtime::dspark_core::build_dspark_speculator(
                                             body,
                                             dspark_weights,
                                             stage_norm,
@@ -783,37 +839,39 @@ fn finish_qwen35_load(
                                             conf_threshold,
                                             true, // sampled verify (temp>0) supported
                                         ))
-                                    }
-                                    Err(e) => {
-                                        eprintln!("  qwen35: DSpark body build failed: {e} — AR/other");
-                                        None
+                                        }
+                                        Err(e) => {
+                                            eprintln!(
+                                            "  qwen35: DSpark body build failed: {e} — AR/other"
+                                        );
+                                            None
+                                        }
                                     }
                                 }
-                            }
-                            Ok(None) => {
-                                eprintln!("  qwen35: DSpark sidecar {p:?} has no dspark_* metadata — skipping");
-                                None
-                            }
-                            Err(e) => {
-                                eprintln!("  qwen35: WARNING DSpark sidecar load failed: {e}");
-                                None
+                                Ok(None) => {
+                                    eprintln!("  qwen35: DSpark sidecar {p:?} has no dspark_* metadata — skipping");
+                                    None
+                                }
+                                Err(e) => {
+                                    eprintln!("  qwen35: WARNING DSpark sidecar load failed: {e}");
+                                    None
+                                }
                             }
                         }
-                    }
-                    Err(e) => {
-                        eprintln!("  qwen35: WARNING cannot open DSpark sidecar {p:?}: {e}");
-                        None
+                        Err(e) => {
+                            eprintln!("  qwen35: WARNING cannot open DSpark sidecar {p:?}: {e}");
+                            None
+                        }
                     }
                 }
+                None => None,
             }
-            None => None,
-        }
-    } else {
-        None
-    };
+        } else {
+            None
+        };
 
     // ── DFlash (skipped when a DSpark sidecar won) ─────────────────
-    let dflash = if dspark_speculator.is_some() {
+    let dflash = if adaptive_blocks_generic_spec || dspark_speculator.is_some() {
         None
     } else if let Some(dp) = ctx.draft_path {
         match hipfire_arch_qwen35::dflash_spec::load_dflash_state(
@@ -849,11 +907,15 @@ fn finish_qwen35_load(
     // MTP head KV is not FlashCASK-compacted), and arch is qwen35 (5/6). Gated
     // here — not in build_speculator — because this is the only site with a
     // `&mut Gpu` to free on decline, and the head allocates GPU buffers.
-    let mtp = if dflash.is_none()
+    let mtp = if !adaptive_blocks_generic_spec
+        && dflash.is_none()
         && dspark_speculator.is_none()
         && eviction.is_none()
         && matches!(arch_id, 5 | 6)
-        && hipfire_config::developer_var("HIPFIRE_QWEN35_MTP").ok().as_deref() == Some("1")
+        && hipfire_config::developer_var("HIPFIRE_QWEN35_MTP")
+            .ok()
+            .as_deref()
+            == Some("1")
         && ctx.path.ends_with(".mq4-mtp")
     {
         match hipfire_arch_qwen35::mtp_head::load_mtp_head_bundled(
@@ -895,16 +957,21 @@ fn finish_qwen35_load(
     // borrowed only for the n-gram arm's scratch construction (snapshot copied to
     // GPU), released before `bundle` moves into `state`. `None` ⇒ AR-only model.
     // DSpark wins over DFlash/MTP/n-gram when its sidecar loaded.
-    let speculator = dspark_speculator.or_else(|| {
-        crate::spec_build::build_speculator(
-            arch_id,
-            dflash,
-            mtp,
-            eviction.is_none(),
-            physical_cap,
-            ctx.spec,
-        )
-    });
+    // When adaptive, upstream gates left dspark/dflash/mtp as None — no free needed.
+    let speculator = if adaptive_blocks_generic_spec {
+        None
+    } else {
+        dspark_speculator.or_else(|| {
+            crate::spec_build::build_speculator(
+                arch_id,
+                dflash,
+                mtp,
+                eviction.is_none(),
+                physical_cap,
+                ctx.spec,
+            )
+        })
+    };
 
     // ── Qwen3.5/3.6 native MTP (NextN) head ────────────────────────
     //
@@ -965,6 +1032,10 @@ fn finish_qwen35_load(
         }
     };
 
+    // Move adaptive controller out of the bundle before parking the rest in
+    // ModelState. LoadedModel.kv_adaptive is the runtime home for downshift hooks.
+    let mut bundle = bundle;
+    let kv_adaptive = bundle.kv_adaptive.take();
     let state = Some(ModelState::Qwen35(bundle));
     let mut model = LoadedModel {
         state,
@@ -973,6 +1044,7 @@ fn finish_qwen35_load(
         vision_config,
         vision_weights,
         max_seq: ctx.max_seq,
+        kv_adaptive,
         ..LoadedModel::skeleton(
             arch_id,
             tokenizer,
@@ -983,7 +1055,7 @@ fn finish_qwen35_load(
         )
     };
     // `mtp_weights_present` drives the mtp_mode=auto serve decision (mirrors the
-    // ds4 probe set in the daemon's load handler). For qwen35 the presence of a
+    // dspark probe set in the daemon's load handler). For qwen35 the presence of a
     // loaded MTP head IS the signal.
     model.mtp_weights_present = qwen35_mtp_head.is_some();
     model.qwen35_mtp_head = qwen35_mtp_head;
@@ -1037,6 +1109,9 @@ pub fn load_model_with_kv_backend(
     spec: SpecLoadCfg,
     gpu: &mut rdna_compute::Gpu,
 ) -> Result<LoadedModel, String> {
+    // Retry any arenas left by a prior failed teardown; refuse the load if
+    // ownership is still live so a new model cannot stack on pending VMM state.
+    ensure_vmm_ready_for_load(gpu)?;
     let src = ModelSource::from_path(path)?;
     let kv_backend_raw = kv_backend_override.unwrap_or("contiguous");
     let kv_backend: KvBackend = kv_backend_raw.parse().map_err(|err| format!("{err}"))?;
@@ -1662,9 +1737,18 @@ fn load_model_ep_minimax(path: &str, max_seq: usize, tp: usize) -> Result<Loaded
     })
 }
 
+/// Retry pending VMM arenas and refuse progress while any remain registered.
+pub fn ensure_vmm_ready_for_load(gpu: &mut rdna_compute::Gpu) -> Result<(), String> {
+    gpu.ensure_vmm_cleaned().map_err(|err| {
+        format!(
+            "refusing load: prior VMM teardown still pending ({err}); retry unload or restart the process"
+        )
+    })
+}
+
 // ─── Unload ───────────────────────────────────────────────────────────
 
-pub fn unload_model(mut m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
+pub fn unload_model(mut m: LoadedModel, gpu: &mut rdna_compute::Gpu) -> Result<(), String> {
     // EP unload-free. An EP model owns its own `Gpus` (the daemon's single `gpu`
     // is unused for tp>1). Without this branch a SUCCESSFUL EP unload leaked every
     // per-rank weight / state / partial. Free per-rank weights → state → partials
@@ -1733,7 +1817,7 @@ pub fn unload_model(mut m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
             dev.drain_pool();
         }
         let _ = gpu;
-        return;
+        return Ok(());
         // `gpus` drops here, tearing down comms + devices.
     }
     if m.pp > 1 {
@@ -1767,7 +1851,7 @@ pub fn unload_model(mut m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
             g.drain_pool();
         }
         let _ = gpu;
-        return;
+        return Ok(());
     }
     if let Some(spec) = m.speculator {
         // Frees the drafter's GPU buffers (draft weights + scratch) AND its
@@ -1782,8 +1866,16 @@ pub fn unload_model(mut m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
     if let Some(ev) = m.eviction {
         ev.free_gpu(gpu);
     }
+    let mut first_err: Option<String> = None;
+    let mut note = |r: Result<(), String>| {
+        if let Err(err) = r {
+            if first_err.is_none() {
+                first_err = Some(err);
+            }
+        }
+    };
     if let Some(kv) = m.kv_cache {
-        kv.free_gpu(gpu);
+        note(kv.free_gpu(gpu).map_err(|e| e.to_string()));
     }
     if let Some(dn) = m.dn_state {
         dn.free_gpu(gpu);
@@ -1802,7 +1894,7 @@ pub fn unload_model(mut m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
                 b.weights.free_gpu(gpu);
             }
             ModelState::Qwen35(b) => {
-                b.kv_cache.free_gpu(gpu);
+                note(b.kv_cache.free_gpu(gpu).map_err(|e| e.to_string()));
                 b.scratch.free_gpu(gpu);
                 b.weights.free_gpu(gpu);
                 b.dn_state.free_gpu(gpu);
@@ -1810,7 +1902,7 @@ pub fn unload_model(mut m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
             ModelState::Llama(b) => {
                 b.scratch.free_gpu(gpu);
                 b.weights.free_gpu(gpu);
-                b.kv.free_gpu(gpu);
+                note(b.kv.free_gpu(gpu).map_err(|e| e.to_string()));
             }
             ModelState::Lfm2Moe(b) => {
                 b.state.free_gpu(gpu);
@@ -1851,6 +1943,13 @@ pub fn unload_model(mut m: LoadedModel, gpu: &mut rdna_compute::Gpu) {
     gpu.invalidate_weight_caches();
     gpu.invalidate_graph_state();
     gpu.drain_pool();
+    // After ordinary frees/pool drain, retry any VMM arenas retained by a
+    // failed free_tensor. Success is reported only when none remain.
+    note(gpu.ensure_vmm_cleaned().map_err(|e| e.to_string()));
+    match first_err {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
 }
 
 #[cfg(test)]

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -716,6 +716,17 @@ fn render_tail_opens_think(rendered: &str) -> bool {
     rendered.trim_end().ends_with("<think>")
 }
 
+/// Reduce the authoritative rendered-prompt state to the signal consumed by
+/// speculative emitters. Jinja owns the generation suffix, so the request's
+/// `assistant_prefix` is not authoritative once rendering succeeds.
+fn spec_assistant_prefix(started_in_think: bool) -> hipfire_runtime::prompt_frame::AssistantPrefix {
+    if started_in_think {
+        hipfire_runtime::prompt_frame::AssistantPrefix::OpenThink
+    } else {
+        hipfire_runtime::prompt_frame::AssistantPrefix::Plain
+    }
+}
+
 fn emit_gen_start(stdout: &mut std::io::Stdout, id: &str, started_in_think: bool) {
     let envelope = serde_json::json!({
         "type": "gen_start",
@@ -912,6 +923,256 @@ fn write_error(stdout: &mut std::io::Stdout, id: &str, message: &str) {
     });
     let _ = writeln!(stdout, "{line}");
     let _ = stdout.flush();
+}
+
+/// Fail-closed policy for ordinary single-GPU Qwen35 AR when
+/// `forward_prefill_batch` / `forward_scratch` returns `Err` (VMM map/growth,
+/// allocation, or other HipResult failure). Injected map failure must never
+/// panic the daemon or emit a token whose trunk KV write did not commit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct QwenArForwardFailAction {
+    /// Emit one request-scoped `{"type":"error",...}` and stop the request.
+    emit_request_error: bool,
+    /// Cold-reset uncommitted DN/KV/seq so unload + retry stay safe.
+    reset_uncommitted_state: bool,
+    /// Must stay false: never emit/commit the token whose KV write failed.
+    emit_failed_token: bool,
+    /// Adaptive poison is sticky across request failures.
+    clear_adaptive_poison: bool,
+}
+
+fn qwen_ar_forward_fail_action() -> QwenArForwardFailAction {
+    QwenArForwardFailAction {
+        emit_request_error: true,
+        reset_uncommitted_state: true,
+        emit_failed_token: false,
+        clear_adaptive_poison: false,
+    }
+}
+
+fn qwen_ar_forward_fail_message(phase: &str, err: impl std::fmt::Display) -> String {
+    format!("{phase}: {err}")
+}
+
+/// VL no-eviction KV admission cap.
+///
+/// Adaptive floor-reserved caches guarantee `max_seq` at the floor tier; the
+/// start tier (FWHT4/Q8) has a smaller `current_cap`, so long multi-chunk VL
+/// must be admitted against the floor window (`max_seq`) while
+/// `maybe_downshift` keeps each committed write inside the live stride.
+/// Non-adaptive paths keep the historical `physical_cap` contract.
+fn vl_no_eviction_kv_cap(physical_cap: usize, max_seq: usize, adaptive_engaged: bool) -> usize {
+    if adaptive_engaged {
+        max_seq
+    } else {
+        physical_cap
+    }
+}
+
+/// Cold-reset VL trunk after a GPU/VMM/adaptive failure so the next request
+/// cannot inherit partial DN/KV/seq or mismatched conversation history.
+///
+/// Takes disjoint fields (`dn`/`kv` from `m.state`, controller + host counters
+/// on `LoadedModel`) so callers holding `kv`/`dn` do not need `&mut LoadedModel`.
+/// Adaptive poison stays sticky: only non-poisoned controllers are
+/// `reset_with_cache`'d back to FWHT4/Q8.
+fn vl_cold_reset_uncommitted(
+    gpu: &mut rdna_compute::Gpu,
+    dn: &qwen35::DeltaNetState,
+    kv: &mut hipfire_runtime::llama::KvCache,
+    kv_adaptive: &mut Option<hipfire_runtime::kv_adaptive::KvAdaptive>,
+    seq_pos: &mut usize,
+    conversation_tokens: &mut Vec<u32>,
+    prefill_checkpoints: &mut Vec<(usize, speculative::DeltaNetSnapshot)>,
+) {
+    for s in &dn.s_matrices {
+        let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+    }
+    for s in &dn.s_scales {
+        let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+    }
+    for s in &dn.conv_states {
+        let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+    }
+    kv.compact_offset = 0;
+    if let Some(ad) = kv_adaptive.as_mut() {
+        if !ad.is_poisoned() {
+            ad.reset_with_cache(gpu, kv);
+        }
+    }
+    *seq_pos = 0;
+    conversation_tokens.clear();
+    free_checkpoints(prefill_checkpoints, gpu);
+}
+
+/// Fail-closed adaptive downshift after a committed VL KV write.
+/// Returns `true` when the request must stop (controller already poisoned).
+/// On Err: cold-reset trunk (poison sticky) + request error, no further tokens.
+fn vl_adaptive_downshift_fail_closed(
+    kv_adaptive: &mut Option<hipfire_runtime::kv_adaptive::KvAdaptive>,
+    seq_pos: &mut usize,
+    gpu: &mut rdna_compute::Gpu,
+    kv: &mut hipfire_runtime::llama::KvCache,
+    dn: &qwen35::DeltaNetState,
+    conversation_tokens: &mut Vec<u32>,
+    prefill_checkpoints: &mut Vec<(usize, speculative::DeltaNetSnapshot)>,
+    stdout: &mut std::io::Stdout,
+    id: &str,
+    phase: &str,
+) -> bool {
+    let Some(ad) = kv_adaptive.as_mut() else {
+        return false;
+    };
+    let committed = *seq_pos;
+    match ad.maybe_downshift(gpu, kv, committed) {
+        Ok(applied) => {
+            for step in &applied {
+                eprintln!(
+                    "[adaptive-kv] downshift @ pos {} ({}): {:?} (K={:?} V={:?})",
+                    committed, phase, step, ad.cur_k, ad.cur_v
+                );
+            }
+            false
+        }
+        Err(e) => {
+            eprintln!(
+                "[adaptive-kv] maybe_downshift error @ pos {} ({}): {:?} — poisoning model",
+                committed, phase, e
+            );
+            // maybe_downshift already poisons on partial failure; cold-reset
+            // leaves poison sticky (reset_with_cache skipped when poisoned).
+            vl_cold_reset_uncommitted(
+                gpu,
+                dn,
+                kv,
+                kv_adaptive,
+                seq_pos,
+                conversation_tokens,
+                prefill_checkpoints,
+            );
+            write_error(
+                stdout,
+                id,
+                &format!("adaptive KV transition failed during {phase}: {e}"),
+            );
+            true
+        }
+    }
+}
+
+/// Request-scoped VL GPU/VMM failure: cold-reset uncommitted trunk state, then
+/// emit error. Never panics; never streams a token for the failed write.
+fn vl_forward_fail(
+    stdout: &mut std::io::Stdout,
+    id: &str,
+    phase: &str,
+    err: impl std::fmt::Display,
+    gpu: &mut rdna_compute::Gpu,
+    dn: &qwen35::DeltaNetState,
+    kv: &mut hipfire_runtime::llama::KvCache,
+    kv_adaptive: &mut Option<hipfire_runtime::kv_adaptive::KvAdaptive>,
+    seq_pos: &mut usize,
+    conversation_tokens: &mut Vec<u32>,
+    prefill_checkpoints: &mut Vec<(usize, speculative::DeltaNetSnapshot)>,
+) {
+    vl_cold_reset_uncommitted(
+        gpu,
+        dn,
+        kv,
+        kv_adaptive,
+        seq_pos,
+        conversation_tokens,
+        prefill_checkpoints,
+    );
+    write_error(stdout, id, &format!("VL {phase}: {err}"));
+}
+
+/// Contract: MTP adaptive downshift sites must see the same exclusive committed
+/// positions the chunked prefill helper writes. Pure schedule — no GPU.
+#[cfg(test)]
+mod mtp_adaptive_route_contract {
+    /// Exact adaptive×MTP prefill invariant:
+    /// external chunk size ≤ PREFILL_MAX_BATCH (= adaptive margin), and
+    /// maybe_downshift runs at each exclusive committed boundary so a long
+    /// prompt cannot hit the start-tier side_cap before return. A single
+    /// whole-prompt prefill + post-only downshift is insufficient.
+    #[test]
+    fn mtp_adaptive_prefill_boundaries_match_chunk_schedule() {
+        use hipfire_arch_qwen35::mtp_spec::mtp_prefill_committed_boundaries;
+        use hipfire_arch_qwen35::qwen35::PREFILL_MAX_BATCH;
+        assert_eq!(
+            mtp_prefill_committed_boundaries(600, 0, PREFILL_MAX_BATCH),
+            vec![256, 512, 600]
+        );
+        assert!(mtp_prefill_committed_boundaries(0, 0, PREFILL_MAX_BATCH).is_empty());
+        // Gaps never exceed one prefill chunk (margin safety).
+        let b = mtp_prefill_committed_boundaries(10_000, 0, PREFILL_MAX_BATCH);
+        let mut prev = 0usize;
+        for &pos in &b {
+            assert!(pos - prev <= PREFILL_MAX_BATCH);
+            prev = pos;
+        }
+    }
+
+    #[test]
+    fn mtp_forward_fail_is_request_error_not_token() {
+        // Mirror AR policy for MTP prefill/spec HipResult (VMM growth, etc.):
+        // emit request error, never the failed token; poison stays sticky.
+        let action = super::qwen_ar_forward_fail_action();
+        assert!(action.emit_request_error);
+        assert!(!action.emit_failed_token);
+        assert!(!action.clear_adaptive_poison);
+    }
+
+    /// Decode-cycle invariant: downshift seq_pos is the live committed prefix
+    /// only. Rejected verify length is (n_verify - advance) and lives strictly
+    /// past that prefix — never included in maybe_downshift's seq_pos.
+    #[test]
+    fn mtp_decode_downshift_uses_committed_prefix_only() {
+        let cur_pos = 1000usize;
+        let max_n = 3usize;
+        let n_verify = max_n + 1; // last_committed + candidates
+        let advance = 2usize; // e.g. accept 1 + bonus
+        let committed_end = cur_pos + advance;
+        let reject_suffix_end = cur_pos + n_verify;
+        assert!(committed_end < reject_suffix_end);
+        // maybe_downshift(committed_end) covers [0, committed_end); rejected
+        // [committed_end, reject_suffix_end) must not be required at new tier.
+        assert_eq!(reject_suffix_end - committed_end, n_verify - advance);
+    }
+}
+
+/// Pure gate for the deferred EP (tp>1) load handoff.
+///
+/// After a new EP model is constructed, the prior model is unloaded. The new
+/// model may be published only when that prior unload succeeds (or there was
+/// no prior model — caller passes `Ok(())` in that case). A failed prior
+/// unload must never install/emit `loaded` for the new model.
+fn ep_deferred_may_publish(prior_unload: &Result<(), String>) -> bool {
+    prior_unload.is_ok()
+}
+
+/// Hard-error text when deferred prior unload fails (and optional new-model
+/// rollback also fails). Always names the prior failure; appends rollback
+/// failure when present so neither is log-and-ignored.
+fn ep_deferred_handoff_error_message(prior_err: &str, rollback_err: Option<&str>) -> String {
+    match rollback_err {
+        None => format!("prior unload failed: {prior_err}"),
+        Some(rb) => {
+            format!("prior unload failed: {prior_err}; new-model rollback also failed: {rb}")
+        }
+    }
+}
+
+/// Whether the deferred-EP load path must run `ensure_vmm_ready_for_load`
+/// before constructing a new EP model.
+///
+/// Only when there is no live prior model (`model_present == false`): a
+/// failed deferred prior unload leaves `model=None` while VMM arenas may
+/// still be pending. Do NOT preflight when a live deferred prior still
+/// occupies `model` — that path tears down after successful new load.
+fn ep_deferred_needs_vmm_preflight(load_tp: usize, model_present: bool) -> bool {
+    load_tp > 1 && !model_present
 }
 
 enum ImageSource<'a> {
@@ -1371,7 +1632,41 @@ fn main() {
                     }
                     pflash_cfg = None;
                     if let Some(m) = model.take() {
-                        hipfire_loader::unload_model(m, &mut gpu);
+                        if let Err(err) = hipfire_loader::unload_model(m, &mut gpu) {
+                            let _ = writeln!(
+                                stdout,
+                                r#"{{"type":"error","message":{}}}"#,
+                                serde_json::to_string(&format!("prior unload failed: {err}"))
+                                    .unwrap()
+                            );
+                            let _ = stdout.flush();
+                            continue;
+                        }
+                    } else if let Err(err) = hipfire_loader::ensure_vmm_ready_for_load(&mut gpu) {
+                        let _ = writeln!(
+                            stdout,
+                            r#"{{"type":"error","message":{}}}"#,
+                            serde_json::to_string(&err).unwrap()
+                        );
+                        let _ = stdout.flush();
+                        continue;
+                    }
+                }
+                // EP path: when no live prior model remains (fresh daemon, or
+                // after deferred prior unload failed and left model=None with
+                // pending VMM), refuse to construct a new EP model until
+                // orphan teardown clears. Skip when a live deferred prior
+                // still sits in `model` — unload stays deferred until after
+                // successful new-model construction.
+                if ep_deferred_needs_vmm_preflight(load_tp, model.is_some()) {
+                    if let Err(err) = hipfire_loader::ensure_vmm_ready_for_load(&mut gpu) {
+                        let _ = writeln!(
+                            stdout,
+                            r#"{{"type":"error","message":{}}}"#,
+                            serde_json::to_string(&err).unwrap()
+                        );
+                        let _ = stdout.flush();
+                        continue;
                     }
                 }
 
@@ -1806,14 +2101,18 @@ fn main() {
                 match loaded {
                     Ok(mut m) => {
                         // FIX #1 (deferred EP unload): the new EP model loaded
-                        // successfully — NOW it's safe to free the prior model
-                        // (single-GPU/pp models were already unloaded eagerly
-                        // above; this branch only fires for the deferred tp>1
-                        // path). The prior model's PFlash drafter (pflash_state)
-                        // is part of that prior model, so it's torn down here in
-                        // the same drainer-before-unload order used elsewhere:
-                        // unload_drafter queues the drafter tensors into the
-                        // pool, then unload_model drains it.
+                        // successfully — NOW unload the prior model before
+                        // publishing (single-GPU/pp models were already unloaded
+                        // eagerly above; this branch only fires for deferred
+                        // tp>1). Prior PFlash drafter is part of that prior
+                        // model, so tear it down first in the same
+                        // drafter-before-unload order used elsewhere.
+                        //
+                        // Transactional: if prior unload fails, do NOT install
+                        // or emit `loaded` for the new model. Explicitly unload
+                        // the newly built EP model, clear associated fresh
+                        // state, and emit a hard error covering prior failure
+                        // and any rollback failure.
                         if load_tp > 1 {
                             if let Some(mut pf) = pflash_state.take() {
                                 if let Some(mut dg) = pflash_drafter_gpu.take() {
@@ -1825,8 +2124,28 @@ fn main() {
                                 }
                             }
                             pflash_cfg = None;
-                            if let Some(old) = model.take() {
-                                hipfire_loader::unload_model(old, &mut gpu);
+                            let prior_unload = if let Some(old) = model.take() {
+                                hipfire_loader::unload_model(old, &mut gpu)
+                            } else {
+                                Ok(())
+                            };
+                            if !ep_deferred_may_publish(&prior_unload) {
+                                let prior_err = prior_unload
+                                    .err()
+                                    .unwrap_or_else(|| "prior unload failed".to_string());
+                                // Roll back the newly built EP model — GpuTensor
+                                // has no Drop; must free explicitly.
+                                let rollback_err = match hipfire_loader::unload_model(m, &mut gpu) {
+                                    Ok(()) => None,
+                                    Err(e) => Some(e),
+                                };
+                                // model stays None; pflash already cleared above.
+                                let msg = ep_deferred_handoff_error_message(
+                                    &prior_err,
+                                    rollback_err.as_deref(),
+                                );
+                                write_error(&mut stdout, "", &msg);
+                                continue;
                             }
                         }
                         let arch = match m.arch_id {
@@ -2486,8 +2805,12 @@ fn main() {
                         if let Some(b) = m.deepseek4_mut() {
                             b.state.reset();
                         }
-                        if let Some(ref mut ad) = m.kv_adaptive {
-                            ad.reset();
+                        if let Some(ad) = m.kv_adaptive.as_mut() {
+                            if let Some(ModelState::Qwen35(b)) = m.state.as_mut() {
+                                ad.reset_with_cache(&mut gpu, &mut b.kv_cache);
+                            } else {
+                                ad.reset();
+                            }
                         }
                     }
                     if image_base64.is_some() && image.is_some() {
@@ -2758,8 +3081,12 @@ fn main() {
                     // Restore adaptive-KV controller to start tier (q8/fwht4)
                     // so thresholds fire correctly on the fresh conversation
                     // instead of staying pinned at the floor tier.
-                    if let Some(ref mut ad) = m.kv_adaptive {
-                        ad.reset();
+                    if let Some(ad) = m.kv_adaptive.as_mut() {
+                        if let Some(ModelState::Qwen35(b)) = m.state.as_mut() {
+                            ad.reset_with_cache(&mut gpu, &mut b.kv_cache);
+                        } else {
+                            ad.reset();
+                        }
                     }
                     let _ = writeln!(stdout, r#"{{"type":"reset","seq_pos":0}}"#);
                 } else {
@@ -2787,10 +3114,27 @@ fn main() {
                     }
                 }
                 pflash_cfg = None;
-                if let Some(m) = model.take() {
-                    hipfire_loader::unload_model(m, &mut gpu);
+                let unload_result = if let Some(m) = model.take() {
+                    hipfire_loader::unload_model(m, &mut gpu)
+                } else {
+                    // No model: still retry any process-global pending VMM arenas.
+                    hipfire_loader::ensure_vmm_ready_for_load(&mut gpu)
+                };
+                match unload_result {
+                    Ok(()) => {
+                        let _ = writeln!(stdout, r#"{{"type":"unloaded"}}"#);
+                    }
+                    Err(err) => {
+                        let _ = writeln!(
+                            stdout,
+                            r#"{{"type":"error","message":{}}}"#,
+                            serde_json::to_string(&format!(
+                                "unload incomplete: {err}; VMM arenas retained for retry"
+                            ))
+                            .unwrap()
+                        );
+                    }
                 }
-                let _ = writeln!(stdout, r#"{{"type":"unloaded"}}"#);
                 let _ = stdout.flush();
             }
 
@@ -5628,6 +5972,18 @@ fn generate_dflash(
     // field can reach it without re-touching this signature.
     cactus_delta: f32,
 ) {
+    // Adaptive KV has no maybe_downshift on the generic spec path. Fail closed
+    // rather than run DSpark/DFlash/ngram past floor-reserved capacity.
+    if m.kv_adaptive.is_some() {
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"error","id":"{}","message":"kv_adaptive cannot use generic speculative decode (DFlash/DSpark/n-gram); use AR or native MTP"}}"#,
+            id
+        );
+        let _ = stdout.flush();
+        return;
+    }
+
     // The spec-step dispatch, ModelSlot assembly, checkpoint ring, and
     // SpecStats that this function used to drive inline now live behind the
     // arch-generic `Speculator` trait (the loader's `DflashSpeculator`) and the
@@ -5654,6 +6010,10 @@ fn generate_dflash(
     // ChatML/Plain). Falls back to Plain automatically when no template resolves.
     let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
     let try_jinja = jinja_enabled && m.chat_template.is_some();
+    let mut started_in_think = matches!(
+        assistant_prefix,
+        hipfire_runtime::prompt_frame::AssistantPrefix::OpenThink
+    );
     let prompt_tokens: Vec<u32> = if try_jinja {
         let template = m.chat_template.as_ref().unwrap();
         let frame = hipfire_runtime::prompt_frame::JinjaChatFrame {
@@ -5695,7 +6055,10 @@ fn generate_dflash(
             frame.render()
         };
         match render_result {
-            Ok(rendered) => tokenizer.encode(&rendered),
+            Ok(rendered) => {
+                started_in_think = render_tail_opens_think(&rendered);
+                tokenizer.encode(&rendered)
+            }
             Err(e) => {
                 eprintln!(
                     "[daemon] jinja render failed in dflash path ({e}) — falling back to Plain"
@@ -5829,6 +6192,10 @@ fn generate_dflash(
         spec.set_sampling(temp, top_p, top_k, cactus_delta);
     }
     let prefill_tokens_full = prefill_tokens.len();
+    // The Jinja prompt can open `<think>` without emitting that token during
+    // generation. Prime both the client channel router and the speculative
+    // think-budget tracker from the rendered tail, exactly as the AR path does.
+    emit_gen_start(stdout, id, started_in_think);
     let run = match generate_spec(
         m,
         gpu,
@@ -5845,7 +6212,7 @@ fn generate_dflash(
             tools: emit_tools,
             stop: stop.to_vec(),
             max_think: max_think_tokens,
-            assistant_prefix,
+            assistant_prefix: spec_assistant_prefix(started_in_think),
             think_mode: ThinkMode::NonThink,
             decoded_vocab: None,
         },
@@ -6002,6 +6369,18 @@ fn generate_spec(
     // drafters ignore it. The daemon's routing gate enforces that invariant.
     temp: f32,
 ) -> Option<SpecRun> {
+    // Adaptive KV has no maybe_downshift on the generic spec path. Fail closed
+    // rather than run unsupported speculation past floor-reserved capacity.
+    if m.kv_adaptive.is_some() {
+        let _ = writeln!(
+            stdout,
+            r#"{{"type":"error","id":"{}","message":"kv_adaptive cannot use generic speculative decode (DFlash/DSpark/n-gram); use AR or native MTP"}}"#,
+            id
+        );
+        let _ = stdout.flush();
+        return None;
+    }
+
     let tokenizer = m.tokenizer.as_ref().unwrap();
 
     // Acquire the target via the RAII slot guard — it restores the bundle into
@@ -6566,11 +6945,16 @@ fn generate_spec(
 ///
 /// Call sequence (mirrors `mtp_only_demo`):
 ///   1. cold-reset trunk DeltaNet/KV (v1 is single-turn — no LCP cache),
-///   2. `prefill_trunk_and_mtp_cache` (trunk batched prefill + MTP private KV
-///      fill over the prompt positions),
+///   2. `prefill_trunk_and_mtp_cache_with_boundary` (chunked ≤ PREFILL_MAX_BATCH
+///      trunk+MTP fill; adaptive `maybe_downshift` at each committed boundary),
 ///   3. seed token = trunk argmax at the last prefill position,
 ///   4. loop `spec_step_mtp_compressed_serial` (the production path), committing
-///      `result.committed` and advancing `cur_pos += result.advance` each cycle.
+///      `result.committed` and advancing `cur_pos += result.advance` each cycle,
+///      then adaptive downshift at the new committed trunk position.
+///
+/// Fail-closed: prefill/spec HipResult and adaptive transition errors free MTP
+/// state, restore the Qwen35 bundle, emit a request error, and never emit a
+/// token after a failed KV commit. Adaptive poison stays sticky on `m.kv_adaptive`.
 ///
 /// Per-request lifecycle (state-bleed guard, the serve-multiturn class): the
 /// `MtpSpecState` (which owns the trunk DN snapshot + the MTP-private KV cache)
@@ -6620,6 +7004,18 @@ fn generate_qwen35_mtp(
     use hipfire_arch_qwen35::mtp_head::MtpKvMode;
     use hipfire_arch_qwen35::mtp_spec::{self, MtpSpecState};
     use hipfire_arch_qwen35::speculative::{ModelSlot, ModelSlotConfig};
+
+    // Adaptive poison is sticky until unload. Fail at preflight — never
+    // reset_with_cache or clear poison on a poisoned controller.
+    if let Some(ad) = m.kv_adaptive.as_ref() {
+        if ad.is_poisoned() {
+            let reason = ad
+                .poison_reason()
+                .unwrap_or("adaptive KV is poisoned; unload/reload required");
+            emit_error_with_id(stdout, id, reason);
+            return;
+        }
+    }
 
     // ── Resolve the proven-durable MTP config ──────────────────────────
     // K defaults to 3 (max_n); p_min defaults to 0.4. Both env-overridable so
@@ -6744,6 +7140,18 @@ fn generate_qwen35_mtp(
     if let Some(ModelState::Qwen35(b)) = m.state.as_mut() {
         b.kv_cache.compact_offset = 0;
     }
+    // Adaptive start-tier restore for single-turn MTP (no LCP): a prior AR
+    // request may have left the controller at a lower tier / next_step>0.
+    // reset_with_cache restores FWHT4/Q8 + next_step=0 and cache mode flags
+    // together. Poisoned controllers are never reset/cleared here (preflight
+    // already refused the request).
+    if let Some(ad) = m.kv_adaptive.as_mut() {
+        if !ad.is_poisoned() {
+            if let Some(ModelState::Qwen35(b)) = m.state.as_mut() {
+                ad.reset_with_cache(gpu, &mut b.kv_cache);
+            }
+        }
+    }
 
     // ── Take the bundle → build a transient ModelSlot ───────────────────
     // The mtp_spec helpers take `&mut ModelSlot`; the daemon owns the qwen35
@@ -6756,6 +7164,7 @@ fn generate_qwen35_mtp(
         scratch,
         kv_cache,
         dn_state,
+        kv_adaptive: _,
     } = match m.state.take() {
         Some(ModelState::Qwen35(b)) => b,
         _ => {
@@ -6774,6 +7183,7 @@ fn generate_qwen35_mtp(
                 scratch,
                 kv_cache,
                 dn_state,
+                kv_adaptive: None,
             }));
             return;
         }
@@ -6823,6 +7233,7 @@ fn generate_qwen35_mtp(
             scratch: target.scratch,
             kv_cache: target.kv_cache,
             dn_state: target.dn_state,
+            kv_adaptive: None,
         }));
         return;
     }
@@ -6848,6 +7259,7 @@ fn generate_qwen35_mtp(
                     scratch: target.scratch,
                     kv_cache: target.kv_cache,
                     dn_state: target.dn_state,
+                    kv_adaptive: None,
                 }));
                 return;
             }
@@ -6859,10 +7271,28 @@ fn generate_qwen35_mtp(
     if let Some(cvs) = cvs_opt {
         if let Err(e) = state.mtp_scratch.ensure_compressed_logits(gpu, cvs) {
             emit_error_with_id(stdout, id, format!("alloc logits_compressed: {e:?}"));
+            state.free_gpu(gpu);
+            m.state = Some(ModelState::Qwen35(Qwen35Bundle {
+                config: orig_config,
+                weights: target.weights,
+                scratch: target.scratch,
+                kv_cache: target.kv_cache,
+                dn_state: target.dn_state,
+                kv_adaptive: None,
+            }));
             return;
         }
         if let Err(e) = state.ensure_compressed_lm_logits(gpu, cvs) {
             emit_error_with_id(stdout, id, format!("alloc mtp_lm_logits_compressed: {e:?}"));
+            state.free_gpu(gpu);
+            m.state = Some(ModelState::Qwen35(Qwen35Bundle {
+                config: orig_config,
+                weights: target.weights,
+                scratch: target.scratch,
+                kv_cache: target.kv_cache,
+                dn_state: target.dn_state,
+                kv_adaptive: None,
+            }));
             return;
         }
     }
@@ -6894,16 +7324,47 @@ fn generate_qwen35_mtp(
 
     let t0 = Instant::now();
 
-    // ── Prefill: trunk batched + MTP private-KV fill (trunk-spine) ──────
+    // ── Prefill: chunked trunk + MTP private-KV fill (committed boundaries) ─
+    // Adaptive controllers live on `m.kv_adaptive` (not the transient slot).
+    // Boundary hook downshifts at exclusive committed pos before the next chunk
+    // can write past the current-tier capacity. Prefill/spec HipResult failures
+    // (incl. lazy VMM growth) are request errors — never unwrap/panic.
     let head = m.qwen35_mtp_head.as_ref().unwrap();
-    let prefill_res = mtp_spec::prefill_trunk_and_mtp_cache(
-        gpu,
-        &mut target,
-        head,
-        &mut state,
-        &prompt_tokens,
-        0,
-    );
+    let prefill_res = {
+        let adaptive = &mut m.kv_adaptive;
+        mtp_spec::prefill_trunk_and_mtp_cache_with_boundary(
+            gpu,
+            &mut target,
+            head,
+            &mut state,
+            &prompt_tokens,
+            0,
+            |gpu, target, committed_pos| {
+                if let Some(ad) = adaptive.as_mut() {
+                    match ad.maybe_downshift(gpu, &mut target.kv_cache, committed_pos) {
+                        Ok(steps) => {
+                            for step in steps {
+                                eprintln!(
+                                    "[adaptive-kv] downshift @ pos {} (mtp prefill): {:?} (K={:?} V={:?})",
+                                    committed_pos, step, ad.cur_k, ad.cur_v
+                                );
+                            }
+                            Ok(())
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "[adaptive-kv] maybe_downshift error @ pos {} (mtp prefill): {:?} — poisoning model",
+                                committed_pos, e
+                            );
+                            Err(e)
+                        }
+                    }
+                } else {
+                    Ok(())
+                }
+            },
+        )
+    };
     if let Err(e) = prefill_res {
         emit_error_with_id(stdout, id, format!("mtp prefill: {e:?}"));
         state.free_gpu(gpu);
@@ -6913,6 +7374,7 @@ fn generate_qwen35_mtp(
             scratch: target.scratch,
             kv_cache: target.kv_cache,
             dn_state: target.dn_state,
+            kv_adaptive: None,
         }));
         return;
     }
@@ -6932,6 +7394,7 @@ fn generate_qwen35_mtp(
                 scratch: target.scratch,
                 kv_cache: target.kv_cache,
                 dn_state: target.dn_state,
+                kv_adaptive: None,
             }));
             return;
         }
@@ -7092,6 +7555,35 @@ fn generate_qwen35_mtp(
             None => break, // defensive: spec_step always commits ≥ 1
         };
         cur_pos += result.advance;
+        // Adaptive KV: downshift ONLY the committed/live trunk prefix
+        // [0, cur_pos) at the block boundary. Spec verify may have written a
+        // rejected suffix at [cur_pos, cur_pos+(max_n+1-advance)); those slots
+        // stay at the pre-transition tier and are guaranteed overwritten
+        // in-order by the next cycle's verify before any new-tier read treats
+        // them as history (mtp_spec trunk KV rollback is intentionally a no-op).
+        // Fail-closed — do not emit further tokens on transition error.
+        if let Some(ad) = m.kv_adaptive.as_mut() {
+            match ad.maybe_downshift(gpu, &mut target.kv_cache, cur_pos) {
+                Ok(steps) => {
+                    for step in steps {
+                        eprintln!(
+                            "[adaptive-kv] downshift @ pos {} (mtp decode): {:?} (K={:?} V={:?})",
+                            cur_pos, step, ad.cur_k, ad.cur_v
+                        );
+                    }
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[adaptive-kv] maybe_downshift error @ pos {} (mtp decode): {:?} — poisoning model",
+                        cur_pos, e
+                    );
+                    step_error = Some(format!(
+                        "adaptive KV transition failed during mtp decode: {e}"
+                    ));
+                    break;
+                }
+            }
+        }
         if result.hit_eos || hit_eos {
             break;
         }
@@ -7136,14 +7628,43 @@ fn generate_qwen35_mtp(
                 let mut advance_toks = Vec::with_capacity(close_ids.len());
                 advance_toks.push(last_committed);
                 advance_toks.extend_from_slice(&close_ids[..close_ids.len() - 1]);
-                if let Err(e) = mtp_spec::prefill_trunk_and_mtp_cache(
-                    gpu,
-                    &mut target,
-                    head,
-                    &mut state,
-                    &advance_toks,
-                    cur_pos,
-                ) {
+                let think_prefill = {
+                    let adaptive = &mut m.kv_adaptive;
+                    let start = cur_pos;
+                    mtp_spec::prefill_trunk_and_mtp_cache_with_boundary(
+                        gpu,
+                        &mut target,
+                        head,
+                        &mut state,
+                        &advance_toks,
+                        start,
+                        |gpu, target, committed_pos| {
+                            if let Some(ad) = adaptive.as_mut() {
+                                match ad.maybe_downshift(gpu, &mut target.kv_cache, committed_pos) {
+                                    Ok(steps) => {
+                                        for step in steps {
+                                            eprintln!(
+                                                "[adaptive-kv] downshift @ pos {} (mtp think-close): {:?} (K={:?} V={:?})",
+                                                committed_pos, step, ad.cur_k, ad.cur_v
+                                            );
+                                        }
+                                        Ok(())
+                                    }
+                                    Err(e) => {
+                                        eprintln!(
+                                            "[adaptive-kv] maybe_downshift error @ pos {} (mtp think-close): {:?} — poisoning model",
+                                            committed_pos, e
+                                        );
+                                        Err(e)
+                                    }
+                                }
+                            } else {
+                                Ok(())
+                            }
+                        },
+                    )
+                };
+                if let Err(e) = think_prefill {
                     step_error = Some(format!("think force-close: {e:?}"));
                     break;
                 }
@@ -7173,6 +7694,7 @@ fn generate_qwen35_mtp(
         scratch: target.scratch,
         kv_cache: target.kv_cache,
         dn_state: target.dn_state,
+        kv_adaptive: None,
     }));
 
     if let Some(e) = step_error {
@@ -7325,7 +7847,11 @@ fn generate_multi(
             b.kv_cache.compact_offset = 0;
         }
         if let Some(ad) = m.kv_adaptive.as_mut() {
-            ad.reset();
+            if let Some(ModelState::Qwen35(b)) = m.state.as_mut() {
+                ad.reset_with_cache(gpu, &mut b.kv_cache);
+            } else {
+                ad.reset();
+            }
         }
     }
 
@@ -8358,6 +8884,18 @@ fn generate(
     // request and does not carry RNG state across requests. Matches the u32 the
     // GPU sample path uses (0x13579BDF).
     hipfire_runtime::llama::reset_cpu_sampler_rng(0x13579BDF);
+    // Adaptive KV poison is sticky until unload/reload. Refuse generation so a
+    // partial tier transition cannot continue writing into mixed-tier state.
+    if let Some(ad) = m.kv_adaptive.as_ref() {
+        if ad.is_poisoned() {
+            let reason = ad
+                .poison_reason()
+                .unwrap_or("adaptive KV is poisoned; unload/reload required");
+            write_error(stdout, id, reason);
+            return;
+        }
+    }
+
     // Expert-parallel (task #26): route to generate_ep BEFORE any arch
     // short-circuit (generate_qwen2/_deepseek4/...), since EP mode leaves the
     // single-GPU arch fields (q35_*/deepseek4_*) None — the per-arch paths
@@ -8988,7 +9526,13 @@ fn generate(
             "[hipfire] id={id}: temp>0 DFlash spec disabled -> AR ({reason}). Temperature honored; spec speedup off."
         );
     }
-    if m.speculator.is_some() && !force_ar_chat && (qwen_dflash_route || llama_dflash_route) {
+    // Adaptive KV: never enter generate_dflash for qwen (no maybe_downshift on
+    // generic spec). Fall through to AR; llama non-adaptive path unchanged.
+    if m.speculator.is_some()
+        && !force_ar_chat
+        && (qwen_dflash_route || llama_dflash_route)
+        && !(m.kv_adaptive.is_some() && (m.arch_id == 5 || m.arch_id == 6))
+    {
         // One-time visibility: temp + top_p + top_k ARE now honored on the
         // DFlash spec sampled path (identical (top_k,top_p) nucleus truncation on
         // draft + target → lossless == AR-at-(top_k,top_p)). Only min_p remains
@@ -9122,7 +9666,11 @@ fn generate(
             b.kv.compact_offset = 0;
         }
         if let Some(ad) = m.kv_adaptive.as_mut() {
-            ad.reset();
+            if let Some(ModelState::Qwen35(b)) = m.state.as_mut() {
+                ad.reset_with_cache(gpu, &mut b.kv_cache);
+            } else {
+                ad.reset();
+            }
         }
     }
 
@@ -9997,6 +10545,34 @@ fn generate(
         let scratch = &b.scratch;
         let kv = &mut b.kv_cache;
         let dn = &mut b.dn_state;
+        // Cold-reset after uncommitted AR prefill/decode failure. Mirrors
+        // multi-GPU `reset_pp_uncommitted_state!` and the prefill-abort path:
+        // DN is non-reversible, so partial forward must not poison the next
+        // turn. Adaptive poison stays sticky (`clear_adaptive_poison: false`).
+        macro_rules! reset_ar_uncommitted_state {
+            () => {{
+                debug_assert!(qwen_ar_forward_fail_action().reset_uncommitted_state);
+                debug_assert!(!qwen_ar_forward_fail_action().clear_adaptive_poison);
+                for s in &dn.s_matrices {
+                    let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                }
+                for s in &dn.s_scales {
+                    let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                }
+                for s in &dn.conv_states {
+                    let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
+                }
+                kv.compact_offset = 0;
+                if let Some(ad) = m.kv_adaptive.as_mut() {
+                    if !ad.is_poisoned() {
+                        ad.reset_with_cache(gpu, kv);
+                    }
+                }
+                m.seq_pos = 0;
+                m.conversation_tokens.clear();
+                free_checkpoints(&mut m.prefill_checkpoints, gpu);
+            }};
+        }
 
         // Prefill this turn's tokens via the batched prefill entry point.
         // On gfx11+ for MQ4/HFQ4/MQ6/HFQ6 weights this hits the WMMA GEMM
@@ -10044,10 +10620,22 @@ fn generate(
                 let space = window.saturating_sub(m.seq_pos).max(1);
                 let chunk_len = remaining.len().min(space);
                 let (chunk, rest) = remaining.split_at(chunk_len);
-                qwen35::forward_prefill_batch(
+                if let Err(e) = qwen35::forward_prefill_batch(
                     gpu, weights, config, chunk, m.seq_pos, kv, dn, scratch, None, None, None, None,
-                )
-                .unwrap();
+                ) {
+                    let action = qwen_ar_forward_fail_action();
+                    if action.reset_uncommitted_state {
+                        reset_ar_uncommitted_state!();
+                    }
+                    if action.emit_request_error {
+                        write_error(
+                            stdout,
+                            id,
+                            &qwen_ar_forward_fail_message("forward_prefill_batch", e),
+                        );
+                    }
+                    return;
+                }
                 m.seq_pos += chunk_len;
                 if let Some(hipfire_runtime::triattn::EvictionResult {
                     new_physical: new_phys,
@@ -10072,10 +10660,22 @@ fn generate(
                 }
                 let end = (start + chunk_max).min(new_tokens.len());
                 let chunk = &new_tokens[start..end];
-                qwen35::forward_prefill_batch(
+                if let Err(e) = qwen35::forward_prefill_batch(
                     gpu, weights, config, chunk, m.seq_pos, kv, dn, scratch, None, None, None, None,
-                )
-                .unwrap();
+                ) {
+                    let action = qwen_ar_forward_fail_action();
+                    if action.reset_uncommitted_state {
+                        reset_ar_uncommitted_state!();
+                    }
+                    if action.emit_request_error {
+                        write_error(
+                            stdout,
+                            id,
+                            &qwen_ar_forward_fail_message("forward_prefill_batch", e),
+                        );
+                    }
+                    return;
+                }
                 m.seq_pos += chunk.len();
                 // Adaptive KV: downshift BETWEEN prefill chunks the moment the
                 // start-tier (q8/fwht4) buffer fills, so a long prompt can't
@@ -10095,7 +10695,22 @@ fn generate(
                             }
                         }
                         Err(e) => {
-                            eprintln!("[adaptive-kv] maybe_downshift error @ pos {} (prefill): {:?} — skipping", m.seq_pos, e);
+                            eprintln!(
+                                "[adaptive-kv] maybe_downshift error @ pos {} (prefill): {:?} — poisoning model",
+                                m.seq_pos, e
+                            );
+                            // maybe_downshift already poisons on partial failure; surface hard.
+                            let _ = writeln!(
+                                stdout,
+                                r#"{{"type":"error","id":"{}","message":{}}}"#,
+                                id,
+                                serde_json::to_string(&format!(
+                                    "adaptive KV transition failed during prefill: {e}"
+                                ))
+                                .unwrap_or_else(|_| "\"adaptive KV transition failed\"".into())
+                            );
+                            let _ = stdout.flush();
+                            return;
                         }
                     }
                 }
@@ -10128,11 +10743,13 @@ fn generate(
                 let _ = gpu.hip.memset(&s.buf, 0, s.buf.size());
             }
             kv.compact_offset = 0;
-            // Reset Llama KV too (decode-abort path does the same) so a model
-            // carrying both caches can't be left with a stale RoPE phase on the
-            // next cold prefill. No-op when Llama state is absent.
-            if let Some(ModelState::Llama(b)) = m.state.as_mut() {
-                b.kv.compact_offset = 0;
+            // Abort clears the conversation; restore adaptive start tier with the
+            // cache flags so the next request is not stuck at a downshifted floor.
+            // Poison is sticky and is intentionally NOT cleared here.
+            if let Some(ad) = m.kv_adaptive.as_mut() {
+                if !ad.is_poisoned() {
+                    ad.reset_with_cache(gpu, kv);
+                }
             }
             m.seq_pos = 0;
             m.conversation_tokens.clear();
@@ -10165,7 +10782,21 @@ fn generate(
                     }
                 }
                 Err(e) => {
-                    eprintln!("[adaptive-kv] maybe_downshift error @ pos {} (post-prefill): {:?} — skipping", m.seq_pos, e);
+                    eprintln!(
+                        "[adaptive-kv] maybe_downshift error @ pos {} (post-prefill): {:?} — poisoning model",
+                        m.seq_pos, e
+                    );
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"error","id":"{}","message":{}}}"#,
+                        id,
+                        serde_json::to_string(&format!(
+                            "adaptive KV transition failed after prefill: {e}"
+                        ))
+                        .unwrap_or_else(|_| "\"adaptive KV transition failed\"".into())
+                    );
+                    let _ = stdout.flush();
+                    return;
                 }
             }
         }
@@ -10458,6 +11089,33 @@ fn generate(
                 let _ = stdout.flush();
                 return;
             }
+            // Write this token's K/V to the cache BEFORE any client-visible
+            // emit so a VMM map/growth failure cannot stream a token whose
+            // trunk write never committed. Successful path still advances
+            // conversation/stream state and emits with the same semantics as
+            // before (generated++, push, committed, token text).
+            //
+            // Under eviction, m.seq_pos is the *physical* write slot; we
+            // advance and call maybe_evict immediately so the next write
+            // never overruns physical_cap. compact_offset bookkeeping on
+            // the cache itself keeps RoPE phase correct across evictions.
+            if let Err(e) = qwen35::forward_scratch(
+                gpu, weights, config, next_token, m.seq_pos, kv, dn, scratch,
+            ) {
+                let action = qwen_ar_forward_fail_action();
+                debug_assert!(!action.emit_failed_token);
+                if action.reset_uncommitted_state {
+                    reset_ar_uncommitted_state!();
+                }
+                if action.emit_request_error {
+                    write_error(
+                        stdout,
+                        id,
+                        &qwen_ar_forward_fail_message("forward_scratch decode", e),
+                    );
+                }
+                return;
+            }
             generated += 1;
             m.conversation_tokens.push(next_token);
             streamed_tokens.push(next_token);
@@ -10484,19 +11142,6 @@ fn generate(
                 );
                 let _ = stdout.flush();
             }
-
-            // Write this token's K/V to the cache FIRST so the next turn
-            // always starts from a fully-written context. Breaking before
-            // forward_scratch used to leave a hole at the im_end/eos
-            // position — the next turn then attended over zero-init K/V
-            // at that slot.
-            //
-            // Under eviction, m.seq_pos is the *physical* write slot; we
-            // advance and call maybe_evict immediately so the next write
-            // never overruns physical_cap. compact_offset bookkeeping on
-            // the cache itself keeps RoPE phase correct across evictions.
-            qwen35::forward_scratch(gpu, weights, config, next_token, m.seq_pos, kv, dn, scratch)
-                .unwrap();
             m.seq_pos += 1;
             // Checkpoint during decode too, so a long generated turn (e.g. a
             // big code emission) can be resumed mid-region if the NEXT turn's
@@ -10535,7 +11180,21 @@ fn generate(
                         }
                     }
                     Err(e) => {
-                        eprintln!("[adaptive-kv] maybe_downshift error @ pos {} (decode): {:?} — skipping", m.seq_pos, e);
+                        eprintln!(
+                            "[adaptive-kv] maybe_downshift error @ pos {} (decode): {:?} — poisoning model",
+                            m.seq_pos, e
+                        );
+                        let _ = writeln!(
+                            stdout,
+                            r#"{{"type":"error","id":"{}","message":{}}}"#,
+                            id,
+                            serde_json::to_string(&format!(
+                                "adaptive KV transition failed during decode: {e}"
+                            ))
+                            .unwrap_or_else(|_| "\"adaptive KV transition failed\"".into())
+                        );
+                        let _ = stdout.flush();
+                        return;
                     }
                 }
             }
@@ -10640,10 +11299,25 @@ fn generate(
                     let budget_left = max_tokens.saturating_sub(generated);
                     let take = close_tokens.len().min(budget_left);
                     for &t in &close_tokens[..take] {
-                        qwen35::forward_scratch(
+                        // KV write before any emit — same contract as the main
+                        // decode step (no token whose trunk write failed).
+                        if let Err(e) = qwen35::forward_scratch(
                             gpu, weights, config, t, m.seq_pos, kv, dn, scratch,
-                        )
-                        .unwrap();
+                        ) {
+                            let action = qwen_ar_forward_fail_action();
+                            debug_assert!(!action.emit_failed_token);
+                            if action.reset_uncommitted_state {
+                                reset_ar_uncommitted_state!();
+                            }
+                            if action.emit_request_error {
+                                write_error(
+                                    stdout,
+                                    id,
+                                    &qwen_ar_forward_fail_message("forward_scratch think_close", e),
+                                );
+                            }
+                            return;
+                        }
                         m.seq_pos += 1;
                         if let Some(ref ev) = m.eviction {
                             if let Some(hipfire_runtime::triattn::EvictionResult {
@@ -10813,6 +11487,38 @@ fn generate(
                     .saturating_add(nl.len());
                 if nudge_len > 0 && (m.eviction.is_some() || need_kv <= m.physical_cap) {
                     for &tok in &nudge_tokens[..nudge_len] {
+                        // KV before emit: budget-alert injection must not stream
+                        // a token if trunk VMM/forward fails mid-nudge.
+                        if let Err(e) = qwen35::forward_scratch(
+                            gpu, weights, config, tok, m.seq_pos, kv, dn, scratch,
+                        ) {
+                            let action = qwen_ar_forward_fail_action();
+                            debug_assert!(!action.emit_failed_token);
+                            if action.reset_uncommitted_state {
+                                reset_ar_uncommitted_state!();
+                            }
+                            if action.emit_request_error {
+                                write_error(
+                                    stdout,
+                                    id,
+                                    &qwen_ar_forward_fail_message(
+                                        "forward_scratch budget_alert",
+                                        e,
+                                    ),
+                                );
+                            }
+                            return;
+                        }
+                        m.seq_pos += 1;
+                        if let Some(ref ev) = m.eviction {
+                            if let Some(hipfire_runtime::triattn::EvictionResult {
+                                new_physical: new_phys,
+                                ..
+                            }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
+                            {
+                                m.seq_pos = new_phys;
+                            }
+                        }
                         m.conversation_tokens.push(tok);
                         streamed_tokens.push(tok);
                         emit_committed_event(
@@ -10838,20 +11544,6 @@ fn generate(
                                 serde_json::to_string(&t).unwrap_or_default()
                             );
                             let _ = stdout.flush();
-                        }
-                        qwen35::forward_scratch(
-                            gpu, weights, config, tok, m.seq_pos, kv, dn, scratch,
-                        )
-                        .unwrap();
-                        m.seq_pos += 1;
-                        if let Some(ref ev) = m.eviction {
-                            if let Some(hipfire_runtime::triattn::EvictionResult {
-                                new_physical: new_phys,
-                                ..
-                            }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
-                            {
-                                m.seq_pos = new_phys;
-                            }
                         }
                         generated += 1;
                     }
@@ -10955,8 +11647,22 @@ fn generate(
         // and DeltaNet state stay in sync with seq_pos.
         if im_end_token == Some(*m.conversation_tokens.last().unwrap_or(&0)) && !nl.is_empty() {
             for &t in &nl {
-                qwen35::forward_scratch(gpu, weights, config, t, m.seq_pos, kv, dn, scratch)
-                    .unwrap();
+                if let Err(e) =
+                    qwen35::forward_scratch(gpu, weights, config, t, m.seq_pos, kv, dn, scratch)
+                {
+                    let action = qwen_ar_forward_fail_action();
+                    if action.reset_uncommitted_state {
+                        reset_ar_uncommitted_state!();
+                    }
+                    if action.emit_request_error {
+                        write_error(
+                            stdout,
+                            id,
+                            &qwen_ar_forward_fail_message("forward_scratch trailer", e),
+                        );
+                    }
+                    return;
+                }
                 m.seq_pos += 1;
                 if let Some(ref ev) = m.eviction {
                     if let Some(hipfire_runtime::triattn::EvictionResult {
@@ -14091,6 +14797,18 @@ fn generate_vl(
         repeat_window,
         max_think_tokens,
     } = *params;
+    // Adaptive KV poison is sticky until unload/reload. Refuse VL generation so a
+    // partial tier transition cannot continue writing into mixed-tier state.
+    // Mirror generate() — reset preserves poison, so VL must refuse independently.
+    if let Some(ad) = m.kv_adaptive.as_ref() {
+        if ad.is_poisoned() {
+            let reason = ad
+                .poison_reason()
+                .unwrap_or("adaptive KV is poisoned; unload/reload required");
+            write_error(stdout, id, reason);
+            return;
+        }
+    }
     let tokenizer = m.tokenizer.as_ref().unwrap();
     let vision_config = m.vision_config.as_ref().unwrap();
 
@@ -14228,7 +14946,11 @@ fn generate_vl(
             b.kv_cache.compact_offset = 0;
         }
         if let Some(ad) = m.kv_adaptive.as_mut() {
-            ad.reset();
+            if let Some(ModelState::Qwen35(b)) = m.state.as_mut() {
+                ad.reset_with_cache(gpu, &mut b.kv_cache);
+            } else {
+                ad.reset();
+            }
         }
     }
 
@@ -14281,17 +15003,19 @@ fn generate_vl(
     }
     .build_with_user_tokens(&user_body);
 
-    // KV-budget guard — physical_cap without eviction, absolute window with.
-    // Mirrors the textual generate() contract; reserves trailer slots so
-    // natural im_end termination can still write the ChatML \n.
+    // KV-budget guard — tier-aware without eviction, absolute window with.
+    // Adaptive admits against max_seq (floor-tier guarantee); non-adaptive keeps
+    // physical_cap. Reserves trailer slots so natural im_end can write ChatML \n.
     let trailer = nl.len();
     let absolute_pos_vl = m.seq_pos.saturating_add(kv.compact_offset);
+    let adaptive_engaged = m.kv_adaptive.is_some();
+    let no_evict_cap = vl_no_eviction_kv_cap(m.physical_cap, m.max_seq, adaptive_engaged);
     let over_budget = if m.eviction.is_none() {
         m.seq_pos
             .saturating_add(prompt_tokens.len())
             .saturating_add(max_tokens)
             .saturating_add(trailer)
-            > m.physical_cap
+            > no_evict_cap
     } else {
         absolute_pos_vl
             .saturating_add(prompt_tokens.len())
@@ -14303,7 +15027,7 @@ fn generate_vl(
         write_error(stdout, id, &format!(
             "request exceeds loaded KV budget: seq_pos={} + prefill={} + max_tokens={} + trailer={} > cap={} — reload model with a larger max_seq",
             m.seq_pos, prompt_tokens.len(), max_tokens, trailer,
-            if m.eviction.is_none() { m.physical_cap } else { m.max_seq },
+            if m.eviction.is_none() { no_evict_cap } else { m.max_seq },
         ));
         return;
     }
@@ -14318,9 +15042,32 @@ fn generate_vl(
         vision_config.temporal_patch_size,
         vision_config.spatial_merge_size,
     );
-    let visual_tokens =
-        qwen35_vl::vision_forward(gpu, vision_weights, vision_config, &patches, grid_h, grid_w)
-            .expect("vision forward failed");
+    let visual_tokens = match qwen35_vl::vision_forward(
+        gpu,
+        vision_weights,
+        vision_config,
+        &patches,
+        grid_h,
+        grid_w,
+    ) {
+        Ok(v) => v,
+        Err(e) => {
+            vl_forward_fail(
+                stdout,
+                id,
+                "vision_forward",
+                e,
+                gpu,
+                dn,
+                kv,
+                &mut m.kv_adaptive,
+                &mut m.seq_pos,
+                &mut m.conversation_tokens,
+                &mut m.prefill_checkpoints,
+            );
+            return;
+        }
+    };
 
     let im_end_token = if im_end.len() == 1 {
         Some(im_end[0])
@@ -14345,31 +15092,114 @@ fn generate_vl(
 
     // Prefill with vision token embedding for image_pad positions. VL
     // prefill is per-token (forward_scratch_embed isn't batched), so we
-    // advance m.seq_pos in-loop and call maybe_evict after every write.
+    // advance m.seq_pos in-loop and call maybe_evict / maybe_downshift after
+    // every committed write. Lazy VMM map/growth failures and adaptive
+    // transition errors are request-scoped (no panic, no later token emit).
     let mut visual_idx = 0usize;
     for &token in prompt_tokens.iter() {
         if token == image_pad_id && visual_idx < n_visual_tokens {
             let emb = &visual_tokens[visual_idx * config.dim..(visual_idx + 1) * config.dim];
-            qwen35::forward_scratch_embed(gpu, weights, config, emb, m.seq_pos, kv, dn, scratch)
-                .expect("forward_scratch_embed failed");
+            if let Err(e) =
+                qwen35::forward_scratch_embed(gpu, weights, config, emb, m.seq_pos, kv, dn, scratch)
+            {
+                vl_forward_fail(
+                    stdout,
+                    id,
+                    "forward_scratch_embed (prefill)",
+                    e,
+                    gpu,
+                    dn,
+                    kv,
+                    &mut m.kv_adaptive,
+                    &mut m.seq_pos,
+                    &mut m.conversation_tokens,
+                    &mut m.prefill_checkpoints,
+                );
+                return;
+            }
             visual_idx += 1;
-        } else {
+        } else if let Err(e) =
             qwen35::forward_scratch(gpu, weights, config, token, m.seq_pos, kv, dn, scratch)
-                .expect("forward_scratch failed");
+        {
+            vl_forward_fail(
+                stdout,
+                id,
+                "forward_scratch (prefill)",
+                e,
+                gpu,
+                dn,
+                kv,
+                &mut m.kv_adaptive,
+                &mut m.seq_pos,
+                &mut m.conversation_tokens,
+                &mut m.prefill_checkpoints,
+            );
+            return;
         }
         m.seq_pos += 1;
         if let Some(ref ev) = m.eviction {
-            if let Some(hipfire_runtime::triattn::EvictionResult {
-                new_physical: new_phys,
-                ..
-            }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
-            {
-                m.seq_pos = new_phys;
+            match ev.maybe_evict(gpu, kv, m.seq_pos) {
+                Ok(Some(hipfire_runtime::triattn::EvictionResult {
+                    new_physical: new_phys,
+                    ..
+                })) => {
+                    m.seq_pos = new_phys;
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    vl_forward_fail(
+                        stdout,
+                        id,
+                        "maybe_evict (prefill)",
+                        e,
+                        gpu,
+                        dn,
+                        kv,
+                        &mut m.kv_adaptive,
+                        &mut m.seq_pos,
+                        &mut m.conversation_tokens,
+                        &mut m.prefill_checkpoints,
+                    );
+                    return;
+                }
             }
+        }
+        // Adaptive KV: downshift BETWEEN prefill tokens the moment the
+        // start-tier buffer fills so a long multi-chunk visual+text prompt
+        // cannot overflow current-stride capacity before decode begins.
+        if vl_adaptive_downshift_fail_closed(
+            &mut m.kv_adaptive,
+            &mut m.seq_pos,
+            gpu,
+            kv,
+            dn,
+            &mut m.conversation_tokens,
+            &mut m.prefill_checkpoints,
+            stdout,
+            id,
+            "vl-prefill",
+        ) {
+            return;
         }
     }
 
     m.conversation_tokens.extend_from_slice(&prompt_tokens);
+
+    // Adaptive KV: post-prefill catch-up before first sample/decode write.
+    if vl_adaptive_downshift_fail_closed(
+        &mut m.kv_adaptive,
+        &mut m.seq_pos,
+        gpu,
+        kv,
+        dn,
+        &mut m.conversation_tokens,
+        &mut m.prefill_checkpoints,
+        stdout,
+        id,
+        "vl-post-prefill",
+    ) {
+        return;
+    }
 
     // hunt3 M-D: repeat-penalty / n-gram-block history must be scoped to the
     // GENERATED tokens only (mirrors the text path's `ngram_scope_start` set to
@@ -14388,7 +15218,25 @@ fn generate_vl(
     // Attractor-block uses CPU-side mutation of the downloaded logits
     // vector (`block_attractor_unclosed_cpu`) instead of the previous
     // GPU memcpy + redownload — saves a full vocab-sized DMA per token.
-    let mut logits = gpu.download_f32(&scratch.logits).unwrap();
+    let mut logits = match gpu.download_f32(&scratch.logits) {
+        Ok(v) => v,
+        Err(e) => {
+            vl_forward_fail(
+                stdout,
+                id,
+                "download_f32 (post-prefill)",
+                e,
+                gpu,
+                dn,
+                kv,
+                &mut m.kv_adaptive,
+                &mut m.seq_pos,
+                &mut m.conversation_tokens,
+                &mut m.prefill_checkpoints,
+            );
+            return;
+        }
+    };
     if let Some((open, close)) = think_pair {
         block_attractor_unclosed_cpu(&mut logits, &m.conversation_tokens, open, close, 20, 2);
     }
@@ -14435,8 +15283,76 @@ fn generate_vl(
         hipfire_runtime::loop_guard::LoopGuard::from_config(hipfire_runtime::config::get());
 
     while generated < max_tokens {
+        // Commit KV for this sampled token BEFORE any client-visible emit so a
+        // lazy VMM map/growth failure cannot stream an uncommitted token.
+        // Order: forward → seq_pos++ → evict → downshift → then
+        // generated/conversation/committed/token text. On failure: cold-reset
+        // + request error only (no failed token). Terminators break after a
+        // successful commit (same as AR).
+        if let Err(e) =
+            qwen35::forward_scratch(gpu, weights, config, next_token, m.seq_pos, kv, dn, scratch)
+        {
+            vl_forward_fail(
+                stdout,
+                id,
+                "forward_scratch (decode)",
+                e,
+                gpu,
+                dn,
+                kv,
+                &mut m.kv_adaptive,
+                &mut m.seq_pos,
+                &mut m.conversation_tokens,
+                &mut m.prefill_checkpoints,
+            );
+            return;
+        }
+        m.seq_pos += 1;
+        if let Some(ref ev) = m.eviction {
+            match ev.maybe_evict(gpu, kv, m.seq_pos) {
+                Ok(Some(hipfire_runtime::triattn::EvictionResult {
+                    new_physical: new_phys,
+                    ..
+                })) => {
+                    m.seq_pos = new_phys;
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    vl_forward_fail(
+                        stdout,
+                        id,
+                        "maybe_evict (decode)",
+                        e,
+                        gpu,
+                        dn,
+                        kv,
+                        &mut m.kv_adaptive,
+                        &mut m.seq_pos,
+                        &mut m.conversation_tokens,
+                        &mut m.prefill_checkpoints,
+                    );
+                    return;
+                }
+            }
+        }
+        if vl_adaptive_downshift_fail_closed(
+            &mut m.kv_adaptive,
+            &mut m.seq_pos,
+            gpu,
+            kv,
+            dn,
+            &mut m.conversation_tokens,
+            &mut m.prefill_checkpoints,
+            stdout,
+            id,
+            "vl-decode",
+        ) {
+            return;
+        }
+
         generated += 1;
         m.conversation_tokens.push(next_token);
+        streamed_tokens.push(next_token);
         emit_committed_event(
             stdout,
             id,
@@ -14444,7 +15360,6 @@ fn generate_vl(
             generated - 1,
             t0.elapsed().as_millis() as u64,
         );
-        streamed_tokens.push(next_token);
 
         let all_bytes = tokenizer.decode_bytes(&streamed_tokens);
         let new_bytes = &all_bytes[emitted_bytes..];
@@ -14487,19 +15402,25 @@ fn generate_vl(
             break;
         }
 
-        qwen35::forward_scratch(gpu, weights, config, next_token, m.seq_pos, kv, dn, scratch)
-            .unwrap();
-        m.seq_pos += 1;
-        if let Some(ref ev) = m.eviction {
-            if let Some(hipfire_runtime::triattn::EvictionResult {
-                new_physical: new_phys,
-                ..
-            }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
-            {
-                m.seq_pos = new_phys;
+        logits = match gpu.download_f32(&scratch.logits) {
+            Ok(v) => v,
+            Err(e) => {
+                vl_forward_fail(
+                    stdout,
+                    id,
+                    "download_f32 (decode)",
+                    e,
+                    gpu,
+                    dn,
+                    kv,
+                    &mut m.kv_adaptive,
+                    &mut m.seq_pos,
+                    &mut m.conversation_tokens,
+                    &mut m.prefill_checkpoints,
+                );
+                return;
             }
-        }
-        logits = gpu.download_f32(&scratch.logits).unwrap();
+        };
         // hunt3 M-D: scope ngram-block + repeat-penalty history to generated-only.
         let vl_ngram_scope = &m.conversation_tokens[vl_ngram_scope_start..];
         llama::apply_ngram_block(&mut logits, vl_ngram_scope);
@@ -14530,19 +15451,66 @@ fn generate_vl(
                     let budget_left = max_tokens.saturating_sub(generated);
                     let take = close_tokens.len().min(budget_left);
                     for &t in &close_tokens[..take] {
-                        qwen35::forward_scratch(
+                        // KV write before any emit — same contract as main decode.
+                        if let Err(e) = qwen35::forward_scratch(
                             gpu, weights, config, t, m.seq_pos, kv, dn, scratch,
-                        )
-                        .unwrap();
+                        ) {
+                            vl_forward_fail(
+                                stdout,
+                                id,
+                                "forward_scratch (vl-think-close)",
+                                e,
+                                gpu,
+                                dn,
+                                kv,
+                                &mut m.kv_adaptive,
+                                &mut m.seq_pos,
+                                &mut m.conversation_tokens,
+                                &mut m.prefill_checkpoints,
+                            );
+                            return;
+                        }
                         m.seq_pos += 1;
                         if let Some(ref ev) = m.eviction {
-                            if let Some(hipfire_runtime::triattn::EvictionResult {
-                                new_physical: new_phys,
-                                ..
-                            }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
-                            {
-                                m.seq_pos = new_phys;
+                            match ev.maybe_evict(gpu, kv, m.seq_pos) {
+                                Ok(Some(hipfire_runtime::triattn::EvictionResult {
+                                    new_physical: new_phys,
+                                    ..
+                                })) => {
+                                    m.seq_pos = new_phys;
+                                }
+                                Ok(None) => {}
+                                Err(e) => {
+                                    vl_forward_fail(
+                                        stdout,
+                                        id,
+                                        "maybe_evict (vl-think-close)",
+                                        e,
+                                        gpu,
+                                        dn,
+                                        kv,
+                                        &mut m.kv_adaptive,
+                                        &mut m.seq_pos,
+                                        &mut m.conversation_tokens,
+                                        &mut m.prefill_checkpoints,
+                                    );
+                                    return;
+                                }
                             }
+                        }
+                        if vl_adaptive_downshift_fail_closed(
+                            &mut m.kv_adaptive,
+                            &mut m.seq_pos,
+                            gpu,
+                            kv,
+                            dn,
+                            &mut m.conversation_tokens,
+                            &mut m.prefill_checkpoints,
+                            stdout,
+                            id,
+                            "vl-think-close",
+                        ) {
+                            return;
                         }
                         m.conversation_tokens.push(t);
                         streamed_tokens.push(t);
@@ -14587,7 +15555,25 @@ fn generate_vl(
                     if generated >= max_tokens {
                         break;
                     }
-                    logits = gpu.download_f32(&scratch.logits).unwrap();
+                    logits = match gpu.download_f32(&scratch.logits) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            vl_forward_fail(
+                                stdout,
+                                id,
+                                "download_f32 (vl-think-close)",
+                                e,
+                                gpu,
+                                dn,
+                                kv,
+                                &mut m.kv_adaptive,
+                                &mut m.seq_pos,
+                                &mut m.conversation_tokens,
+                                &mut m.prefill_checkpoints,
+                            );
+                            return;
+                        }
+                    };
                     block_attractor_unclosed_cpu(
                         &mut logits,
                         &m.conversation_tokens,
@@ -14610,16 +15596,65 @@ fn generate_vl(
     // ChatML \n boundary — run through forward to keep KV cache + DeltaNet in sync
     if im_end_token == Some(*m.conversation_tokens.last().unwrap_or(&0)) && !nl.is_empty() {
         for &t in &nl {
-            qwen35::forward_scratch(gpu, weights, config, t, m.seq_pos, kv, dn, scratch).unwrap();
+            if let Err(e) =
+                qwen35::forward_scratch(gpu, weights, config, t, m.seq_pos, kv, dn, scratch)
+            {
+                vl_forward_fail(
+                    stdout,
+                    id,
+                    "forward_scratch (vl-trailer)",
+                    e,
+                    gpu,
+                    dn,
+                    kv,
+                    &mut m.kv_adaptive,
+                    &mut m.seq_pos,
+                    &mut m.conversation_tokens,
+                    &mut m.prefill_checkpoints,
+                );
+                return;
+            }
             m.seq_pos += 1;
             if let Some(ref ev) = m.eviction {
-                if let Some(hipfire_runtime::triattn::EvictionResult {
-                    new_physical: new_phys,
-                    ..
-                }) = ev.maybe_evict(gpu, kv, m.seq_pos).unwrap()
-                {
-                    m.seq_pos = new_phys;
+                match ev.maybe_evict(gpu, kv, m.seq_pos) {
+                    Ok(Some(hipfire_runtime::triattn::EvictionResult {
+                        new_physical: new_phys,
+                        ..
+                    })) => {
+                        m.seq_pos = new_phys;
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        vl_forward_fail(
+                            stdout,
+                            id,
+                            "maybe_evict (vl-trailer)",
+                            e,
+                            gpu,
+                            dn,
+                            kv,
+                            &mut m.kv_adaptive,
+                            &mut m.seq_pos,
+                            &mut m.conversation_tokens,
+                            &mut m.prefill_checkpoints,
+                        );
+                        return;
+                    }
                 }
+            }
+            if vl_adaptive_downshift_fail_closed(
+                &mut m.kv_adaptive,
+                &mut m.seq_pos,
+                gpu,
+                kv,
+                dn,
+                &mut m.conversation_tokens,
+                &mut m.prefill_checkpoints,
+                stdout,
+                id,
+                "vl-trailer",
+            ) {
+                return;
             }
             m.conversation_tokens.push(t);
         }
@@ -14659,18 +15694,6 @@ fn generate_vl(
     let _ = stdout.flush();
 }
 
-/// dots.ocr (arch_id=8) VL generation. Single-image, greedy decode —
-/// the phase-3 bring-up serving path that promotes the standalone
-/// `ocr_e2e` example into the daemon.
-///
-/// Flow: preprocess image → `build_prompt_ids` (HF-exact framing) →
-/// `vision_forward` → per-token prefill splicing merged visual
-/// embeddings at `<|imgpad|>` slots → greedy decode to EOS, streaming
-/// tokens in the daemon's JSONL protocol.
-///
-/// MVP scope: greedy only (sampling params ignored), single image,
-/// per-token prefill, `--image <path>` only (base64 deferred). The text
-/// side is Qwen2; the decode state reuses `m.qwen2_state`.
 fn generate_vl_dots_ocr(
     m: &mut LoadedModel,
     gpu: &mut rdna_compute::Gpu,
@@ -15571,11 +16594,25 @@ mod tool_call_parser_tests {
 mod render_tail_think_tests {
     use super::{
         asst_turn_fingerprint, normalize_asst_turn_for_fingerprint, render_tail_opens_think,
+        spec_assistant_prefix,
     };
+    use hipfire_runtime::prompt_frame::AssistantPrefix;
 
     #[test]
     fn qwen_jinja_think_tail_primes_reasoning_channel() {
         assert!(render_tail_opens_think("<|im_start|>assistant\n<think>\n"));
+    }
+
+    #[test]
+    fn speculative_emitter_uses_rendered_think_state() {
+        assert!(matches!(
+            spec_assistant_prefix(true),
+            AssistantPrefix::OpenThink
+        ));
+        assert!(matches!(
+            spec_assistant_prefix(false),
+            AssistantPrefix::Plain
+        ));
     }
 
     #[test]
@@ -15598,5 +16635,34 @@ mod render_tail_think_tests {
             asst_turn_fingerprint(&normalized, &[]),
             asst_turn_fingerprint("visible answer", &[])
         );
+    }
+}
+
+#[cfg(test)]
+mod vl_adaptive_admission_tests {
+    use super::vl_no_eviction_kv_cap;
+
+    #[test]
+    fn adaptive_admits_against_max_seq_not_start_tier_physical() {
+        // physical_cap may equal max_seq at load, but the important case is
+        // that adaptive never silently shrinks admission to start-tier cap.
+        let physical_cap = 8192;
+        let max_seq = 32768;
+        assert_eq!(
+            vl_no_eviction_kv_cap(physical_cap, max_seq, true),
+            max_seq,
+            "adaptive VL must admit against floor-tier max_seq"
+        );
+        assert_eq!(
+            vl_no_eviction_kv_cap(physical_cap, max_seq, false),
+            physical_cap,
+            "non-adaptive VL keeps physical_cap contract"
+        );
+    }
+
+    #[test]
+    fn equal_caps_identical_either_mode() {
+        assert_eq!(vl_no_eviction_kv_cap(4096, 4096, false), 4096);
+        assert_eq!(vl_no_eviction_kv_cap(4096, 4096, true), 4096);
     }
 }

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -1434,6 +1434,12 @@ fn main() {
                     .and_then(|v| v.as_str())
                     .filter(|s| !s.is_empty())
                     .map(|s| s.to_string());
+                let kv_backend_override = msg
+                    .get("params")
+                    .and_then(|p| p.get("kv_backend"))
+                    .and_then(|v| v.as_str())
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.to_string());
                 // Per-load adaptive-KV selector (mirrors kv_mode). Overrides the
                 // HIPFIRE_KV_ADAPTIVE env. off|conservative|balanced|aggressive|
                 // advanced:k=..,v=.. — resolved in load_model (param > env > off).
@@ -1766,14 +1772,29 @@ fn main() {
                     .filter(|s| !s.is_empty())
                     .map(|s| s.to_string());
 
+                let requested_kv_backend = kv_backend_override
+                    .as_deref()
+                    .unwrap_or("contiguous")
+                    .to_ascii_lowercase();
+                if tp > 1 && requested_kv_backend != "contiguous" {
+                    let _ = writeln!(
+                        stdout,
+                        r#"{{"type":"error","message":"KV backend '{}' requires tp=1"}}"#,
+                        requested_kv_backend
+                    );
+                    let _ = stdout.flush();
+                    continue;
+                }
+
                 let loaded = if tp > 1 {
                     hipfire_loader::load_model_ep(path, max_seq, tp)
                 } else {
-                    hipfire_loader::load_model(
+                    hipfire_loader::load_model_with_kv_backend(
                         path,
                         max_seq,
                         draft_path.as_deref(),
                         kv_mode_override.as_deref(),
+                        kv_backend_override.as_deref(),
                         kv_adaptive_override.as_deref(),
                         state_quant_override.as_deref(),
                         &cask,

--- a/crates/hipfire-runtime/examples/ep_decode_parity.rs
+++ b/crates/hipfire-runtime/examples/ep_decode_parity.rs
@@ -438,7 +438,7 @@ fn main() {
         );
         eprintln!("\n✅ tp=1 ANCHOR PASS: EP argmax stream == production forward_scratch.");
         dn_ref.free_gpu(&mut gpus.devices[0]);
-        kv_ref.free_gpu(&mut gpus.devices[0]);
+        let _ = kv_ref.free_gpu(&mut gpus.devices[0]);
     }
 
     eprintln!(

--- a/crates/hipfire-runtime/examples/llama_dflash_hidden_capture.rs
+++ b/crates/hipfire-runtime/examples/llama_dflash_hidden_capture.rs
@@ -39,6 +39,7 @@ fn main() {
         max_seq: 2048,
         draft_path: None,
         kv_mode_override: None,
+        kv_backend: hipfire_runtime::kv_backend::KvBackend::Contiguous,
         kv_adaptive_override: None,
         state_quant_override: None,
         cask: &cask,

--- a/crates/hipfire-runtime/examples/llama_lm_head_logits_parity.rs
+++ b/crates/hipfire-runtime/examples/llama_lm_head_logits_parity.rs
@@ -50,6 +50,7 @@ fn main() {
         max_seq: 2048,
         draft_path: None,
         kv_mode_override: None,
+        kv_backend: hipfire_runtime::kv_backend::KvBackend::Contiguous,
         kv_adaptive_override: None,
         state_quant_override: None,
         cask: &cask,

--- a/crates/hipfire-runtime/examples/pp_parity.rs
+++ b/crates/hipfire-runtime/examples/pp_parity.rs
@@ -74,7 +74,7 @@ fn run_single_gpu(path: &str) -> Vec<u32> {
     // leak fits inside the 2 GiB tolerance.
     scratch.free_gpu(&mut gpu);
     dn.free_gpu(&mut gpu);
-    kv.free_gpu(&mut gpu);
+    let _ = kv.free_gpu(&mut gpu);
     weights.free_gpu(&mut gpu);
     gpu.drain_pool();
     tokens

--- a/crates/hipfire-runtime/examples/pp_parity_chatml.rs
+++ b/crates/hipfire-runtime/examples/pp_parity_chatml.rs
@@ -125,7 +125,7 @@ fn run_single_gpu(path: &str, prompt_tokens: &[u32]) -> (Vec<u32>, Vec<Vec<f32>>
     }
     scratch.free_gpu(&mut gpu);
     dn.free_gpu(&mut gpu);
-    kv.free_gpu(&mut gpu);
+    let _ = kv.free_gpu(&mut gpu);
     weights.free_gpu(&mut gpu);
     gpu.drain_pool();
     (tokens, all_logits)

--- a/crates/hipfire-runtime/examples/test_inference.rs
+++ b/crates/hipfire-runtime/examples/test_inference.rs
@@ -300,7 +300,7 @@ fn main() {
             "KV cache should use >1MB, got {alloc_mb:.1}MB"
         );
         // Explicit free + drain
-        kv.free_gpu(&mut gpu);
+        let _ = kv.free_gpu(&mut gpu);
         gpu.drain_pool();
         let (free_after, _) = gpu.hip.get_vram_info().map_err(|e| format!("{e}"))?;
         let leak_mb = (free_before as i64 - free_after as i64) as f64 / 1e6;

--- a/crates/hipfire-runtime/src/kv_adaptive.rs
+++ b/crates/hipfire-runtime/src/kv_adaptive.rs
@@ -117,6 +117,10 @@ pub struct KvAdaptive {
     pub next_step: usize,       // index into steps
     pub thresholds: Vec<usize>, // seq_pos at which steps[i] fires
     pub margin: usize,          // fire this many tokens before the cap
+    /// Sticky failure after a partial tier transition. Further generation must
+    /// refuse until unload/reload; reset does not clear poison.
+    poisoned: bool,
+    poison_reason: Option<String>,
 }
 
 impl KvAdaptive {
@@ -152,8 +156,8 @@ impl KvAdaptive {
             // was set to the aggressive floor (fwht2/lloyd2), making the two presets
             // identical. K/V bit-gap stays ≤ 1 tier at every rung.
             Preset::Conservative => (KMode::Fwht4, VMode::Lloyd4),
-            Preset::Balanced     => (KMode::Fwht3, VMode::Lloyd3),
-            Preset::Aggressive   => (KMode::Fwht2, VMode::Lloyd2),
+            Preset::Balanced => (KMode::Fwht3, VMode::Lloyd3),
+            Preset::Aggressive => (KMode::Fwht2, VMode::Lloyd2),
         };
         Self::new(max_seq, n_kv_heads, head_dim, k_floor, v_floor)
     }
@@ -187,6 +191,8 @@ impl KvAdaptive {
             // 256 is comfortably conservative.
             thresholds: Vec::new(),
             margin: crate::llama::PREFILL_MAX_BATCH,
+            poisoned: false,
+            poison_reason: None,
         };
         s.recompute_thresholds();
         s
@@ -242,14 +248,40 @@ impl KvAdaptive {
         }
     }
 
-    /// Reset the tier state to the start (Q8/fwht4) position.  Call this
-    /// whenever the KV cache is cold-reset (context-full rollover, explicit
-    /// "reset" command) so the threshold sequence restarts from the beginning
-    /// instead of staying pinned at the floor tier permanently.
+    /// Controller-only tier rewind to FWHT4/Q8 step 0. Prefer
+    /// [`Self::reset_with_cache`] so cache mode flags stay synchronized.
     pub fn reset(&mut self) {
         self.cur_k = KMode::Fwht4;
         self.cur_v = crate::llama::VMode::Q8;
         self.next_step = 0;
+    }
+
+    /// Atomically restore controller + cache encoding to the adaptive start
+    /// tier (K=fwht4, V=q8, step 0), then invalidate captured HipGraphs and
+    /// retained replay recorded under the previous tier. Does not clear poison
+    /// — a poisoned model still requires unload/reload.
+    pub fn reset_with_cache(
+        &mut self,
+        gpu: &mut rdna_compute::Gpu,
+        kv: &mut crate::llama::KvCache,
+    ) {
+        self.reset();
+        kv.restore_adaptive_start_flags();
+        gpu.invalidate_for_kv_mode_switch();
+    }
+
+    pub fn is_poisoned(&self) -> bool {
+        self.poisoned
+    }
+
+    pub fn poison_reason(&self) -> Option<&str> {
+        self.poison_reason.as_deref()
+    }
+
+    pub fn poison(&mut self, reason: impl Into<String>) {
+        let reason = reason.into();
+        self.poisoned = true;
+        self.poison_reason = Some(reason);
     }
 
     /// Apply ALL downshift steps whose threshold seq_pos has crossed (handles
@@ -257,25 +289,46 @@ impl KvAdaptive {
     /// point). Called after each committed token write at the same site as
     /// `maybe_evict`. The common case (no threshold crossed) is a single integer
     /// compare returning an empty Vec. Returns the steps applied this call.
+    ///
+    /// On any transcode failure after zero or more successful steps in this
+    /// call, the controller is poisoned and the error propagates. Callers must
+    /// not continue generation on a poisoned model.
     pub fn maybe_downshift(
         &mut self,
         gpu: &mut rdna_compute::Gpu,
         kv: &mut crate::llama::KvCache,
         seq_pos: usize,
     ) -> hip_bridge::HipResult<Vec<Step>> {
+        if self.poisoned {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "adaptive KV is poisoned{}; unload/reload required",
+                    self.poison_reason
+                        .as_deref()
+                        .map(|r| format!(" ({r})"))
+                        .unwrap_or_default()
+                ),
+            ));
+        }
         let mut applied = Vec::new();
         while self.next_step < self.steps.len() && seq_pos >= self.thresholds[self.next_step] {
-            match self.steps[self.next_step] {
-                Step::V(nv) => {
-                    kv.transcode_v_step(gpu, nv, seq_pos)?;
+            let step = self.steps[self.next_step];
+            let result = match step {
+                Step::V(nv) => kv.transcode_v_step(gpu, nv, seq_pos).map(|()| {
                     self.cur_v = nv;
-                }
-                Step::K(nk) => {
-                    kv.transcode_k_step(gpu, nk.bits(), seq_pos)?;
+                }),
+                Step::K(nk) => kv.transcode_k_step(gpu, nk.bits(), seq_pos).map(|()| {
                     self.cur_k = nk;
-                }
+                }),
+            };
+            if let Err(err) = result {
+                self.poison(format!(
+                    "partial adaptive transition at seq_pos={seq_pos} step={step:?}: {err}"
+                ));
+                return Err(err);
             }
-            applied.push(self.steps[self.next_step]);
+            applied.push(step);
             self.next_step += 1;
         }
         Ok(applied)
@@ -359,16 +412,38 @@ mod tests {
         // chain descends V to lloyd3, then K to fwht3 (no final lloyd2 step — that
         // belongs to aggressive).
         let a = KvAdaptive::from_preset(Preset::Balanced, 10_000, 4, 256);
-        assert_eq!(a.steps, vec![
-            Step::V(VMode::Lloyd4), Step::V(VMode::Lloyd3), Step::K(KMode::Fwht3),
-        ]);
+        assert_eq!(
+            a.steps,
+            vec![
+                Step::V(VMode::Lloyd4),
+                Step::V(VMode::Lloyd3),
+                Step::K(KMode::Fwht3),
+            ]
+        );
         // thresholds non-decreasing.
-        for w in a.thresholds.windows(2) { assert!(w[1] >= w[0], "thresholds {:?}", a.thresholds); }
+        for w in a.thresholds.windows(2) {
+            assert!(w[1] >= w[0], "thresholds {:?}", a.thresholds);
+        }
         // first threshold = start-tier cap - margin (computed at the new floors so
         // it can't drift to a stale magic number).
-        let start_cap = cap_min(10_000, 256, KMode::Fwht3, VMode::Lloyd3, KMode::Fwht4, VMode::Q8);
-        assert_eq!(a.current_cap(), start_cap, "current_cap at construction == start-tier cap");
-        assert_eq!(a.thresholds[0], start_cap - a.margin, "first threshold = start_cap - margin");
+        let start_cap = cap_min(
+            10_000,
+            256,
+            KMode::Fwht3,
+            VMode::Lloyd3,
+            KMode::Fwht4,
+            VMode::Q8,
+        );
+        assert_eq!(
+            a.current_cap(),
+            start_cap,
+            "current_cap at construction == start-tier cap"
+        );
+        assert_eq!(
+            a.thresholds[0],
+            start_cap - a.margin,
+            "first threshold = start_cap - margin"
+        );
     }
 
     #[test]
@@ -402,6 +477,32 @@ mod tests {
         let a = KvAdaptive::from_preset(Preset::Conservative, 10_000, 4, 256);
         assert_eq!(a.steps, vec![Step::V(VMode::Lloyd4)]);
     }
+    #[test]
+    fn reset_restores_start_tier_and_step_index() {
+        let mut a = KvAdaptive::from_preset(Preset::Aggressive, 10_000, 4, 256);
+        a.cur_k = KMode::Fwht2;
+        a.cur_v = VMode::Lloyd2;
+        a.next_step = a.steps.len();
+        a.reset();
+        assert_eq!(a.cur_k, KMode::Fwht4);
+        assert_eq!(a.cur_v, VMode::Q8);
+        assert_eq!(a.next_step, 0);
+        assert!(!a.is_poisoned());
+    }
+
+    #[test]
+    fn poison_is_sticky_across_reset() {
+        let mut a = KvAdaptive::from_preset(Preset::Balanced, 10_000, 4, 256);
+        a.poison("transcode failed mid-step");
+        assert!(a.is_poisoned());
+        assert_eq!(a.poison_reason(), Some("transcode failed mid-step"));
+        a.reset();
+        assert!(
+            a.is_poisoned(),
+            "reset must not clear poison; unload/reload is required"
+        );
+    }
+
     #[test]
     fn advanced_k_fwht3_floor() {
         let a = KvAdaptive::new(10_000, 4, 256, KMode::Fwht3, VMode::Lloyd2);

--- a/crates/hipfire-runtime/src/kv_backend.rs
+++ b/crates/hipfire-runtime/src/kv_backend.rs
@@ -1,0 +1,346 @@
+//! KV storage backend selection.
+//!
+//! This is deliberately separate from [`crate::kv_mode`]. A KV mode selects
+//! the element encoding (q8, asym3, and so on); a backend selects how the
+//! resulting bytes are allocated and grown.
+
+use std::fmt;
+use std::str::FromStr;
+
+pub const KV_BACKEND_NAMES: &[&str] = &["contiguous", "vmm"];
+pub const DEFAULT_KV_CHUNK_TOKENS: usize = 64;
+
+/// Default physical growth target. Standard GPU VMM drivers may account each
+/// handle in 2 MiB pages even when the API accepts finer map alignment.
+/// The final reserve tail may be smaller.
+pub const DEFAULT_VMM_PHYSICAL_CHUNK_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum KvBackend {
+    #[default]
+    Contiguous,
+    Vmm,
+}
+
+impl KvBackend {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Contiguous => "contiguous",
+            Self::Vmm => "vmm",
+        }
+    }
+}
+
+impl fmt::Display for KvBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ParseKvBackendError {
+    value: String,
+}
+
+impl fmt::Display for ParseKvBackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "unknown KV backend {:?}; expected one of: {}",
+            self.value,
+            KV_BACKEND_NAMES.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for ParseKvBackendError {}
+
+impl FromStr for KvBackend {
+    type Err = ParseKvBackendError;
+
+    fn from_str(raw: &str) -> Result<Self, Self::Err> {
+        match raw {
+            "contiguous" => Ok(Self::Contiguous),
+            "vmm" => Ok(Self::Vmm),
+            other => Err(ParseKvBackendError {
+                value: other.to_string(),
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct KvMapGrowth {
+    pub offset_bytes: usize,
+    pub size_bytes: usize,
+    pub token_capacity: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct KvChunkPlan {
+    bytes_per_token: usize,
+    max_tokens: usize,
+    target_chunk_tokens: usize,
+    granularity: usize,
+    reserve_bytes: usize,
+    growth_bytes: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum KvChunkPlanError {
+    Zero(&'static str),
+    Overflow,
+    RequiredTokens { required: usize, max: usize },
+    InvalidMappedBytes { mapped: usize, reserve: usize },
+}
+
+impl fmt::Display for KvChunkPlanError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Zero(field) => write!(f, "{field} must be greater than zero"),
+            Self::Overflow => f.write_str("KV chunk byte calculation overflowed"),
+            Self::RequiredTokens { required, max } => {
+                write!(f, "required token count {required} exceeds maximum {max}")
+            }
+            Self::InvalidMappedBytes { mapped, reserve } => write!(
+                f,
+                "current mapped byte count {mapped} is not page-aligned or exceeds reserve {reserve}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for KvChunkPlanError {}
+
+impl KvChunkPlan {
+    pub fn new(
+        bytes_per_token: usize,
+        max_tokens: usize,
+        target_chunk_tokens: usize,
+        granularity: usize,
+        minimum_growth_bytes: usize,
+    ) -> Result<Self, KvChunkPlanError> {
+        for (name, value) in [
+            ("bytes_per_token", bytes_per_token),
+            ("max_tokens", max_tokens),
+            ("target_chunk_tokens", target_chunk_tokens),
+            ("granularity", granularity),
+            ("minimum_growth_bytes", minimum_growth_bytes),
+        ] {
+            if value == 0 {
+                return Err(KvChunkPlanError::Zero(name));
+            }
+        }
+
+        let logical_bytes = bytes_per_token
+            .checked_mul(max_tokens)
+            .ok_or(KvChunkPlanError::Overflow)?;
+        let target_bytes = bytes_per_token
+            .checked_mul(target_chunk_tokens)
+            .ok_or(KvChunkPlanError::Overflow)?;
+        let reserve_bytes = checked_round_up(logical_bytes, granularity)?;
+        let growth_bytes = checked_round_up(target_bytes.max(minimum_growth_bytes), granularity)?;
+
+        Ok(Self {
+            bytes_per_token,
+            max_tokens,
+            target_chunk_tokens,
+            granularity,
+            reserve_bytes,
+            growth_bytes,
+        })
+    }
+
+    pub const fn reserve_bytes(self) -> usize {
+        self.reserve_bytes
+    }
+
+    pub const fn growth_bytes(self) -> usize {
+        self.growth_bytes
+    }
+
+    pub const fn bytes_per_token(self) -> usize {
+        self.bytes_per_token
+    }
+
+    pub const fn target_chunk_tokens(self) -> usize {
+        self.target_chunk_tokens
+    }
+
+    pub const fn granularity(self) -> usize {
+        self.granularity
+    }
+
+    pub fn mapped_bytes_for_tokens(
+        self,
+        required_tokens: usize,
+    ) -> Result<usize, KvChunkPlanError> {
+        if required_tokens > self.max_tokens {
+            return Err(KvChunkPlanError::RequiredTokens {
+                required: required_tokens,
+                max: self.max_tokens,
+            });
+        }
+        if required_tokens == 0 {
+            return Ok(0);
+        }
+
+        let required_bytes = self
+            .bytes_per_token
+            .checked_mul(required_tokens)
+            .ok_or(KvChunkPlanError::Overflow)?;
+        Ok(checked_round_up(required_bytes, self.growth_bytes)?.min(self.reserve_bytes))
+    }
+
+    pub fn token_capacity(self, mapped_bytes: usize) -> usize {
+        (mapped_bytes / self.bytes_per_token).min(self.max_tokens)
+    }
+
+    pub fn growth(
+        self,
+        mapped_bytes: usize,
+        required_tokens: usize,
+    ) -> Result<Option<KvMapGrowth>, KvChunkPlanError> {
+        if mapped_bytes > self.reserve_bytes || !mapped_bytes.is_multiple_of(self.granularity) {
+            return Err(KvChunkPlanError::InvalidMappedBytes {
+                mapped: mapped_bytes,
+                reserve: self.reserve_bytes,
+            });
+        }
+        let target = self.mapped_bytes_for_tokens(required_tokens)?;
+        if target <= mapped_bytes {
+            return Ok(None);
+        }
+        Ok(Some(KvMapGrowth {
+            offset_bytes: mapped_bytes,
+            size_bytes: target - mapped_bytes,
+            token_capacity: self.token_capacity(target),
+        }))
+    }
+}
+
+fn checked_round_up(value: usize, alignment: usize) -> Result<usize, KvChunkPlanError> {
+    let remainder = value % alignment;
+    if remainder == 0 {
+        Ok(value)
+    } else {
+        value
+            .checked_add(alignment - remainder)
+            .ok_or(KvChunkPlanError::Overflow)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_all_stable_backend_names() {
+        assert_eq!("contiguous".parse(), Ok(KvBackend::Contiguous));
+        assert_eq!("vmm".parse(), Ok(KvBackend::Vmm));
+    }
+
+    #[test]
+    fn default_is_the_existing_contiguous_path() {
+        assert_eq!(KvBackend::default(), KvBackend::Contiguous);
+    }
+
+    #[test]
+    fn rejects_unknown_or_empty_names() {
+        for raw in ["", "auto", "paged", "VMM"] {
+            let err = raw.parse::<KvBackend>().unwrap_err().to_string();
+            assert!(err.contains(raw));
+            assert!(err.contains("contiguous, vmm"));
+        }
+    }
+
+    #[test]
+    fn page_aligns_asym3_and_q8_growth_without_padding_the_dense_rows() {
+        let k = KvChunkPlan::new(200, 4096, 64, 4096, 4096).unwrap();
+        assert_eq!(k.growth_bytes(), 16_384);
+        assert_eq!(k.mapped_bytes_for_tokens(64).unwrap(), 16_384);
+        assert_eq!(k.token_capacity(16_384), 81);
+
+        let v = KvChunkPlan::new(544, 4096, 64, 4096, 4096).unwrap();
+        assert_eq!(v.growth_bytes(), 36_864);
+        assert_eq!(v.mapped_bytes_for_tokens(64).unwrap(), 36_864);
+        assert_eq!(v.token_capacity(36_864), 67);
+    }
+
+    #[test]
+    fn emits_aligned_incremental_growth() {
+        let plan = KvChunkPlan::new(544, 4096, 64, 4096, 4096).unwrap();
+        let first = plan.growth(0, 1).unwrap().unwrap();
+        assert_eq!(first.offset_bytes, 0);
+        assert_eq!(first.size_bytes, 36_864);
+        assert_eq!(first.token_capacity, 67);
+
+        assert_eq!(plan.growth(first.size_bytes, 64).unwrap(), None);
+        let second = plan.growth(first.size_bytes, 68).unwrap().unwrap();
+        assert_eq!(second.offset_bytes, 36_864);
+        assert_eq!(second.size_bytes, 36_864);
+        assert_eq!(second.token_capacity, 135);
+    }
+
+    #[test]
+    fn applies_a_physical_growth_target_without_padding_the_final_tail() {
+        let k = KvChunkPlan::new(
+            200,
+            9216,
+            DEFAULT_KV_CHUNK_TOKENS,
+            4096,
+            DEFAULT_VMM_PHYSICAL_CHUNK_BYTES,
+        )
+        .unwrap();
+        assert_eq!(k.growth_bytes(), 2 * 1024 * 1024);
+        let full_k = k.growth(0, 1).unwrap().unwrap();
+        assert_eq!(full_k.size_bytes, k.reserve_bytes());
+        assert_eq!(full_k.token_capacity, 9216);
+
+        let v = KvChunkPlan::new(
+            544,
+            9216,
+            DEFAULT_KV_CHUNK_TOKENS,
+            4096,
+            DEFAULT_VMM_PHYSICAL_CHUNK_BYTES,
+        )
+        .unwrap();
+        let first_v = v.growth(0, 1).unwrap().unwrap();
+        assert_eq!(first_v.size_bytes, 2 * 1024 * 1024);
+        assert_eq!(first_v.token_capacity, 3855);
+        let second_v = v.growth(first_v.size_bytes, 4096).unwrap().unwrap();
+        assert_eq!(second_v.size_bytes, 2 * 1024 * 1024);
+        assert_eq!(second_v.token_capacity, 7710);
+        let final_v = v.growth(2 * second_v.size_bytes, 8192).unwrap().unwrap();
+        assert_eq!(
+            final_v.size_bytes,
+            v.reserve_bytes() - 2 * second_v.size_bytes
+        );
+        assert_eq!(final_v.token_capacity, 9216);
+    }
+
+    #[test]
+    fn validates_chunk_plan_bounds() {
+        assert!(matches!(
+            KvChunkPlan::new(0, 4096, 64, 4096, 4096),
+            Err(KvChunkPlanError::Zero("bytes_per_token"))
+        ));
+        assert!(matches!(
+            KvChunkPlan::new(200, 100, 64, 4096, 0),
+            Err(KvChunkPlanError::Zero("minimum_growth_bytes"))
+        ));
+        let plan = KvChunkPlan::new(200, 100, 64, 4096, 4096).unwrap();
+        assert_eq!(plan.reserve_bytes(), 20_480);
+        assert!(matches!(
+            plan.mapped_bytes_for_tokens(101),
+            Err(KvChunkPlanError::RequiredTokens {
+                required: 101,
+                max: 100
+            })
+        ));
+        assert!(matches!(
+            plan.growth(1, 1),
+            Err(KvChunkPlanError::InvalidMappedBytes { .. })
+        ));
+    }
+}

--- a/crates/hipfire-runtime/src/lib.rs
+++ b/crates/hipfire-runtime/src/lib.rs
@@ -35,6 +35,7 @@ pub mod eval_common;
 pub mod gguf;
 pub mod hfq;
 pub mod kv_adaptive;
+pub mod kv_backend;
 pub mod kv_mode;
 pub mod llama;
 pub mod llama_spec;

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -3471,7 +3471,12 @@ pub fn forward_scratch_embed(
 fn llama_forward_lowered_enabled() -> bool {
     use std::sync::OnceLock;
     static F: OnceLock<bool> = OnceLock::new();
-    *F.get_or_init(|| hipfire_config::developer_var("HIPFIRE_FORWARD_LOWERED").ok().as_deref() != Some("0"))
+    *F.get_or_init(|| {
+        hipfire_config::developer_var("HIPFIRE_FORWARD_LOWERED")
+            .ok()
+            .as_deref()
+            != Some("0")
+    })
 }
 
 /// KV-cache write + single-token attention, extracted verbatim from the hand
@@ -5354,6 +5359,50 @@ pub enum KvTarget<'a> {
     Multi(&'a mut Gpus),
 }
 
+/// Single source of truth for VMM K/V byte layout.
+///
+/// - `k_bytes_per_token` / `v_bytes_per_token` are **current** encoding strides
+///   (drive mapped-token capacity, growth, and live source-prefix sizing).
+/// - `k_reserve_*` describe the virtual VA arena size (static: reserve == current;
+///   adaptive may reserve at floor while current encoding is FWHT4/Q8).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct VmmKvLayout {
+    mode: KvMode,
+    v_mode: VMode,
+    n_kv_heads: usize,
+    head_dim: usize,
+    physical_cap: usize,
+    kv_dim: usize,
+    k_bytes_per_head: usize,
+    v_bytes_per_head: usize,
+    k_bytes_per_token: usize,
+    v_bytes_per_token: usize,
+    /// Virtual reserve bytes at the reserve tier (may differ from current).
+    k_reserve_bytes: usize,
+    v_reserve_bytes: usize,
+    k_reserve_elems: usize,
+    v_reserve_elems: usize,
+    /// Sign/angle table width. 0 = none (Q8). 128 = Givens or FWHT-128.
+    /// 256 = FWHT-256 (fwht3, or any FWHT+lloyd-V).
+    rotation_table_len: usize,
+    uses_fwht_signs: bool,
+}
+
+impl VmmKvLayout {
+    /// Checked live K source-prefix bytes for `n_positions` at the **current**
+    /// K stride. Independent of virtual reserve size — used by adaptive
+    /// transcode scratch sizing and map-before-read guards.
+    fn prefix_k_bytes(self, n_positions: usize) -> HipResult<usize> {
+        KvCache::checked_vmm_product("K source prefix", &[n_positions, self.k_bytes_per_token])
+    }
+
+    /// Checked live V source-prefix bytes for `n_positions` at the **current**
+    /// V stride. Independent of virtual reserve size.
+    fn prefix_v_bytes(self, n_positions: usize) -> HipResult<usize> {
+        KvCache::checked_vmm_product("V source prefix", &[n_positions, self.v_bytes_per_token])
+    }
+}
+
 impl KvCache {
     fn checked_vmm_product(label: &str, factors: &[usize]) -> HipResult<usize> {
         factors
@@ -5368,26 +5417,311 @@ impl KvCache {
         })
     }
 
+    /// Packed K bytes-per-head for Q8 / asym{2,3,4} / fwht{2,3,4}.
+    /// Asym and FWHT share storage at the same bit width; only rotation tables differ.
+    fn vmm_k_bytes_per_head(mode: KvMode, head_dim: usize) -> HipResult<usize> {
+        match mode {
+            KvMode::Q8 => {
+                if head_dim == 0 || !head_dim.is_multiple_of(32) {
+                    return Err(hip_bridge::HipError::new(
+                        0,
+                        &format!(
+                            "VMM q8 requires a non-zero head_dim divisible by 32 (got head_dim={head_dim})"
+                        ),
+                    ));
+                }
+                Self::checked_vmm_product("q8 K head stride", &[head_dim / 32, 34])
+            }
+            KvMode::Asym2 | KvMode::Fwht2 => head_dim
+                .checked_div(4)
+                .and_then(|n| n.checked_add(4))
+                .ok_or_else(|| hip_bridge::HipError::new(0, "VMM 2-bit K head stride overflowed")),
+            KvMode::Asym3 | KvMode::Fwht3 => head_dim
+                .checked_mul(3)
+                .and_then(|n| n.checked_div(8))
+                .and_then(|n| n.checked_add(4))
+                .ok_or_else(|| hip_bridge::HipError::new(0, "VMM 3-bit K head stride overflowed")),
+            KvMode::Asym4 | KvMode::Fwht4 => head_dim
+                .checked_div(2)
+                .and_then(|n| n.checked_add(4))
+                .ok_or_else(|| hip_bridge::HipError::new(0, "VMM 4-bit K head stride overflowed")),
+            KvMode::Asym3Auto => Err(hip_bridge::HipError::new(
+                0,
+                "KV mode Asym3Auto must be resolved before VMM layout",
+            )),
+        }
+    }
+
+    /// Packed V bytes-per-head for Q8 / Lloyd{2,3,4}.
+    fn vmm_v_bytes_per_head(v_mode: VMode, head_dim: usize) -> HipResult<usize> {
+        match v_mode {
+            VMode::Q8 => {
+                if head_dim == 0 || !head_dim.is_multiple_of(32) {
+                    return Err(hip_bridge::HipError::new(
+                        0,
+                        &format!(
+                            "VMM Q8-V requires a non-zero head_dim divisible by 32 (got head_dim={head_dim})"
+                        ),
+                    ));
+                }
+                Self::checked_vmm_product("q8 V head stride", &[head_dim / 32, 34])
+            }
+            VMode::Lloyd2 | VMode::Lloyd3 | VMode::Lloyd4 => {
+                let bits = v_mode.bits() as usize;
+                head_dim
+                    .checked_mul(bits)
+                    .and_then(|n| n.checked_div(8))
+                    .and_then(|n| n.checked_add(4))
+                    .ok_or_else(|| {
+                        hip_bridge::HipError::new(
+                            0,
+                            &format!("VMM lloyd{bits} V head stride overflowed"),
+                        )
+                    })
+            }
+        }
+    }
+
+    /// Geometry gates shared by every static VMM mode (and legal Lloyd-V pairs).
+    fn validate_vmm_static_geometry(
+        mode: KvMode,
+        v_mode: VMode,
+        n_kv_heads: usize,
+        head_dim: usize,
+    ) -> HipResult<()> {
+        if n_kv_heads == 0 {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!("VMM {mode:?} requires n_kv_heads>0 (got 0)"),
+            ));
+        }
+        match mode {
+            KvMode::Q8 => {
+                if head_dim == 0 || !head_dim.is_multiple_of(32) {
+                    return Err(hip_bridge::HipError::new(
+                        0,
+                        &format!(
+                            "VMM q8 requires n_kv_heads>0 and a non-zero head_dim divisible by 32 (got n_kv_heads={n_kv_heads}, head_dim={head_dim})"
+                        ),
+                    ));
+                }
+                if !matches!(v_mode, VMode::Q8) {
+                    return Err(hip_bridge::HipError::new(
+                        0,
+                        "VMM q8 only supports VMode::Q8 (lloyd-V requires an FWHT K mode)",
+                    ));
+                }
+            }
+            KvMode::Asym2 | KvMode::Asym3 | KvMode::Asym4 => {
+                let ok_hd = match mode {
+                    KvMode::Asym3 => head_dim == 256,
+                    _ => head_dim == 128 || head_dim == 256,
+                };
+                if !ok_hd {
+                    return Err(hip_bridge::HipError::new(
+                        0,
+                        &format!(
+                            "VMM {mode:?} requires head_dim={} (got {head_dim})",
+                            if matches!(mode, KvMode::Asym3) {
+                                "256"
+                            } else {
+                                "128 or 256"
+                            }
+                        ),
+                    ));
+                }
+                if !matches!(v_mode, VMode::Q8) {
+                    return Err(hip_bridge::HipError::new(
+                        0,
+                        &format!(
+                            "VMM {mode:?} only supports VMode::Q8 (lloyd-V requires an FWHT K mode)"
+                        ),
+                    ));
+                }
+            }
+            KvMode::Fwht2 | KvMode::Fwht3 | KvMode::Fwht4 => match v_mode {
+                VMode::Q8 => {
+                    let ok_hd = match mode {
+                        KvMode::Fwht3 => head_dim == 256,
+                        _ => head_dim == 128 || head_dim == 256,
+                    };
+                    if !ok_hd {
+                        return Err(hip_bridge::HipError::new(
+                            0,
+                            &format!(
+                                "VMM {mode:?} requires head_dim={} (got {head_dim})",
+                                if matches!(mode, KvMode::Fwht3) {
+                                    "256"
+                                } else {
+                                    "128 or 256"
+                                }
+                            ),
+                        ));
+                    }
+                }
+                VMode::Lloyd2 | VMode::Lloyd3 | VMode::Lloyd4 => {
+                    if head_dim != 256 {
+                        return Err(hip_bridge::HipError::new(
+                            0,
+                            &format!(
+                                "VMM lloyd-V requires head_dim=256 with FWHT K (got mode={mode:?}, head_dim={head_dim})"
+                            ),
+                        ));
+                    }
+                }
+            },
+            KvMode::Asym3Auto => {
+                return Err(hip_bridge::HipError::new(
+                    0,
+                    "KV mode Asym3Auto must be resolved before VMM layout",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Build a static VMM layout (reserve tier == current tier).
+    fn vmm_static_layout(
+        mode: KvMode,
+        v_mode: VMode,
+        n_kv_heads: usize,
+        head_dim: usize,
+        physical_cap: usize,
+    ) -> HipResult<VmmKvLayout> {
+        Self::validate_vmm_static_geometry(mode, v_mode, n_kv_heads, head_dim)?;
+        if physical_cap == 0 {
+            return Err(hip_bridge::HipError::new(0, "VMM physical_cap must be > 0"));
+        }
+        let kv_dim = Self::checked_vmm_product("logical", &[n_kv_heads, head_dim])?;
+        let k_bytes_per_head = Self::vmm_k_bytes_per_head(mode, head_dim)?;
+        let v_bytes_per_head = Self::vmm_v_bytes_per_head(v_mode, head_dim)?;
+        let k_bytes_per_token =
+            Self::checked_vmm_product("K token stride", &[n_kv_heads, k_bytes_per_head])?;
+        let v_bytes_per_token =
+            Self::checked_vmm_product("V token stride", &[n_kv_heads, v_bytes_per_head])?;
+        let k_reserve_bytes =
+            Self::checked_vmm_product("K reserve", &[physical_cap, k_bytes_per_token])?;
+        let v_reserve_bytes =
+            Self::checked_vmm_product("V reserve", &[physical_cap, v_bytes_per_token])?;
+        let rotation_table_len = match mode {
+            KvMode::Q8 => 0,
+            KvMode::Asym2 | KvMode::Asym3 | KvMode::Asym4 => head_dim / 2,
+            KvMode::Fwht3 => 256,
+            KvMode::Fwht2 | KvMode::Fwht4 => {
+                // Q8-V uses 128-wide signs; lloyd-V needs 256-wide up front so
+                // constructors never replace owners after publish.
+                if matches!(v_mode, VMode::Q8) {
+                    128
+                } else {
+                    256
+                }
+            }
+            KvMode::Asym3Auto => 0,
+        };
+        let uses_fwht_signs = matches!(mode, KvMode::Fwht2 | KvMode::Fwht3 | KvMode::Fwht4);
+        Ok(VmmKvLayout {
+            mode,
+            v_mode,
+            n_kv_heads,
+            head_dim,
+            physical_cap,
+            kv_dim,
+            k_bytes_per_head,
+            v_bytes_per_head,
+            k_bytes_per_token,
+            v_bytes_per_token,
+            k_reserve_bytes,
+            v_reserve_bytes,
+            k_reserve_elems: Self::bytes_to_f32_elems("K reserve", k_reserve_bytes)?,
+            v_reserve_elems: Self::bytes_to_f32_elems("V reserve", v_reserve_bytes)?,
+            rotation_table_len,
+            uses_fwht_signs,
+        })
+    }
+
+    /// Floor-reserved layout: current encoding strides may differ from reserve.
+    /// Adaptive uses this with start FWHT4/Q8 and floor reserve bph/v_mode.
+    fn vmm_layout_with_reserve(
+        mode: KvMode,
+        v_mode: VMode,
+        n_kv_heads: usize,
+        head_dim: usize,
+        physical_cap: usize,
+        reserve_k_bytes_per_head: usize,
+        reserve_v_mode: VMode,
+    ) -> HipResult<VmmKvLayout> {
+        Self::validate_vmm_static_geometry(mode, v_mode, n_kv_heads, head_dim)?;
+        if physical_cap == 0 {
+            return Err(hip_bridge::HipError::new(0, "VMM physical_cap must be > 0"));
+        }
+        if reserve_k_bytes_per_head == 0 {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "VMM reserve K bytes-per-head must be > 0",
+            ));
+        }
+        let kv_dim = Self::checked_vmm_product("logical", &[n_kv_heads, head_dim])?;
+        let k_bytes_per_head = Self::vmm_k_bytes_per_head(mode, head_dim)?;
+        let v_bytes_per_head = Self::vmm_v_bytes_per_head(v_mode, head_dim)?;
+        let reserve_v_bph = Self::vmm_v_bytes_per_head(reserve_v_mode, head_dim)?;
+        let k_bytes_per_token =
+            Self::checked_vmm_product("K token stride", &[n_kv_heads, k_bytes_per_head])?;
+        let v_bytes_per_token =
+            Self::checked_vmm_product("V token stride", &[n_kv_heads, v_bytes_per_head])?;
+        let k_reserve_token =
+            Self::checked_vmm_product("K reserve token", &[n_kv_heads, reserve_k_bytes_per_head])?;
+        let v_reserve_token =
+            Self::checked_vmm_product("V reserve token", &[n_kv_heads, reserve_v_bph])?;
+        let k_reserve_bytes =
+            Self::checked_vmm_product("K reserve", &[physical_cap, k_reserve_token])?;
+        let v_reserve_bytes =
+            Self::checked_vmm_product("V reserve", &[physical_cap, v_reserve_token])?;
+        // Adaptive / lloyd paths need 256-wide signs (q8→lloyd, optional fwht4→fwht3).
+        let rotation_table_len = if matches!(mode, KvMode::Fwht2 | KvMode::Fwht3 | KvMode::Fwht4)
+            || !matches!(reserve_v_mode, VMode::Q8)
+            || !matches!(v_mode, VMode::Q8)
+        {
+            256
+        } else if matches!(mode, KvMode::Asym2 | KvMode::Asym3 | KvMode::Asym4) {
+            head_dim / 2
+        } else {
+            0
+        };
+        let uses_fwht_signs = matches!(mode, KvMode::Fwht2 | KvMode::Fwht3 | KvMode::Fwht4)
+            || !matches!(reserve_v_mode, VMode::Q8);
+        Ok(VmmKvLayout {
+            mode,
+            v_mode,
+            n_kv_heads,
+            head_dim,
+            physical_cap,
+            kv_dim,
+            k_bytes_per_head,
+            v_bytes_per_head,
+            k_bytes_per_token,
+            v_bytes_per_token,
+            k_reserve_bytes,
+            v_reserve_bytes,
+            k_reserve_elems: Self::bytes_to_f32_elems("K reserve", k_reserve_bytes)?,
+            v_reserve_elems: Self::bytes_to_f32_elems("V reserve", v_reserve_bytes)?,
+            rotation_table_len,
+            uses_fwht_signs,
+        })
+    }
+
+    /// Back-compat wrappers used by older call sites / tests.
     fn q8_vmm_layout(
         n_kv_heads: usize,
         head_dim: usize,
         physical_cap: usize,
     ) -> HipResult<(usize, usize, usize)> {
-        if n_kv_heads == 0 || head_dim == 0 || !head_dim.is_multiple_of(32) {
-            return Err(hip_bridge::HipError::new(
-                0,
-                &format!(
-                    "VMM q8 requires n_kv_heads>0 and a non-zero head_dim divisible by 32 (got n_kv_heads={n_kv_heads}, head_dim={head_dim})"
-                ),
-            ));
-        }
-        let kv_dim = Self::checked_vmm_product("q8 logical", &[n_kv_heads, head_dim])?;
-        let bytes_per_token =
-            Self::checked_vmm_product("q8 token stride", &[n_kv_heads, head_dim / 32, 34])?;
-        let cache_bytes =
-            Self::checked_vmm_product("q8 reserve", &[physical_cap, bytes_per_token])?;
-        let cache_elems = Self::bytes_to_f32_elems("q8 reserve", cache_bytes)?;
-        Ok((kv_dim, cache_elems, bytes_per_token))
+        let layout =
+            Self::vmm_static_layout(KvMode::Q8, VMode::Q8, n_kv_heads, head_dim, physical_cap)?;
+        Ok((
+            layout.kv_dim,
+            layout.k_reserve_elems,
+            layout.k_bytes_per_token,
+        ))
     }
 
     fn asym3_vmm_layout(
@@ -5395,37 +5729,48 @@ impl KvCache {
         head_dim: usize,
         physical_cap: usize,
     ) -> HipResult<(usize, usize, usize, usize, usize)> {
-        if n_kv_heads == 0 || head_dim != 256 {
-            return Err(hip_bridge::HipError::new(
-                0,
-                &format!(
-                    "VMM asym3 requires n_kv_heads>0 and head_dim=256 (got n_kv_heads={n_kv_heads}, head_dim={head_dim})"
-                ),
-            ));
-        }
-        let kv_dim = Self::checked_vmm_product("asym3 logical", &[n_kv_heads, head_dim])?;
-        let packed_k = head_dim
-            .checked_mul(3)
-            .and_then(|value| value.checked_div(8))
-            .and_then(|value| value.checked_add(4))
-            .ok_or_else(|| hip_bridge::HipError::new(0, "VMM asym3 K stride overflowed"))?;
-        let v_bytes_per_head =
-            Self::checked_vmm_product("asym3 V head stride", &[head_dim / 32, 34])?;
-        let k_bytes_per_token =
-            Self::checked_vmm_product("asym3 K token stride", &[n_kv_heads, packed_k])?;
-        let v_bytes_per_token =
-            Self::checked_vmm_product("asym3 V token stride", &[n_kv_heads, v_bytes_per_head])?;
-        let k_bytes =
-            Self::checked_vmm_product("asym3 K reserve", &[physical_cap, k_bytes_per_token])?;
-        let v_bytes =
-            Self::checked_vmm_product("asym3 V reserve", &[physical_cap, v_bytes_per_token])?;
+        let layout =
+            Self::vmm_static_layout(KvMode::Asym3, VMode::Q8, n_kv_heads, head_dim, physical_cap)?;
         Ok((
-            kv_dim,
-            Self::bytes_to_f32_elems("asym3 K reserve", k_bytes)?,
-            Self::bytes_to_f32_elems("asym3 V reserve", v_bytes)?,
-            packed_k,
-            v_bytes_per_head,
+            layout.kv_dim,
+            layout.k_reserve_elems,
+            layout.v_reserve_elems,
+            layout.k_bytes_per_head,
+            layout.v_bytes_per_head,
         ))
+    }
+
+    /// FWHT3 reuses the Asym3 packed-K / Q8-V byte layout; only the rotation
+    /// tables and `quant_fwht` flag differ from Asym3 VMM.
+    fn fwht3_vmm_layout(
+        n_kv_heads: usize,
+        head_dim: usize,
+        physical_cap: usize,
+    ) -> HipResult<(usize, usize, usize, usize, usize)> {
+        let layout =
+            Self::vmm_static_layout(KvMode::Fwht3, VMode::Q8, n_kv_heads, head_dim, physical_cap)?;
+        Ok((
+            layout.kv_dim,
+            layout.k_reserve_elems,
+            layout.v_reserve_elems,
+            layout.k_bytes_per_head,
+            layout.v_bytes_per_head,
+        ))
+    }
+
+    /// Flag bundle applied by the unified static VMM constructor.
+    /// Returns (quant_q8, quant_asym4, quant_asym3, quant_asym2, quant_fwht).
+    fn vmm_mode_flags(mode: KvMode) -> (bool, bool, bool, bool, bool) {
+        match mode {
+            KvMode::Q8 => (true, false, false, false, false),
+            KvMode::Asym2 => (false, false, false, true, false),
+            KvMode::Asym3 => (false, false, true, false, false),
+            KvMode::Asym4 => (false, true, false, false, false),
+            KvMode::Fwht2 => (false, false, false, true, true),
+            KvMode::Fwht3 => (false, false, true, false, true),
+            KvMode::Fwht4 => (false, true, false, false, true),
+            KvMode::Asym3Auto => (false, false, false, false, false),
+        }
     }
 
     /// Validate a backend request without touching GPU memory.
@@ -5489,16 +5834,29 @@ impl KvCache {
             ));
         }
         match mode {
-            KvMode::Q8 => {
-                Self::q8_vmm_layout(dims.n_kv_heads, dims.head_dim, physical_cap)?;
-            }
-            KvMode::Asym3 => {
-                Self::asym3_vmm_layout(dims.n_kv_heads, dims.head_dim, physical_cap)?;
+            KvMode::Q8
+            | KvMode::Asym2
+            | KvMode::Asym3
+            | KvMode::Asym4
+            | KvMode::Fwht2
+            | KvMode::Fwht3
+            | KvMode::Fwht4 => {
+                // Default static V is Q8; Lloyd-V is validated when a constructor
+                // is invoked with an explicit v_mode.
+                Self::vmm_static_layout(
+                    mode,
+                    VMode::Q8,
+                    dims.n_kv_heads,
+                    dims.head_dim,
+                    physical_cap,
+                )?;
             }
             other => {
                 return Err(hip_bridge::HipError::new(
                     0,
-                    &format!("KV backend 'vmm' supports kv_mode=q8|asym3 only (got {other:?})"),
+                    &format!(
+                        "KV backend 'vmm' supports kv_mode=q8|asym2|asym3|asym4|fwht2|fwht3|fwht4 only (got {other:?})"
+                    ),
                 ));
             }
         }
@@ -5570,22 +5928,24 @@ impl KvCache {
         let physical_cap = dims
             .physical_cap
             .expect("VMM physical capacity validated before dispatch");
+        // Static path defaults V to Q8. Carrier may call
+        // `new_gpu_vmm_capped_filtered` directly with Lloyd-V for FWHT-K.
         match mode {
-            KvMode::Q8 => Self::new_gpu_q8_vmm_capped_filtered(
+            KvMode::Q8
+            | KvMode::Asym2
+            | KvMode::Asym3
+            | KvMode::Asym4
+            | KvMode::Fwht2
+            | KvMode::Fwht3
+            | KvMode::Fwht4 => Self::new_gpu_vmm_capped_filtered(
                 gpu,
                 is_kv_layer,
                 dims.n_kv_heads,
                 dims.head_dim,
                 dims.max_seq,
                 physical_cap,
-            ),
-            KvMode::Asym3 => Self::new_gpu_asym3_vmm_capped_filtered(
-                gpu,
-                is_kv_layer,
-                dims.n_kv_heads,
-                dims.head_dim,
-                dims.max_seq,
-                physical_cap,
+                mode,
+                VMode::Q8,
             ),
             other => unreachable!("VMM mode {other:?} validated before dispatch"),
         }
@@ -5886,41 +6246,52 @@ impl KvCache {
         Ok((k_gpu, v_gpu))
     }
 
-    fn vmm_bytes_per_token(&self) -> HipResult<(usize, usize)> {
-        if self.head_dim == 0 || !self.head_dim.is_multiple_of(32) {
-            return Err(hip_bridge::HipError::new(
-                0,
-                &format!(
-                    "VMM KV requires a non-zero head_dim divisible by 32 (got {})",
-                    self.head_dim
-                ),
-            ));
-        }
-        let q8 = self
-            .n_kv_heads
-            .checked_mul(self.head_dim / 32)
-            .and_then(|n| n.checked_mul(34))
-            .ok_or_else(|| hip_bridge::HipError::new(0, "VMM Q8 byte stride overflowed"))?;
+    /// Resolve the current K `KvMode` from live cache flags.
+    fn current_kv_mode(&self) -> HipResult<KvMode> {
         if self.quant_q8 {
-            return Ok((q8, q8));
+            return Ok(KvMode::Q8);
         }
-        if self.quant_asym3 && !self.quant_fwht && self.v_mode == VMode::Q8 {
-            let k_bytes_per_head = self
-                .head_dim
-                .checked_mul(3)
-                .and_then(|n| n.checked_div(8))
-                .and_then(|n| n.checked_add(4))
-                .ok_or_else(|| hip_bridge::HipError::new(0, "VMM Asym3 head stride overflowed"))?;
-            let k = self
-                .n_kv_heads
-                .checked_mul(k_bytes_per_head)
-                .ok_or_else(|| hip_bridge::HipError::new(0, "VMM Asym3 byte stride overflowed"))?;
-            return Ok((k, q8));
+        if self.quant_asym4 {
+            return Ok(if self.quant_fwht {
+                KvMode::Fwht4
+            } else {
+                KvMode::Asym4
+            });
+        }
+        if self.quant_asym3 {
+            return Ok(if self.quant_fwht {
+                KvMode::Fwht3
+            } else {
+                KvMode::Asym3
+            });
+        }
+        if self.quant_asym2 {
+            return Ok(if self.quant_fwht {
+                KvMode::Fwht2
+            } else {
+                KvMode::Asym2
+            });
         }
         Err(hip_bridge::HipError::new(
             0,
-            "VMM KV cache encoding changed after allocation",
+            "VMM KV cache encoding flags are not a recognized static mode",
         ))
+    }
+
+    /// Current K/V bytes-per-token from live flags / V mode.
+    /// Independent K and V strides — capacity is always min-of-two.
+    fn vmm_bytes_per_token(&self) -> HipResult<(usize, usize)> {
+        if self.n_kv_heads == 0 {
+            return Err(hip_bridge::HipError::new(0, "VMM KV requires n_kv_heads>0"));
+        }
+        let mode = self.current_kv_mode()?;
+        // Geometry for the live encoding; lloyd-V only legal on FWHT-K.
+        Self::validate_vmm_static_geometry(mode, self.v_mode, self.n_kv_heads, self.head_dim)?;
+        let k_bph = Self::vmm_k_bytes_per_head(mode, self.head_dim)?;
+        let v_bph = Self::vmm_v_bytes_per_head(self.v_mode, self.head_dim)?;
+        let k = Self::checked_vmm_product("K token stride", &[self.n_kv_heads, k_bph])?;
+        let v = Self::checked_vmm_product("V token stride", &[self.n_kv_heads, v_bph])?;
+        Ok((k, v))
     }
 
     pub fn uses_vmm_backend(&self) -> bool {
@@ -6013,6 +6384,12 @@ impl KvCache {
         Ok(())
     }
 
+    /// Grow VMM tensors for one side (K or V).
+    ///
+    /// `bytes_per_token` is the **current** encoding stride. `physical_cap` is
+    /// the constructor token horizon. Per-tensor max tokens is
+    /// `min(physical_cap, reserve_bytes / current_stride)` so adaptive
+    /// floor-reserved arenas never plan growth past the stable VA.
     fn grow_vmm_tensors(
         gpu: &mut Gpu,
         tensors: &mut [GpuTensor],
@@ -6020,6 +6397,12 @@ impl KvCache {
         physical_cap: usize,
         required_tokens: usize,
     ) -> HipResult<usize> {
+        if bytes_per_token == 0 {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "VMM growth requires a non-zero current byte stride",
+            ));
+        }
         let mut grown = 0usize;
         let device_id = gpu.device_id;
         let minimum_growth_bytes = DEFAULT_VMM_PHYSICAL_CHUNK_BYTES;
@@ -6039,9 +6422,26 @@ impl KvCache {
             let granularity = gpu.vmm_granularity(tensor).ok_or_else(|| {
                 hip_bridge::HipError::new(0, "VMM KV tensor has no allocation granularity")
             })?;
+            // Full reserved VA size (shape × dtype), independent of mapped prefix.
+            let reserve_bytes = tensor.byte_size();
+            let side_cap = (reserve_bytes / bytes_per_token).min(physical_cap);
+            if side_cap == 0 {
+                return Err(hip_bridge::HipError::new(
+                    0,
+                    "VMM KV reserve is smaller than one token at the current stride",
+                ));
+            }
+            if required_tokens > side_cap {
+                return Err(hip_bridge::HipError::new(
+                    0,
+                    &format!(
+                        "VMM KV current-stride capacity is {side_cap} tokens but the operation requires {required_tokens}"
+                    ),
+                ));
+            }
             let plan = KvChunkPlan::new(
                 bytes_per_token,
-                physical_cap,
+                side_cap,
                 DEFAULT_KV_CHUNK_TOKENS,
                 granularity,
                 minimum_growth_bytes,
@@ -6057,6 +6457,7 @@ impl KvCache {
                         "VMM KV growth requested during graph capture",
                     ));
                 }
+                // Map before any subsequent write; owners stay at the same VA.
                 gpu.grow_vmm_tensor(tensor, growth.size_bytes, &[device_id])?;
                 grown += 1;
             }
@@ -6064,6 +6465,9 @@ impl KvCache {
         Ok(grown)
     }
 
+    /// Ensure both K and V mapped prefixes cover `required_tokens` at the
+    /// **current** strides. Growth is independent per side and completes before
+    /// the caller may write. Never replaces VMM owners.
     pub fn ensure_mapped_capacity(
         &mut self,
         gpu: &mut Gpu,
@@ -6087,6 +6491,7 @@ impl KvCache {
         let (k_bytes_per_token, v_bytes_per_token) = self.vmm_bytes_per_token()?;
         // Growth is monotonic: if a later map fails, the next call keeps the
         // completed prefixes and fills the lagging tensors before the final guard.
+        // K and V are grown independently at their current strides.
         Self::grow_vmm_tensors(
             gpu,
             &mut self.k_gpu,
@@ -6317,6 +6722,14 @@ impl KvCache {
         v_floor: VMode,
         k_floor_bph: usize,
     ) -> HipResult<()> {
+        // VMM owners are never replaced after publication. Adaptive VMM must be
+        // constructed via `new_gpu_vmm_adaptive_filtered` with floor reserve.
+        if self.uses_vmm_backend() {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "set_adaptive_floor_alloc refuses VMM owners; construct adaptive VMM with floor reserve up front",
+            ));
+        }
         // Mirror the set_v_mode_realloc guard: lloyd-V is 256-wide and requires
         // an FWHT K mode + head_dim == 256.
         assert!(
@@ -6375,6 +6788,20 @@ impl KvCache {
             Self::resize_real_tensors_zeroed(gpu, &mut self.k_gpu, k_elems)?;
         }
         Ok(())
+    }
+
+    /// Restore cache mode flags to the adaptive start tier (K=fwht4, V=q8)
+    /// without touching buffer owners. Used by atomic controller+cache reset.
+    pub fn restore_adaptive_start_flags(&mut self) {
+        self.quant_q8 = false;
+        self.quant_int8 = false;
+        self.quant_hfq4 = false;
+        self.quant_asym4 = true;
+        self.quant_asym3 = false;
+        self.quant_asym2 = false;
+        self.quant_fwht = true;
+        self.v_mode = VMode::Q8;
+        self.quantized = true;
     }
 
     /// Adaptive-KV: re-quantize the EXISTING V cache (all written positions of
@@ -6466,21 +6893,48 @@ impl KvCache {
             Op::Down(_, _) => (None, None),
         };
 
-        // 1-layer scratch sized to the SOURCE layer's full element count (the
-        // source record is the larger one). We copy layer→scratch (d2d) then
-        // transcode scratch→layer (non-aliasing). Crash-safe (a HIP error never
-        // half-writes the live layer) and overlap-safe (the q8→lloyd4 kernel is
-        // NOT true-in-place safe — see its header). Sized once, reused per layer.
-        let src_elems = self
-            .v_gpu
-            .iter()
-            .map(|t| t.numel())
-            .filter(|&n| n > 1)
-            .max();
+        // Map the live prefix at the CURRENT V stride before any read/write.
+        // Floor-reserved VMM VA may be larger than the mapped prefix — never
+        // size or copy from the full virtual reserve.
+        self.ensure_mapped_capacity(gpu, n_positions)?;
+        let (cur_k_bpt, cur_v_bpt) = if self.uses_vmm_backend() {
+            self.vmm_bytes_per_token()?
+        } else {
+            // Contiguous: full buffer is mapped; keep prior full-layer scratch size.
+            (0, 0)
+        };
+        let prefix_v_bytes = if self.uses_vmm_backend() {
+            Self::checked_vmm_product("V source prefix", &[n_positions, cur_v_bpt])?
+        } else {
+            0
+        };
+        let prefix_v_elems = if self.uses_vmm_backend() {
+            Self::bytes_to_f32_elems("V source prefix", prefix_v_bytes)?
+        } else {
+            0
+        };
+
+        // 1-layer scratch: VMM uses live source-prefix elems only; contiguous
+        // keeps full-layer elems (prior behavior). Copy layer→scratch then
+        // transcode scratch→layer (non-aliasing).
+        let src_elems = if self.uses_vmm_backend() {
+            if prefix_v_elems > 0 {
+                Some(prefix_v_elems)
+            } else {
+                None
+            }
+        } else {
+            self.v_gpu
+                .iter()
+                .map(|t| t.numel())
+                .filter(|&n| n > 1)
+                .max()
+        };
         let scratch = match src_elems {
             Some(n) => Some(gpu.zeros(&[n], DType::F32)?),
             None => None,
         };
+        let _ = cur_k_bpt; // K stride unused on V step
 
         // Free the scratch on EVERY exit path (GpuTensor has no Drop): capture
         // the first error, break, free, then propagate — a HIP failure mid-pass
@@ -6492,9 +6946,13 @@ impl KvCache {
                 continue;
             }
             let scratch = scratch.as_ref().unwrap();
-            // Copy the live layer into scratch (device-to-device), then read
-            // from scratch and write the compacted record back into the layer.
-            let nbytes = t.byte_size();
+            // Copy the live source prefix into scratch (device-to-device), then
+            // read from scratch and write the compacted record back into the layer.
+            let nbytes = if self.uses_vmm_backend() {
+                prefix_v_bytes
+            } else {
+                t.byte_size()
+            };
             pending = gpu.hip.memcpy_dtod(&scratch.buf, &t.buf, nbytes);
             if pending.is_err() {
                 break;
@@ -6645,16 +7103,41 @@ impl KvCache {
             None
         };
 
-        // 1-layer scratch sized to the max real K layer's element count (the K
-        // buffer is floor-sized; the live fwht4 records occupy a prefix of it).
-        // Copy layer→scratch (d2d) then transcode scratch→layer (non-aliasing,
-        // crash-safe). Sized once, reused per layer.
-        let src_elems = self
-            .k_gpu
-            .iter()
-            .map(|t| t.numel())
-            .filter(|&n| n > 1)
-            .max();
+        // Map the live prefix at the CURRENT K stride before any read/write.
+        // Floor-reserved VMM VA may be larger than the mapped prefix — never
+        // size or copy from the full virtual reserve.
+        self.ensure_mapped_capacity(gpu, n_positions)?;
+        let (cur_k_bpt, _cur_v_bpt) = if self.uses_vmm_backend() {
+            self.vmm_bytes_per_token()?
+        } else {
+            (0, 0)
+        };
+        let prefix_k_bytes = if self.uses_vmm_backend() {
+            Self::checked_vmm_product("K source prefix", &[n_positions, cur_k_bpt])?
+        } else {
+            0
+        };
+        let prefix_k_elems = if self.uses_vmm_backend() {
+            Self::bytes_to_f32_elems("K source prefix", prefix_k_bytes)?
+        } else {
+            0
+        };
+
+        // 1-layer scratch: VMM uses live source-prefix elems only; contiguous
+        // keeps full-layer elems (prior behavior).
+        let src_elems = if self.uses_vmm_backend() {
+            if prefix_k_elems > 0 {
+                Some(prefix_k_elems)
+            } else {
+                None
+            }
+        } else {
+            self.k_gpu
+                .iter()
+                .map(|t| t.numel())
+                .filter(|&n| n > 1)
+                .max()
+        };
         let scratch = match src_elems {
             Some(n) => Some(gpu.zeros(&[n], DType::F32)?),
             None => None,
@@ -6669,7 +7152,11 @@ impl KvCache {
                 continue;
             }
             let scratch = scratch.as_ref().unwrap();
-            let nbytes = t.byte_size();
+            let nbytes = if self.uses_vmm_backend() {
+                prefix_k_bytes
+            } else {
+                t.byte_size()
+            };
             pending = gpu.hip.memcpy_dtod(&scratch.buf, &t.buf, nbytes);
             if pending.is_err() {
                 break;
@@ -6708,6 +7195,143 @@ impl KvCache {
         }
         gpu.invalidate_for_kv_mode_switch();
         Ok(())
+    }
+
+    /// Adaptive VMM constructor: reserve at K/V floors, start encoding FWHT4/Q8.
+    /// One stable K and one stable V owner per real layer for the load lifetime.
+    /// Built on `vmm_layout_with_reserve`; never replaces owners after publish.
+    pub fn new_gpu_vmm_adaptive_filtered(
+        gpu: &mut Gpu,
+        is_kv_layer: &[bool],
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq: usize,
+        k_floor_bph: usize,
+        v_floor: VMode,
+    ) -> HipResult<Self> {
+        if max_seq == 0 {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "adaptive VMM requires max_seq > 0",
+            ));
+        }
+        if !is_kv_layer.iter().any(|is_kv| *is_kv) {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "adaptive VMM requires at least one KV-carrying layer",
+            ));
+        }
+        if matches!(v_floor, VMode::Q8) {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "adaptive VMM V floor must be a lloyd tier (got Q8)",
+            ));
+        }
+        if head_dim != 256 {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!("adaptive VMM requires head_dim=256 (got {head_dim})"),
+            ));
+        }
+        let layout = Self::vmm_layout_with_reserve(
+            KvMode::Fwht4,
+            VMode::Q8,
+            n_kv_heads,
+            head_dim,
+            max_seq,
+            k_floor_bph,
+            v_floor,
+        )?;
+        let (mut k_gpu, mut v_gpu) = Self::alloc_k_v_vmm_filtered(
+            gpu,
+            layout.k_reserve_elems,
+            layout.v_reserve_elems,
+            is_kv_layer,
+        )?;
+
+        // Adaptive always needs 256-wide FWHT signs (q8→lloyd and optional fwht4→fwht3).
+        let n = layout.rotation_table_len.max(256);
+        let s1_vals = Self::gen_fwht_signs(42, n);
+        let s2_vals = Self::gen_fwht_signs(1042, n);
+        let s1_bytes: Vec<u8> = s1_vals.iter().flat_map(|v| v.to_ne_bytes()).collect();
+        let s2_bytes: Vec<u8> = s2_vals.iter().flat_map(|v| v.to_ne_bytes()).collect();
+        let tables = (|| -> HipResult<(GpuTensor, GpuTensor)> {
+            let s1 = gpu.alloc_tensor(&[n], DType::F32)?;
+            let s2 = match gpu.alloc_tensor(&[n], DType::F32) {
+                Ok(s2) => s2,
+                Err(err) => {
+                    let _ = gpu.free_tensor(s1);
+                    return Err(err);
+                }
+            };
+            if let Err(err) = gpu.hip.memcpy_htod(&s1.buf, &s1_bytes) {
+                let _ = gpu.free_tensor(s1);
+                let _ = gpu.free_tensor(s2);
+                return Err(err);
+            }
+            if let Err(err) = gpu.hip.memcpy_htod(&s2.buf, &s2_bytes) {
+                let _ = gpu.free_tensor(s1);
+                let _ = gpu.free_tensor(s2);
+                return Err(err);
+            }
+            Ok((s1, s2))
+        })();
+        let (s1, s2) = match tables {
+            Ok(pair) => pair,
+            Err(err) => {
+                for tensor in k_gpu.drain(..).chain(v_gpu.drain(..)) {
+                    let _ = gpu.free_tensor(tensor);
+                }
+                return Err(err);
+            }
+        };
+
+        let mut cache = Self {
+            k_gpu,
+            v_gpu,
+            k_scales: vec![],
+            v_scales: vec![],
+            kv_dim: layout.kv_dim,
+            max_seq,
+            physical_cap: layout.physical_cap,
+            n_kv_heads,
+            head_dim,
+            quantized: true,
+            quant_q8: false,
+            quant_int8: false,
+            quant_hfq4: false,
+            quant_asym4: true, // FWHT4 start
+            quant_asym3: false,
+            quant_asym2: false,
+            quant_fwht: true,
+            boundary_layers: 0,
+            givens_cos: Some(s1),
+            givens_sin: Some(s2),
+            layer_is_boundary: vec![],
+            compact_offset: 0,
+            v_mode: VMode::Q8, // start tier
+        };
+        if let Err(err) = cache.ensure_mapped_capacity(gpu, 1) {
+            let _ = cache.free_gpu(gpu);
+            return Err(err);
+        }
+        let n_kv = is_kv_layer.iter().filter(|is_kv| **is_kv).count();
+        let mapped = match cache.mapped_token_capacity() {
+            Ok(capacity) => capacity.unwrap_or(0),
+            Err(err) => {
+                let _ = cache.free_gpu(gpu);
+                return Err(err);
+            }
+        };
+        eprintln!(
+            "KV cache: adaptive vmm ({n_kv}/{} layers; start FWHT4/Q8; K floor {}B/head V floor {:?}; reserve_k={}B reserve_v={}B; mapped_prefix={mapped} / max_seq={max_seq})",
+            is_kv_layer.len(),
+            k_floor_bph,
+            v_floor,
+            layout.k_reserve_bytes,
+            layout.v_reserve_bytes,
+        );
+        Ok(cache)
     }
 
     /// Q8_0 KV cache that skips allocation for layers flagged as non-KV.
@@ -6784,8 +7408,150 @@ impl KvCache {
         })
     }
 
-    /// VMM-backed Q8 cache for Qwen3.5 hybrid stacks. Virtual tensors reserve
-    /// `physical_cap`, while only a page-aligned token chunk is mapped initially.
+    /// Unified static VMM constructor for every legal (K mode × V mode) pair.
+    ///
+    /// Reserves stable K/V VAs from [`vmm_static_layout`], maps an initial
+    /// prefix, and never replaces owners afterward. Lloyd-V is accepted only
+    /// with FWHT-K and head_dim=256 (validated by the layout table).
+    pub fn new_gpu_vmm_capped_filtered(
+        gpu: &mut Gpu,
+        is_kv_layer: &[bool],
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+        physical_cap: usize,
+        mode: KvMode,
+        v_mode: VMode,
+    ) -> HipResult<Self> {
+        if physical_cap == 0 || physical_cap > max_seq_len {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "VMM {mode:?} physical_cap must be in 1..=max_seq_len (got physical_cap={physical_cap}, max_seq_len={max_seq_len})"
+                ),
+            ));
+        }
+        if !is_kv_layer.iter().any(|is_kv| *is_kv) {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!("VMM {mode:?} requires at least one KV-carrying layer"),
+            ));
+        }
+        let layout = Self::vmm_static_layout(mode, v_mode, n_kv_heads, head_dim, physical_cap)?;
+        let (mut k_gpu, mut v_gpu) = Self::alloc_k_v_vmm_filtered(
+            gpu,
+            layout.k_reserve_elems,
+            layout.v_reserve_elems,
+            is_kv_layer,
+        )?;
+
+        // Optional rotation tables (Givens angles or FWHT signs). Built before
+        // the cache is published so a table failure can roll back arenas.
+        let rotation = if layout.rotation_table_len == 0 {
+            None
+        } else {
+            let n = layout.rotation_table_len;
+            let (a_vals, b_vals) = if layout.uses_fwht_signs {
+                (Self::gen_fwht_signs(42, n), Self::gen_fwht_signs(1042, n))
+            } else {
+                Self::gen_givens_angles(42, n)
+            };
+            let a_bytes: Vec<u8> = a_vals.iter().flat_map(|v| v.to_ne_bytes()).collect();
+            let b_bytes: Vec<u8> = b_vals.iter().flat_map(|v| v.to_ne_bytes()).collect();
+            let tables = (|| -> HipResult<(GpuTensor, GpuTensor)> {
+                let a = gpu.alloc_tensor(&[n], DType::F32)?;
+                let b = match gpu.alloc_tensor(&[n], DType::F32) {
+                    Ok(b) => b,
+                    Err(err) => {
+                        let _ = gpu.free_tensor(a);
+                        return Err(err);
+                    }
+                };
+                if let Err(err) = gpu.hip.memcpy_htod(&a.buf, &a_bytes) {
+                    let _ = gpu.free_tensor(a);
+                    let _ = gpu.free_tensor(b);
+                    return Err(err);
+                }
+                if let Err(err) = gpu.hip.memcpy_htod(&b.buf, &b_bytes) {
+                    let _ = gpu.free_tensor(a);
+                    let _ = gpu.free_tensor(b);
+                    return Err(err);
+                }
+                Ok((a, b))
+            })();
+            match tables {
+                Ok(pair) => Some(pair),
+                Err(err) => {
+                    for tensor in k_gpu.drain(..).chain(v_gpu.drain(..)) {
+                        let _ = gpu.free_tensor(tensor);
+                    }
+                    return Err(err);
+                }
+            }
+        };
+
+        let (quant_q8, quant_asym4, quant_asym3, quant_asym2, quant_fwht) =
+            Self::vmm_mode_flags(mode);
+        let (givens_cos, givens_sin) = match rotation {
+            Some((a, b)) => (Some(a), Some(b)),
+            None => (None, None),
+        };
+
+        let mut cache = Self {
+            k_gpu,
+            v_gpu,
+            k_scales: vec![],
+            v_scales: vec![],
+            kv_dim: layout.kv_dim,
+            max_seq: max_seq_len,
+            physical_cap,
+            n_kv_heads,
+            head_dim,
+            quantized: true,
+            quant_q8,
+            quant_int8: false,
+            quant_hfq4: false,
+            quant_asym4,
+            quant_asym3,
+            quant_asym2,
+            quant_fwht,
+            boundary_layers: 0,
+            givens_cos,
+            givens_sin,
+            layer_is_boundary: vec![],
+            compact_offset: 0,
+            v_mode,
+        };
+        // Map initial prefix before any write; roll back on failure.
+        if let Err(err) = cache.ensure_mapped_capacity(gpu, 1) {
+            let _ = cache.free_gpu(gpu);
+            return Err(err);
+        }
+        let n_kv = is_kv_layer.iter().filter(|is_kv| **is_kv).count();
+        let mapped = match cache.mapped_token_capacity() {
+            Ok(capacity) => capacity.unwrap_or(0),
+            Err(err) => {
+                let _ = cache.free_gpu(gpu);
+                return Err(err);
+            }
+        };
+        let v_label = match v_mode {
+            VMode::Q8 => "Q8".to_string(),
+            VMode::Lloyd2 => "lloyd2".to_string(),
+            VMode::Lloyd3 => "lloyd3".to_string(),
+            VMode::Lloyd4 => "lloyd4".to_string(),
+        };
+        eprintln!(
+            "KV cache: {mode:?} vmm ({n_kv}/{} layers carry KV; K {}B/head + V {v_label} {}B/head; mapped_prefix={mapped} / physical_cap={physical_cap} / max_seq={max_seq_len})",
+            is_kv_layer.len(),
+            layout.k_bytes_per_head,
+            layout.v_bytes_per_head,
+        );
+        Ok(cache)
+    }
+
+    /// VMM-backed Q8 cache for Qwen3.5 hybrid stacks.
+    /// Thin wrapper over [`Self::new_gpu_vmm_capped_filtered`].
     pub fn new_gpu_q8_vmm_capped_filtered(
         gpu: &mut Gpu,
         is_kv_layer: &[bool],
@@ -6794,66 +7560,16 @@ impl KvCache {
         max_seq_len: usize,
         physical_cap: usize,
     ) -> HipResult<Self> {
-        if physical_cap == 0 || physical_cap > max_seq_len {
-            return Err(hip_bridge::HipError::new(
-                0,
-                &format!(
-                    "VMM q8 physical_cap must be in 1..=max_seq_len (got physical_cap={physical_cap}, max_seq_len={max_seq_len})"
-                ),
-            ));
-        }
-        if !is_kv_layer.iter().any(|is_kv| *is_kv) {
-            return Err(hip_bridge::HipError::new(
-                0,
-                "VMM q8 requires at least one KV-carrying layer",
-            ));
-        }
-        let (kv_dim, cache_elems, _bytes_per_token) =
-            Self::q8_vmm_layout(n_kv_heads, head_dim, physical_cap)?;
-        let (k_gpu, v_gpu) =
-            Self::alloc_k_v_vmm_filtered(gpu, cache_elems, cache_elems, is_kv_layer)?;
-        let mut cache = Self {
-            k_gpu,
-            v_gpu,
-            k_scales: vec![],
-            v_scales: vec![],
-            kv_dim,
-            max_seq: max_seq_len,
-            physical_cap,
+        Self::new_gpu_vmm_capped_filtered(
+            gpu,
+            is_kv_layer,
             n_kv_heads,
             head_dim,
-            quantized: true,
-            quant_q8: true,
-            quant_int8: false,
-            quant_hfq4: false,
-            quant_asym4: false,
-            quant_asym3: false,
-            quant_asym2: false,
-            quant_fwht: false,
-            boundary_layers: 0,
-            givens_cos: None,
-            givens_sin: None,
-            layer_is_boundary: vec![],
-            compact_offset: 0,
-            v_mode: VMode::Q8,
-        };
-        if let Err(err) = cache.ensure_mapped_capacity(gpu, 1) {
-            cache.free_gpu(gpu);
-            return Err(err);
-        }
-        let n_kv = is_kv_layer.iter().filter(|is_kv| **is_kv).count();
-        let mapped = match cache.mapped_token_capacity() {
-            Ok(capacity) => capacity.unwrap_or(0),
-            Err(err) => {
-                cache.free_gpu(gpu);
-                return Err(err);
-            }
-        };
-        eprintln!(
-            "KV cache: q8 vmm ({n_kv}/{} layers carry KV, mapped_prefix={mapped} / physical_cap={physical_cap} / max_seq={max_seq_len})",
-            is_kv_layer.len()
-        );
-        Ok(cache)
+            max_seq_len,
+            physical_cap,
+            KvMode::Q8,
+            VMode::Q8,
+        )
     }
 
     /// Create INT8 co-located KV cache: [f32 scale][pad 4B][int8 × head_dim] = 136 bytes per head.
@@ -7494,6 +8210,7 @@ impl KvCache {
     }
 
     /// VMM-backed Asym3-K/Q8-V cache for Qwen3.5 hybrid stacks.
+    /// Thin wrapper over [`Self::new_gpu_vmm_capped_filtered`].
     pub fn new_gpu_asym3_vmm_capped_filtered(
         gpu: &mut Gpu,
         is_kv_layer: &[bool],
@@ -7502,103 +8219,38 @@ impl KvCache {
         max_seq_len: usize,
         physical_cap: usize,
     ) -> HipResult<Self> {
-        if physical_cap == 0 || physical_cap > max_seq_len {
-            return Err(hip_bridge::HipError::new(
-                0,
-                &format!(
-                    "VMM asym3 physical_cap must be in 1..=max_seq_len (got physical_cap={physical_cap}, max_seq_len={max_seq_len})"
-                ),
-            ));
-        }
-        if !is_kv_layer.iter().any(|is_kv| *is_kv) {
-            return Err(hip_bridge::HipError::new(
-                0,
-                "VMM asym3 requires at least one KV-carrying layer",
-            ));
-        }
-        let (kv_dim, k_elems, v_elems, k_bytes_per_head, v_bytes_per_head) =
-            Self::asym3_vmm_layout(n_kv_heads, head_dim, physical_cap)?;
-        let (mut k_gpu, mut v_gpu) =
-            Self::alloc_k_v_vmm_filtered(gpu, k_elems, v_elems, is_kv_layer)?;
-
-        let n_blocks = head_dim / 2;
-        let (cos_vals, sin_vals) = Self::gen_givens_angles(42, n_blocks);
-        let cos_bytes: Vec<u8> = cos_vals.iter().flat_map(|v| v.to_ne_bytes()).collect();
-        let sin_bytes: Vec<u8> = sin_vals.iter().flat_map(|v| v.to_ne_bytes()).collect();
-        let tables = (|| -> HipResult<(GpuTensor, GpuTensor)> {
-            let cos = gpu.alloc_tensor(&[n_blocks], DType::F32)?;
-            let sin = match gpu.alloc_tensor(&[n_blocks], DType::F32) {
-                Ok(sin) => sin,
-                Err(err) => {
-                    let _ = gpu.free_tensor(cos);
-                    return Err(err);
-                }
-            };
-            if let Err(err) = gpu.hip.memcpy_htod(&cos.buf, &cos_bytes) {
-                let _ = gpu.free_tensor(cos);
-                let _ = gpu.free_tensor(sin);
-                return Err(err);
-            }
-            if let Err(err) = gpu.hip.memcpy_htod(&sin.buf, &sin_bytes) {
-                let _ = gpu.free_tensor(cos);
-                let _ = gpu.free_tensor(sin);
-                return Err(err);
-            }
-            Ok((cos, sin))
-        })();
-        let (cos, sin) = match tables {
-            Ok(tables) => tables,
-            Err(err) => {
-                for tensor in k_gpu.drain(..).chain(v_gpu.drain(..)) {
-                    let _ = gpu.free_tensor(tensor);
-                }
-                return Err(err);
-            }
-        };
-
-        let mut cache = Self {
-            k_gpu,
-            v_gpu,
-            k_scales: vec![],
-            v_scales: vec![],
-            kv_dim,
-            max_seq: max_seq_len,
-            physical_cap,
+        Self::new_gpu_vmm_capped_filtered(
+            gpu,
+            is_kv_layer,
             n_kv_heads,
             head_dim,
-            quantized: true,
-            quant_q8: false,
-            quant_int8: false,
-            quant_hfq4: false,
-            quant_asym4: false,
-            quant_asym3: true,
-            quant_asym2: false,
-            quant_fwht: false,
-            boundary_layers: 0,
-            givens_cos: Some(cos),
-            givens_sin: Some(sin),
-            layer_is_boundary: vec![],
-            compact_offset: 0,
-            v_mode: VMode::Q8,
-        };
-        if let Err(err) = cache.ensure_mapped_capacity(gpu, 1) {
-            cache.free_gpu(gpu);
-            return Err(err);
-        }
-        let n_kv = is_kv_layer.iter().filter(|is_kv| **is_kv).count();
-        let mapped = match cache.mapped_token_capacity() {
-            Ok(capacity) => capacity.unwrap_or(0),
-            Err(err) => {
-                cache.free_gpu(gpu);
-                return Err(err);
-            }
-        };
-        eprintln!(
-            "KV cache: asym3 vmm ({n_kv}/{} layers carry KV; K {k_bytes_per_head}B/head + V {}B/head; mapped_prefix={mapped} / physical_cap={physical_cap} / max_seq={max_seq_len})",
-            is_kv_layer.len(),
-            v_bytes_per_head,
-        );
-        Ok(cache)
+            max_seq_len,
+            physical_cap,
+            KvMode::Asym3,
+            VMode::Q8,
+        )
+    }
+
+    /// VMM-backed FWHT3-K/Q8-V cache for Qwen3.5 hybrid stacks.
+    /// Thin wrapper over [`Self::new_gpu_vmm_capped_filtered`].
+    pub fn new_gpu_fwht3_vmm_capped_filtered(
+        gpu: &mut Gpu,
+        is_kv_layer: &[bool],
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+        physical_cap: usize,
+    ) -> HipResult<Self> {
+        Self::new_gpu_vmm_capped_filtered(
+            gpu,
+            is_kv_layer,
+            n_kv_heads,
+            head_dim,
+            max_seq_len,
+            physical_cap,
+            KvMode::Fwht3,
+            VMode::Q8,
+        )
     }
 
     /// Filtered variant of fwht3 — signed-FWHT-256 K-rotation, 3-bit centroid,
@@ -8027,24 +8679,40 @@ impl KvCache {
 
     /// Free all GPU tensors in this cache. Call before drop to return VRAM.
     /// After calling, follow with gpu.drain_pool() to actually release memory.
-    pub fn free_gpu(self, gpu: &mut Gpu) {
+    ///
+    /// Contiguous frees keep prior log-and-continue behavior. VMM teardown
+    /// failures are aggregated and returned so unload cannot claim success
+    /// while arenas remain registered (retry via `Gpu::ensure_vmm_cleaned`).
+    pub fn free_gpu(self, gpu: &mut Gpu) -> HipResult<()> {
+        let mut first_err: Option<hip_bridge::HipError> = None;
+        let mut note = |r: HipResult<()>| {
+            if let Err(err) = r {
+                if first_err.is_none() {
+                    first_err = Some(err);
+                }
+            }
+        };
         for t in self.k_gpu {
-            let _ = gpu.free_tensor(t);
+            note(gpu.free_tensor(t));
         }
         for t in self.v_gpu {
-            let _ = gpu.free_tensor(t);
+            note(gpu.free_tensor(t));
         }
         for t in self.k_scales {
-            let _ = gpu.free_tensor(t);
+            note(gpu.free_tensor(t));
         }
         for t in self.v_scales {
-            let _ = gpu.free_tensor(t);
+            note(gpu.free_tensor(t));
         }
         if let Some(t) = self.givens_cos {
-            let _ = gpu.free_tensor(t);
+            note(gpu.free_tensor(t));
         }
         if let Some(t) = self.givens_sin {
-            let _ = gpu.free_tensor(t);
+            note(gpu.free_tensor(t));
+        }
+        match first_err {
+            Some(err) => Err(err),
+            None => Ok(()),
         }
     }
 
@@ -10676,5 +11344,522 @@ mod tests {
             KvTierPlan::derive(got).unwrap().write_key,
             KvTierPlan::derive(legacy).unwrap().write_key,
         );
+    }
+
+    fn vmm_mask_dims(
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq: usize,
+        physical_cap: usize,
+    ) -> KvDims {
+        KvDims {
+            layers: KvLayers::Mask(vec![true, false, true]),
+            n_kv_heads,
+            head_dim,
+            max_seq,
+            physical_cap: Some(physical_cap),
+        }
+    }
+
+    fn expected_k_bph(mode: KvMode, head_dim: usize) -> usize {
+        match mode {
+            KvMode::Q8 => (head_dim / 32) * 34,
+            KvMode::Asym2 | KvMode::Fwht2 => 4 + head_dim / 4,
+            KvMode::Asym3 | KvMode::Fwht3 => 4 + (head_dim * 3) / 8,
+            KvMode::Asym4 | KvMode::Fwht4 => 4 + head_dim / 2,
+            KvMode::Asym3Auto => panic!("Asym3Auto is not a layout mode"),
+        }
+    }
+
+    fn expected_v_bph(v_mode: VMode, head_dim: usize) -> usize {
+        match v_mode {
+            VMode::Q8 => (head_dim / 32) * 34,
+            VMode::Lloyd2 => 4 + head_dim / 4,
+            VMode::Lloyd3 => 4 + (head_dim * 3) / 8,
+            VMode::Lloyd4 => 4 + head_dim / 2,
+        }
+    }
+
+    fn flag_standin(mode: KvMode, v_mode: VMode, n_kv_heads: usize, head_dim: usize) -> KvCache {
+        let (q8, a4, a3, a2, fwht) = KvCache::vmm_mode_flags(mode);
+        KvCache {
+            k_gpu: vec![],
+            v_gpu: vec![],
+            k_scales: vec![],
+            v_scales: vec![],
+            kv_dim: n_kv_heads * head_dim,
+            max_seq: 128,
+            physical_cap: 128,
+            n_kv_heads,
+            head_dim,
+            quantized: true,
+            quant_q8: q8,
+            quant_int8: false,
+            quant_hfq4: false,
+            quant_asym4: a4,
+            quant_asym3: a3,
+            quant_asym2: a2,
+            quant_fwht: fwht,
+            boundary_layers: 0,
+            givens_cos: None,
+            givens_sin: None,
+            layer_is_boundary: vec![],
+            compact_offset: 0,
+            v_mode,
+        }
+    }
+
+    #[test]
+    fn adaptive_reset_invalidates_captured_execution_state() {
+        let Ok(mut gpu) = Gpu::init() else {
+            eprintln!("skip: no GPU");
+            return;
+        };
+        let mut cache = flag_standin(KvMode::Fwht2, VMode::Lloyd2, 4, 256);
+        let mut adaptive = crate::kv_adaptive::KvAdaptive::from_preset(
+            crate::kv_adaptive::Preset::Aggressive,
+            128,
+            4,
+            256,
+        );
+        adaptive.cur_k = crate::kv_adaptive::KMode::Fwht2;
+        adaptive.cur_v = VMode::Lloyd2;
+        adaptive.next_step = adaptive.steps.len();
+        gpu.graphs.ar_forward_replay_enabled = true;
+        gpu.graphs.ar_forward_kernel_dirty = false;
+
+        adaptive.reset_with_cache(&mut gpu, &mut cache);
+
+        assert_eq!(cache.current_kv_mode().unwrap(), KvMode::Fwht4);
+        assert_eq!(cache.v_mode, VMode::Q8);
+        assert!(!gpu.graphs.ar_forward_replay_enabled);
+        assert!(gpu.graphs.ar_forward_kernel_dirty);
+    }
+
+    #[test]
+    fn vmm_static_layout_covers_all_seven_k_modes_with_q8_v() {
+        let n_kv_heads = 4;
+        let head_dim = 256;
+        let physical_cap = 128;
+        let modes = [
+            KvMode::Q8,
+            KvMode::Asym2,
+            KvMode::Asym3,
+            KvMode::Asym4,
+            KvMode::Fwht2,
+            KvMode::Fwht3,
+            KvMode::Fwht4,
+        ];
+        for mode in modes {
+            let layout =
+                KvCache::vmm_static_layout(mode, VMode::Q8, n_kv_heads, head_dim, physical_cap)
+                    .unwrap_or_else(|e| panic!("mode={mode:?}: {e}"));
+            let k_bph = expected_k_bph(mode, head_dim);
+            let v_bph = expected_v_bph(VMode::Q8, head_dim);
+            assert_eq!(layout.k_bytes_per_head, k_bph, "mode={mode:?}");
+            assert_eq!(layout.v_bytes_per_head, v_bph, "mode={mode:?}");
+            assert_eq!(
+                layout.k_bytes_per_token,
+                n_kv_heads * k_bph,
+                "mode={mode:?}"
+            );
+            assert_eq!(
+                layout.v_bytes_per_token,
+                n_kv_heads * v_bph,
+                "mode={mode:?}"
+            );
+            // Static: reserve == current.
+            assert_eq!(
+                layout.k_reserve_bytes,
+                physical_cap * layout.k_bytes_per_token,
+                "mode={mode:?}"
+            );
+            assert_eq!(
+                layout.v_reserve_bytes,
+                physical_cap * layout.v_bytes_per_token,
+                "mode={mode:?}"
+            );
+            assert_eq!(
+                layout.k_reserve_elems,
+                (layout.k_reserve_bytes + 3) / 4,
+                "mode={mode:?}"
+            );
+            assert_eq!(
+                layout.v_reserve_elems,
+                (layout.v_reserve_bytes + 3) / 4,
+                "mode={mode:?}"
+            );
+            assert_eq!(layout.kv_dim, n_kv_heads * head_dim);
+            // Independent K vs V capacity at equal physical_cap is just physical_cap.
+            let k_cap = layout.k_reserve_bytes / layout.k_bytes_per_token;
+            let v_cap = layout.v_reserve_bytes / layout.v_bytes_per_token;
+            assert_eq!(k_cap.min(v_cap), physical_cap, "mode={mode:?}");
+        }
+    }
+
+    #[test]
+    fn vmm_static_layout_covers_fwht_k_with_lloyd_v() {
+        let n_kv_heads = 4;
+        let head_dim = 256;
+        let physical_cap = 64;
+        let k_modes = [KvMode::Fwht2, KvMode::Fwht3, KvMode::Fwht4];
+        let v_modes = [VMode::Lloyd2, VMode::Lloyd3, VMode::Lloyd4];
+        for mode in k_modes {
+            for v_mode in v_modes {
+                let layout =
+                    KvCache::vmm_static_layout(mode, v_mode, n_kv_heads, head_dim, physical_cap)
+                        .unwrap_or_else(|e| panic!("{mode:?}/{v_mode:?}: {e}"));
+                assert_eq!(layout.k_bytes_per_head, expected_k_bph(mode, head_dim));
+                assert_eq!(layout.v_bytes_per_head, expected_v_bph(v_mode, head_dim));
+                // Lloyd-V forces 256-wide signs even for fwht2/4.
+                assert_eq!(layout.rotation_table_len, 256, "{mode:?}/{v_mode:?}");
+                assert!(layout.uses_fwht_signs, "{mode:?}/{v_mode:?}");
+                // Prefix helpers use current stride, not reserve.
+                let n_pos = 17;
+                assert_eq!(
+                    layout.prefix_k_bytes(n_pos).unwrap(),
+                    n_pos * layout.k_bytes_per_token
+                );
+                assert_eq!(
+                    layout.prefix_v_bytes(n_pos).unwrap(),
+                    n_pos * layout.v_bytes_per_token
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn vmm_layout_rejects_illegal_pairs() {
+        // Asym-K + Lloyd-V is illegal.
+        for mode in [KvMode::Asym2, KvMode::Asym3, KvMode::Asym4, KvMode::Q8] {
+            let err = KvCache::vmm_static_layout(mode, VMode::Lloyd4, 4, 256, 64)
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("lloyd-V") || err.contains("VMode::Q8"),
+                "mode={mode:?} err={err}"
+            );
+        }
+        // FWHT3 / Asym3 require head_dim=256.
+        for mode in [KvMode::Fwht3, KvMode::Asym3] {
+            let err = KvCache::vmm_static_layout(mode, VMode::Q8, 4, 128, 64)
+                .unwrap_err()
+                .to_string();
+            assert!(err.contains("head_dim"), "mode={mode:?} err={err}");
+        }
+        // n_kv_heads == 0.
+        let err = KvCache::vmm_static_layout(KvMode::Fwht3, VMode::Q8, 0, 256, 64)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("n_kv_heads>0"), "{err}");
+        // Lloyd-V with FWHT-K but head_dim != 256.
+        let err = KvCache::vmm_static_layout(KvMode::Fwht4, VMode::Lloyd2, 4, 128, 64)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("head_dim=256"), "{err}");
+    }
+
+    #[test]
+    fn fwht3_vmm_layout_matches_asym3_byte_geometry() {
+        let n_kv_heads = 4;
+        let head_dim = 256;
+        let physical_cap = 128;
+        let asym = KvCache::asym3_vmm_layout(n_kv_heads, head_dim, physical_cap).unwrap();
+        let fwht = KvCache::fwht3_vmm_layout(n_kv_heads, head_dim, physical_cap).unwrap();
+        assert_eq!(fwht, asym, "fwht3 VMM must reuse asym3 K/V byte layout");
+        // Explicit stride math: K 100 B/head, V Q8 272 B/head at head_dim=256.
+        assert_eq!(fwht.3, 4 + (head_dim * 3) / 8);
+        assert_eq!(fwht.4, (head_dim / 32) * 34);
+        let k_bytes = physical_cap * n_kv_heads * fwht.3;
+        let v_bytes = physical_cap * n_kv_heads * fwht.4;
+        assert_eq!(fwht.1, (k_bytes + 3) / 4);
+        assert_eq!(fwht.2, (v_bytes + 3) / 4);
+        assert_eq!(fwht.0, n_kv_heads * head_dim);
+    }
+
+    #[test]
+    fn vmm_layout_with_reserve_separates_current_and_floor() {
+        // Adaptive-style: current FWHT4/Q8, reserve at fwht2/lloyd2 floors.
+        let n_kv_heads = 4;
+        let head_dim = 256;
+        let physical_cap = 1000;
+        let k_floor_bph = expected_k_bph(KvMode::Fwht2, head_dim); // 68
+        let layout = KvCache::vmm_layout_with_reserve(
+            KvMode::Fwht4,
+            VMode::Q8,
+            n_kv_heads,
+            head_dim,
+            physical_cap,
+            k_floor_bph,
+            VMode::Lloyd2,
+        )
+        .unwrap();
+        // Current strides are start encoding.
+        assert_eq!(
+            layout.k_bytes_per_token,
+            n_kv_heads * expected_k_bph(KvMode::Fwht4, head_dim)
+        );
+        assert_eq!(
+            layout.v_bytes_per_token,
+            n_kv_heads * expected_v_bph(VMode::Q8, head_dim)
+        );
+        // Reserve is floor-sized.
+        assert_eq!(
+            layout.k_reserve_bytes,
+            physical_cap * n_kv_heads * k_floor_bph
+        );
+        assert_eq!(
+            layout.v_reserve_bytes,
+            physical_cap * n_kv_heads * expected_v_bph(VMode::Lloyd2, head_dim)
+        );
+        // Token capacity at start is min of reserve/current (V binds: 68/272).
+        let k_cap = layout.k_reserve_bytes / layout.k_bytes_per_token;
+        let v_cap = layout.v_reserve_bytes / layout.v_bytes_per_token;
+        assert_eq!(
+            k_cap,
+            physical_cap * k_floor_bph / expected_k_bph(KvMode::Fwht4, head_dim)
+        );
+        assert_eq!(
+            v_cap,
+            physical_cap * expected_v_bph(VMode::Lloyd2, head_dim)
+                / expected_v_bph(VMode::Q8, head_dim)
+        );
+        assert!(v_cap < k_cap, "V should bind at FWHT4/Q8 start");
+        // Source-prefix bytes remain current-stride × n_pos (not floor).
+        assert_eq!(
+            layout.prefix_k_bytes(10).unwrap(),
+            10 * layout.k_bytes_per_token
+        );
+        assert_eq!(
+            layout.prefix_v_bytes(10).unwrap(),
+            10 * layout.v_bytes_per_token
+        );
+        assert_eq!(layout.rotation_table_len, 256);
+    }
+
+    #[test]
+    fn validate_mode_admits_all_seven_static_vmm_modes() {
+        let dims = vmm_mask_dims(4, 256, 4096, 1024);
+        for mode in [
+            KvMode::Q8,
+            KvMode::Asym2,
+            KvMode::Asym3,
+            KvMode::Asym4,
+            KvMode::Fwht2,
+            KvMode::Fwht3,
+            KvMode::Fwht4,
+        ] {
+            KvCache::validate_mode_with_backend(mode, KvBackend::Vmm, true, &dims)
+                .unwrap_or_else(|e| panic!("mode={mode:?}: {e}"));
+            // Contiguous admission remains open (no VMM-only gate).
+            KvCache::validate_mode_with_backend(mode, KvBackend::Contiguous, true, &dims)
+                .unwrap_or_else(|e| panic!("contiguous mode={mode:?}: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_mode_rejects_multi_gpu_flat_and_asym3auto_vmm() {
+        let mask = vmm_mask_dims(4, 256, 4096, 1024);
+        let err = KvCache::validate_mode_with_backend(KvMode::Fwht3, KvBackend::Vmm, false, &mask)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("single-GPU"), "{err}");
+
+        let flat = KvDims {
+            layers: KvLayers::Flat(8),
+            n_kv_heads: 4,
+            head_dim: 256,
+            max_seq: 4096,
+            physical_cap: Some(1024),
+        };
+        let err = KvCache::validate_mode_with_backend(KvMode::Fwht3, KvBackend::Vmm, true, &flat)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("filtered"), "{err}");
+
+        let err =
+            KvCache::validate_mode_with_backend(KvMode::Asym3Auto, KvBackend::Vmm, true, &mask)
+                .unwrap_err()
+                .to_string();
+        assert!(err.contains("Asym3Auto"), "{err}");
+    }
+
+    #[test]
+    fn vmm_bytes_per_token_matches_layout_for_all_static_modes() {
+        let n_kv_heads = 4;
+        let head_dim = 256;
+        for mode in [
+            KvMode::Q8,
+            KvMode::Asym2,
+            KvMode::Asym3,
+            KvMode::Asym4,
+            KvMode::Fwht2,
+            KvMode::Fwht3,
+            KvMode::Fwht4,
+        ] {
+            let cache = flag_standin(mode, VMode::Q8, n_kv_heads, head_dim);
+            let (k, v) = cache.vmm_bytes_per_token().unwrap();
+            assert_eq!(k, n_kv_heads * expected_k_bph(mode, head_dim), "{mode:?}");
+            assert_eq!(
+                v,
+                n_kv_heads * expected_v_bph(VMode::Q8, head_dim),
+                "{mode:?}"
+            );
+        }
+        // FWHT-K + Lloyd-V current strides.
+        for v_mode in [VMode::Lloyd2, VMode::Lloyd3, VMode::Lloyd4] {
+            let cache = flag_standin(KvMode::Fwht4, v_mode, n_kv_heads, head_dim);
+            let (k, v) = cache.vmm_bytes_per_token().unwrap();
+            assert_eq!(
+                k,
+                n_kv_heads * expected_k_bph(KvMode::Fwht4, head_dim),
+                "{v_mode:?}"
+            );
+            assert_eq!(
+                v,
+                n_kv_heads * expected_v_bph(v_mode, head_dim),
+                "{v_mode:?}"
+            );
+        }
+        // Asym-K + Lloyd-V must fail (illegal pair).
+        let bad = flag_standin(KvMode::Asym3, VMode::Lloyd3, n_kv_heads, head_dim);
+        assert!(bad.vmm_bytes_per_token().is_err());
+    }
+
+    #[test]
+    fn independent_k_v_capacity_math_from_reserve_and_current() {
+        // Simulate lopsided adaptive start: K floor 68, V floor 68, current K132/V272.
+        let n_kv_heads = 4;
+        let head_dim = 256;
+        let physical_cap = 1000;
+        let layout = KvCache::vmm_layout_with_reserve(
+            KvMode::Fwht4,
+            VMode::Q8,
+            n_kv_heads,
+            head_dim,
+            physical_cap,
+            expected_k_bph(KvMode::Fwht2, head_dim),
+            VMode::Lloyd2,
+        )
+        .unwrap();
+        let k_tokens = layout.k_reserve_bytes / layout.k_bytes_per_token;
+        let v_tokens = layout.v_reserve_bytes / layout.v_bytes_per_token;
+        // Must NOT sum K+V bytes into a shared pool.
+        let naive_shared = (layout.k_reserve_bytes + layout.v_reserve_bytes)
+            / (layout.k_bytes_per_token + layout.v_bytes_per_token);
+        assert_ne!(
+            k_tokens.min(v_tokens),
+            naive_shared,
+            "min-of-two must differ from shared-pool sum"
+        );
+        assert_eq!(k_tokens.min(v_tokens), v_tokens);
+    }
+
+    #[test]
+    fn free_gpu_empty_cache_is_ok() {
+        let Ok(mut gpu) = Gpu::init() else {
+            eprintln!("skip: no GPU");
+            return;
+        };
+        let cache = KvCache {
+            k_gpu: vec![],
+            v_gpu: vec![],
+            k_scales: vec![],
+            v_scales: vec![],
+            kv_dim: 0,
+            max_seq: 0,
+            physical_cap: 0,
+            n_kv_heads: 0,
+            head_dim: 0,
+            quantized: false,
+            quant_q8: false,
+            quant_int8: false,
+            quant_hfq4: false,
+            quant_asym4: false,
+            quant_asym3: false,
+            quant_asym2: false,
+            quant_fwht: false,
+            boundary_layers: 0,
+            givens_cos: None,
+            givens_sin: None,
+            layer_is_boundary: vec![],
+            compact_offset: 0,
+            v_mode: VMode::Q8,
+        };
+        cache.free_gpu(&mut gpu).expect("empty free");
+    }
+
+    #[test]
+    fn free_gpu_propagates_vmm_teardown_failure_and_retries() {
+        let Ok(mut gpu) = Gpu::init() else {
+            eprintln!("skip: no GPU");
+            return;
+        };
+        hip_bridge::clear_vmm_faults();
+        let access = [gpu.device_id];
+        let chunk = 2 * 1024 * 1024;
+        let tensor = match unsafe { gpu.alloc_vmm_tensor(&[chunk], DType::Raw, chunk, &access) } {
+            Ok(t) => t,
+            Err(_) => {
+                eprintln!("skip: VMM unavailable");
+                return;
+            }
+        };
+        let cache = KvCache {
+            k_gpu: vec![tensor],
+            v_gpu: vec![],
+            k_scales: vec![],
+            v_scales: vec![],
+            kv_dim: 1,
+            max_seq: 1,
+            physical_cap: 1,
+            n_kv_heads: 1,
+            head_dim: 1,
+            quantized: false,
+            quant_q8: false,
+            quant_int8: false,
+            quant_hfq4: false,
+            quant_asym4: false,
+            quant_asym3: false,
+            quant_asym2: false,
+            quant_fwht: false,
+            boundary_layers: 0,
+            givens_cos: None,
+            givens_sin: None,
+            layer_is_boundary: vec![],
+            compact_offset: 0,
+            v_mode: VMode::Q8,
+        };
+        hip_bridge::inject_vmm_fault(hip_bridge::VmmFaultKind::Unmap, 1);
+        let err = cache
+            .free_gpu(&mut gpu)
+            .expect_err("must surface teardown fault");
+        assert!(
+            err.to_string().contains("retained") || err.to_string().contains("injected"),
+            "{err}"
+        );
+        assert_eq!(
+            gpu.vmm_allocation_count(),
+            1,
+            "ownership retained after free_gpu err"
+        );
+        hip_bridge::clear_vmm_faults();
+        gpu.ensure_vmm_cleaned().expect("retry");
+        assert_eq!(gpu.vmm_allocation_count(), 0);
+        // No new load while pending would be refused:
+        // Two unmap faults: one for free_tensor, one for ensure/retry.
+        hip_bridge::inject_vmm_fault(hip_bridge::VmmFaultKind::Unmap, 2);
+        let t2 =
+            unsafe { gpu.alloc_vmm_tensor(&[chunk], DType::Raw, chunk, &access) }.expect("alloc");
+        let _ = gpu.free_tensor(t2).expect_err("fault");
+        assert!(gpu.vmm_allocation_count() >= 1);
+        // simulate load gate
+        let refuse = gpu.ensure_vmm_cleaned();
+        assert!(
+            refuse.is_err(),
+            "load must refuse while pending: {refuse:?}"
+        );
+        hip_bridge::clear_vmm_faults();
+        gpu.ensure_vmm_cleaned().expect("clear");
     }
 }

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -7,11 +7,13 @@
 
 use crate::arch::{screen_weight_tensor, MmqScreenable};
 use crate::gguf::{GgmlType, GgufFile, TensorInfo};
+use crate::kv_backend::{
+    KvBackend, KvChunkPlan, DEFAULT_KV_CHUNK_TOKENS, DEFAULT_VMM_PHYSICAL_CHUNK_BYTES,
+};
 use crate::kv_mode::KvMode;
 use crate::multi_gpu::Gpus;
 use hip_bridge::HipResult;
 use rdna_compute::{DType, Gpu, GpuTensor};
-use std::path::Path;
 
 /// Model architecture type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -5353,6 +5355,156 @@ pub enum KvTarget<'a> {
 }
 
 impl KvCache {
+    fn checked_vmm_product(label: &str, factors: &[usize]) -> HipResult<usize> {
+        factors
+            .iter()
+            .try_fold(1usize, |product, &factor| product.checked_mul(factor))
+            .ok_or_else(|| hip_bridge::HipError::new(0, &format!("VMM KV {label} size overflowed")))
+    }
+
+    fn bytes_to_f32_elems(label: &str, bytes: usize) -> HipResult<usize> {
+        bytes.checked_add(3).map(|value| value / 4).ok_or_else(|| {
+            hip_bridge::HipError::new(0, &format!("VMM KV {label} element count overflowed"))
+        })
+    }
+
+    fn q8_vmm_layout(
+        n_kv_heads: usize,
+        head_dim: usize,
+        physical_cap: usize,
+    ) -> HipResult<(usize, usize, usize)> {
+        if n_kv_heads == 0 || head_dim == 0 || !head_dim.is_multiple_of(32) {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "VMM q8 requires n_kv_heads>0 and a non-zero head_dim divisible by 32 (got n_kv_heads={n_kv_heads}, head_dim={head_dim})"
+                ),
+            ));
+        }
+        let kv_dim = Self::checked_vmm_product("q8 logical", &[n_kv_heads, head_dim])?;
+        let bytes_per_token =
+            Self::checked_vmm_product("q8 token stride", &[n_kv_heads, head_dim / 32, 34])?;
+        let cache_bytes =
+            Self::checked_vmm_product("q8 reserve", &[physical_cap, bytes_per_token])?;
+        let cache_elems = Self::bytes_to_f32_elems("q8 reserve", cache_bytes)?;
+        Ok((kv_dim, cache_elems, bytes_per_token))
+    }
+
+    fn asym3_vmm_layout(
+        n_kv_heads: usize,
+        head_dim: usize,
+        physical_cap: usize,
+    ) -> HipResult<(usize, usize, usize, usize, usize)> {
+        if n_kv_heads == 0 || head_dim != 256 {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "VMM asym3 requires n_kv_heads>0 and head_dim=256 (got n_kv_heads={n_kv_heads}, head_dim={head_dim})"
+                ),
+            ));
+        }
+        let kv_dim = Self::checked_vmm_product("asym3 logical", &[n_kv_heads, head_dim])?;
+        let packed_k = head_dim
+            .checked_mul(3)
+            .and_then(|value| value.checked_div(8))
+            .and_then(|value| value.checked_add(4))
+            .ok_or_else(|| hip_bridge::HipError::new(0, "VMM asym3 K stride overflowed"))?;
+        let v_bytes_per_head =
+            Self::checked_vmm_product("asym3 V head stride", &[head_dim / 32, 34])?;
+        let k_bytes_per_token =
+            Self::checked_vmm_product("asym3 K token stride", &[n_kv_heads, packed_k])?;
+        let v_bytes_per_token =
+            Self::checked_vmm_product("asym3 V token stride", &[n_kv_heads, v_bytes_per_head])?;
+        let k_bytes =
+            Self::checked_vmm_product("asym3 K reserve", &[physical_cap, k_bytes_per_token])?;
+        let v_bytes =
+            Self::checked_vmm_product("asym3 V reserve", &[physical_cap, v_bytes_per_token])?;
+        Ok((
+            kv_dim,
+            Self::bytes_to_f32_elems("asym3 K reserve", k_bytes)?,
+            Self::bytes_to_f32_elems("asym3 V reserve", v_bytes)?,
+            packed_k,
+            v_bytes_per_head,
+        ))
+    }
+
+    /// Validate a backend request without touching GPU memory.
+    pub fn validate_mode_with_backend(
+        mode: KvMode,
+        backend: KvBackend,
+        single_gpu: bool,
+        dims: &KvDims,
+    ) -> HipResult<()> {
+        if mode == KvMode::Asym3Auto {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "KV mode Asym3Auto must be resolved before allocation",
+            ));
+        }
+        if matches!(mode, KvMode::Asym4 | KvMode::Asym3) && dims.head_dim != 256 {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "{} KV cache requires head_dim=256; head_dim={} is unsupported",
+                    if mode == KvMode::Asym4 {
+                        "asym4"
+                    } else {
+                        "asym3"
+                    },
+                    dims.head_dim
+                ),
+            ));
+        }
+        if backend != KvBackend::Vmm {
+            return Ok(());
+        }
+        if !single_gpu {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "KV backend 'vmm' currently supports single-GPU qwen3.5 only",
+            ));
+        }
+        let KvLayers::Mask(is_kv_layer) = &dims.layers else {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "KV backend 'vmm' requires qwen3.5's filtered FullAttention layer mask",
+            ));
+        };
+        if !is_kv_layer.iter().any(|is_kv| *is_kv) {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "KV backend 'vmm' requires at least one FullAttention layer",
+            ));
+        }
+        let physical_cap = dims.physical_cap.ok_or_else(|| {
+            hip_bridge::HipError::new(0, "KV backend 'vmm' requires a physical token capacity")
+        })?;
+        if physical_cap == 0 || physical_cap > dims.max_seq {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "VMM physical_cap must be in 1..=max_seq (got {physical_cap}, max_seq={})",
+                    dims.max_seq
+                ),
+            ));
+        }
+        match mode {
+            KvMode::Q8 => {
+                Self::q8_vmm_layout(dims.n_kv_heads, dims.head_dim, physical_cap)?;
+            }
+            KvMode::Asym3 => {
+                Self::asym3_vmm_layout(dims.n_kv_heads, dims.head_dim, physical_cap)?;
+            }
+            other => {
+                return Err(hip_bridge::HipError::new(
+                    0,
+                    &format!("KV backend 'vmm' supports kv_mode=q8|asym3 only (got {other:?})"),
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Check if a given KV layer ordinal is a boundary layer (first N + last N).
     pub fn is_boundary(&self, kv_ordinal: usize) -> bool {
         kv_ordinal < self.layer_is_boundary.len() && self.layer_is_boundary[kv_ordinal]
@@ -5373,7 +5525,8 @@ impl KvCache {
             .chain(self.k_scales.iter())
             .chain(self.v_scales.iter())
         {
-            gpu.hip.memset(&t.buf, 0, t.buf.size())?;
+            let bytes = gpu.vmm_mapped_bytes(t).unwrap_or_else(|| t.buf.size());
+            gpu.hip.memset(&t.buf, 0, bytes)?;
         }
         Ok(())
     }
@@ -5384,33 +5537,57 @@ impl KvCache {
     /// target)` cells return `Err` rather than panic, so a future policy mis-wire
     /// surfaces as a clean load failure.
     pub fn from_mode(mode: KvMode, target: KvTarget, dims: &KvDims) -> HipResult<Self> {
-        debug_assert_ne!(
-            mode,
-            KvMode::Asym3Auto,
-            "from_mode received unresolved sentinel"
-        );
-        // GATE: asym4 and asym3 require head_dim=256. Both are validated only on
-        // Qwen 3.5 (head_dim=256); the constructors hard-assert head_dim==256 and
-        // the flash-decode paths are untested below that. Return a clean error here
-        // rather than panicking or emitting garbage inside the constructor.
-        if matches!(mode, KvMode::Asym4 | KvMode::Asym3) && dims.head_dim != 256 {
-            return Err(hip_bridge::HipError::new(
+        Self::from_mode_with_backend(mode, KvBackend::Contiguous, target, dims)
+    }
+
+    pub fn from_mode_with_backend(
+        mode: KvMode,
+        backend: KvBackend,
+        target: KvTarget,
+        dims: &KvDims,
+    ) -> HipResult<Self> {
+        let single_gpu = matches!(&target, KvTarget::Single(_));
+        Self::validate_mode_with_backend(mode, backend, single_gpu, dims)?;
+        match (backend, target) {
+            (KvBackend::Contiguous, KvTarget::Single(gpu)) => {
+                Self::from_mode_single(mode, gpu, dims)
+            }
+            (KvBackend::Contiguous, KvTarget::Multi(gpus)) => {
+                Self::from_mode_multi(mode, gpus, dims)
+            }
+            (KvBackend::Vmm, KvTarget::Single(gpu)) => Self::from_mode_single_vmm(mode, gpu, dims),
+            (KvBackend::Vmm, KvTarget::Multi(_)) => Err(hip_bridge::HipError::new(
                 0,
-                &format!(
-                    "{} KV cache requires head_dim=256 (validated on Qwen 3.5); \
-                     head_dim={} is unsupported. Use --kv-mode q8.",
-                    match mode {
-                        KvMode::Asym4 => "asym4",
-                        KvMode::Asym3 => "asym3",
-                        _ => unreachable!(),
-                    },
-                    dims.head_dim
-                ),
-            ));
+                "KV backend 'vmm' currently supports single-GPU qwen3.5 only",
+            )),
         }
-        match target {
-            KvTarget::Single(gpu) => Self::from_mode_single(mode, gpu, dims),
-            KvTarget::Multi(gpus) => Self::from_mode_multi(mode, gpus, dims),
+    }
+
+    fn from_mode_single_vmm(mode: KvMode, gpu: &mut Gpu, dims: &KvDims) -> HipResult<Self> {
+        let KvLayers::Mask(is_kv_layer) = &dims.layers else {
+            unreachable!("VMM layer shape validated before dispatch")
+        };
+        let physical_cap = dims
+            .physical_cap
+            .expect("VMM physical capacity validated before dispatch");
+        match mode {
+            KvMode::Q8 => Self::new_gpu_q8_vmm_capped_filtered(
+                gpu,
+                is_kv_layer,
+                dims.n_kv_heads,
+                dims.head_dim,
+                dims.max_seq,
+                physical_cap,
+            ),
+            KvMode::Asym3 => Self::new_gpu_asym3_vmm_capped_filtered(
+                gpu,
+                is_kv_layer,
+                dims.n_kv_heads,
+                dims.head_dim,
+                dims.max_seq,
+                physical_cap,
+            ),
+            other => unreachable!("VMM mode {other:?} validated before dispatch"),
         }
     }
 
@@ -5669,6 +5846,263 @@ impl KvCache {
             }
         }
         Ok((k_gpu, v_gpu))
+    }
+
+    /// Reserve dense virtual K/V tensors while mapping physical pages only as
+    /// the request grows. Placeholder tensors preserve absolute layer indices.
+    fn alloc_k_v_vmm_filtered(
+        gpu: &mut Gpu,
+        k_elems: usize,
+        v_elems: usize,
+        is_kv_layer: &[bool],
+    ) -> HipResult<(Vec<GpuTensor>, Vec<GpuTensor>)> {
+        let mut k_gpu = Vec::with_capacity(is_kv_layer.len());
+        let mut v_gpu = Vec::with_capacity(is_kv_layer.len());
+        let device_id = gpu.device_id;
+        let result = (|| -> HipResult<()> {
+            for &is_kv in is_kv_layer {
+                if is_kv {
+                    // SAFETY: Qwen3.5 mapped-prefix guards run before every
+                    // write, attention dispatch, and graph capture/replay.
+                    k_gpu.push(unsafe {
+                        gpu.alloc_vmm_tensor(&[k_elems], DType::F32, 0, &[device_id])?
+                    });
+                    v_gpu.push(unsafe {
+                        gpu.alloc_vmm_tensor(&[v_elems], DType::F32, 0, &[device_id])?
+                    });
+                } else {
+                    k_gpu.push(gpu.zeros(&[1], DType::F32)?);
+                    v_gpu.push(gpu.zeros(&[1], DType::F32)?);
+                }
+            }
+            Ok(())
+        })();
+        if let Err(err) = result {
+            for tensor in k_gpu.drain(..).chain(v_gpu.drain(..)) {
+                let _ = gpu.free_tensor(tensor);
+            }
+            return Err(err);
+        }
+        Ok((k_gpu, v_gpu))
+    }
+
+    fn vmm_bytes_per_token(&self) -> HipResult<(usize, usize)> {
+        if self.head_dim == 0 || !self.head_dim.is_multiple_of(32) {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "VMM KV requires a non-zero head_dim divisible by 32 (got {})",
+                    self.head_dim
+                ),
+            ));
+        }
+        let q8 = self
+            .n_kv_heads
+            .checked_mul(self.head_dim / 32)
+            .and_then(|n| n.checked_mul(34))
+            .ok_or_else(|| hip_bridge::HipError::new(0, "VMM Q8 byte stride overflowed"))?;
+        if self.quant_q8 {
+            return Ok((q8, q8));
+        }
+        if self.quant_asym3 && !self.quant_fwht && self.v_mode == VMode::Q8 {
+            let k_bytes_per_head = self
+                .head_dim
+                .checked_mul(3)
+                .and_then(|n| n.checked_div(8))
+                .and_then(|n| n.checked_add(4))
+                .ok_or_else(|| hip_bridge::HipError::new(0, "VMM Asym3 head stride overflowed"))?;
+            let k = self
+                .n_kv_heads
+                .checked_mul(k_bytes_per_head)
+                .ok_or_else(|| hip_bridge::HipError::new(0, "VMM Asym3 byte stride overflowed"))?;
+            return Ok((k, q8));
+        }
+        Err(hip_bridge::HipError::new(
+            0,
+            "VMM KV cache encoding changed after allocation",
+        ))
+    }
+
+    pub fn uses_vmm_backend(&self) -> bool {
+        self.k_gpu
+            .iter()
+            .chain(self.v_gpu.iter())
+            .find(|tensor| tensor.numel() > 1)
+            .is_some_and(|tensor| tensor.buf.is_vmm_owner())
+    }
+
+    fn fast_mapped_token_capacity(&self) -> HipResult<Option<usize>> {
+        if !self.uses_vmm_backend() {
+            return Ok(None);
+        }
+        let (k_bytes_per_token, v_bytes_per_token) = self.vmm_bytes_per_token()?;
+        let capacity = [
+            ("K", self.k_gpu.as_slice(), k_bytes_per_token),
+            ("V", self.v_gpu.as_slice(), v_bytes_per_token),
+        ]
+        .into_iter()
+        .try_fold(self.physical_cap, |capacity, (label, tensors, stride)| {
+            let tensor = tensors
+                .iter()
+                .rev()
+                .find(|tensor| tensor.numel() > 1)
+                .ok_or_else(|| {
+                    hip_bridge::HipError::new(
+                        0,
+                        &format!("VMM KV cache has no real {label} tensor"),
+                    )
+                })?;
+            if !tensor.buf.is_vmm_owner() {
+                return Err(hip_bridge::HipError::new(
+                    0,
+                    &format!("VMM KV cache has a non-VMM real {label} tensor"),
+                ));
+            }
+            Ok(capacity.min(tensor.buf.size() / stride))
+        })?;
+        Ok(Some(capacity))
+    }
+
+    pub fn mapped_token_capacity(&self) -> HipResult<Option<usize>> {
+        if !self.uses_vmm_backend() {
+            return Ok(None);
+        }
+        let (k_bytes_per_token, v_bytes_per_token) = self.vmm_bytes_per_token()?;
+        let mut capacity = self.physical_cap;
+        for (label, tensors, bytes_per_token) in [
+            ("K", self.k_gpu.as_slice(), k_bytes_per_token),
+            ("V", self.v_gpu.as_slice(), v_bytes_per_token),
+        ] {
+            for tensor in tensors {
+                if tensor.buf.is_vmm_owner() {
+                    capacity = capacity.min(tensor.buf.size() / bytes_per_token);
+                } else if tensor.numel() > 1 {
+                    return Err(hip_bridge::HipError::new(
+                        0,
+                        &format!(
+                            "VMM KV cache mixes a non-VMM real {label} tensor with VMM tensors"
+                        ),
+                    ));
+                }
+            }
+        }
+        Ok(Some(capacity))
+    }
+
+    pub fn require_mapped_capacity(&self, required_tokens: usize) -> HipResult<()> {
+        let Some(mapped_tokens) = self.mapped_token_capacity()? else {
+            return Ok(());
+        };
+        if required_tokens > self.physical_cap {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "KV write requires {required_tokens} tokens but physical_cap is {}",
+                    self.physical_cap
+                ),
+            ));
+        }
+        if required_tokens > mapped_tokens {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "VMM KV mapped prefix holds {mapped_tokens} tokens but the operation requires {required_tokens}"
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    fn grow_vmm_tensors(
+        gpu: &mut Gpu,
+        tensors: &mut [GpuTensor],
+        bytes_per_token: usize,
+        physical_cap: usize,
+        required_tokens: usize,
+    ) -> HipResult<usize> {
+        let mut grown = 0usize;
+        let device_id = gpu.device_id;
+        let minimum_growth_bytes = DEFAULT_VMM_PHYSICAL_CHUNK_BYTES;
+        for tensor in tensors {
+            if !tensor.buf.is_vmm_owner() {
+                if tensor.numel() > 1 {
+                    return Err(hip_bridge::HipError::new(
+                        0,
+                        "VMM KV cache contains a non-VMM real tensor",
+                    ));
+                }
+                continue;
+            }
+            let mapped = gpu.vmm_mapped_bytes(tensor).ok_or_else(|| {
+                hip_bridge::HipError::new(0, "VMM KV tensor is not registered with its GPU")
+            })?;
+            let granularity = gpu.vmm_granularity(tensor).ok_or_else(|| {
+                hip_bridge::HipError::new(0, "VMM KV tensor has no allocation granularity")
+            })?;
+            let plan = KvChunkPlan::new(
+                bytes_per_token,
+                physical_cap,
+                DEFAULT_KV_CHUNK_TOKENS,
+                granularity,
+                minimum_growth_bytes,
+            )
+            .map_err(|err| hip_bridge::HipError::new(0, &err.to_string()))?;
+            if let Some(growth) = plan
+                .growth(mapped, required_tokens)
+                .map_err(|err| hip_bridge::HipError::new(0, &err.to_string()))?
+            {
+                if gpu.graphs.capture_mode {
+                    return Err(hip_bridge::HipError::new(
+                        0,
+                        "VMM KV growth requested during graph capture",
+                    ));
+                }
+                gpu.grow_vmm_tensor(tensor, growth.size_bytes, &[device_id])?;
+                grown += 1;
+            }
+        }
+        Ok(grown)
+    }
+
+    pub fn ensure_mapped_capacity(
+        &mut self,
+        gpu: &mut Gpu,
+        required_tokens: usize,
+    ) -> HipResult<()> {
+        let Some(fast_capacity) = self.fast_mapped_token_capacity()? else {
+            return Ok(());
+        };
+        if required_tokens > self.physical_cap {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "KV write requires {required_tokens} tokens but physical_cap is {}",
+                    self.physical_cap
+                ),
+            ));
+        }
+        if required_tokens <= fast_capacity {
+            return Ok(());
+        }
+        let (k_bytes_per_token, v_bytes_per_token) = self.vmm_bytes_per_token()?;
+        // Growth is monotonic: if a later map fails, the next call keeps the
+        // completed prefixes and fills the lagging tensors before the final guard.
+        Self::grow_vmm_tensors(
+            gpu,
+            &mut self.k_gpu,
+            k_bytes_per_token,
+            self.physical_cap,
+            required_tokens,
+        )?;
+        Self::grow_vmm_tensors(
+            gpu,
+            &mut self.v_gpu,
+            v_bytes_per_token,
+            self.physical_cap,
+            required_tokens,
+        )?;
+        self.require_mapped_capacity(required_tokens)?;
+        Ok(())
     }
 
     /// Bytes of V-cache per token-position (all heads) for a given V mode.
@@ -6350,6 +6784,78 @@ impl KvCache {
         })
     }
 
+    /// VMM-backed Q8 cache for Qwen3.5 hybrid stacks. Virtual tensors reserve
+    /// `physical_cap`, while only a page-aligned token chunk is mapped initially.
+    pub fn new_gpu_q8_vmm_capped_filtered(
+        gpu: &mut Gpu,
+        is_kv_layer: &[bool],
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+        physical_cap: usize,
+    ) -> HipResult<Self> {
+        if physical_cap == 0 || physical_cap > max_seq_len {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "VMM q8 physical_cap must be in 1..=max_seq_len (got physical_cap={physical_cap}, max_seq_len={max_seq_len})"
+                ),
+            ));
+        }
+        if !is_kv_layer.iter().any(|is_kv| *is_kv) {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "VMM q8 requires at least one KV-carrying layer",
+            ));
+        }
+        let (kv_dim, cache_elems, _bytes_per_token) =
+            Self::q8_vmm_layout(n_kv_heads, head_dim, physical_cap)?;
+        let (k_gpu, v_gpu) =
+            Self::alloc_k_v_vmm_filtered(gpu, cache_elems, cache_elems, is_kv_layer)?;
+        let mut cache = Self {
+            k_gpu,
+            v_gpu,
+            k_scales: vec![],
+            v_scales: vec![],
+            kv_dim,
+            max_seq: max_seq_len,
+            physical_cap,
+            n_kv_heads,
+            head_dim,
+            quantized: true,
+            quant_q8: true,
+            quant_int8: false,
+            quant_hfq4: false,
+            quant_asym4: false,
+            quant_asym3: false,
+            quant_asym2: false,
+            quant_fwht: false,
+            boundary_layers: 0,
+            givens_cos: None,
+            givens_sin: None,
+            layer_is_boundary: vec![],
+            compact_offset: 0,
+            v_mode: VMode::Q8,
+        };
+        if let Err(err) = cache.ensure_mapped_capacity(gpu, 1) {
+            cache.free_gpu(gpu);
+            return Err(err);
+        }
+        let n_kv = is_kv_layer.iter().filter(|is_kv| **is_kv).count();
+        let mapped = match cache.mapped_token_capacity() {
+            Ok(capacity) => capacity.unwrap_or(0),
+            Err(err) => {
+                cache.free_gpu(gpu);
+                return Err(err);
+            }
+        };
+        eprintln!(
+            "KV cache: q8 vmm ({n_kv}/{} layers carry KV, mapped_prefix={mapped} / physical_cap={physical_cap} / max_seq={max_seq_len})",
+            is_kv_layer.len()
+        );
+        Ok(cache)
+    }
+
     /// Create INT8 co-located KV cache: [f32 scale][pad 4B][int8 × head_dim] = 136 bytes per head.
     pub fn new_gpu_int8c(
         gpu: &mut Gpu,
@@ -6985,6 +7491,114 @@ impl KvCache {
             compact_offset: 0,
             v_mode: VMode::Q8,
         })
+    }
+
+    /// VMM-backed Asym3-K/Q8-V cache for Qwen3.5 hybrid stacks.
+    pub fn new_gpu_asym3_vmm_capped_filtered(
+        gpu: &mut Gpu,
+        is_kv_layer: &[bool],
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+        physical_cap: usize,
+    ) -> HipResult<Self> {
+        if physical_cap == 0 || physical_cap > max_seq_len {
+            return Err(hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "VMM asym3 physical_cap must be in 1..=max_seq_len (got physical_cap={physical_cap}, max_seq_len={max_seq_len})"
+                ),
+            ));
+        }
+        if !is_kv_layer.iter().any(|is_kv| *is_kv) {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "VMM asym3 requires at least one KV-carrying layer",
+            ));
+        }
+        let (kv_dim, k_elems, v_elems, k_bytes_per_head, v_bytes_per_head) =
+            Self::asym3_vmm_layout(n_kv_heads, head_dim, physical_cap)?;
+        let (mut k_gpu, mut v_gpu) =
+            Self::alloc_k_v_vmm_filtered(gpu, k_elems, v_elems, is_kv_layer)?;
+
+        let n_blocks = head_dim / 2;
+        let (cos_vals, sin_vals) = Self::gen_givens_angles(42, n_blocks);
+        let cos_bytes: Vec<u8> = cos_vals.iter().flat_map(|v| v.to_ne_bytes()).collect();
+        let sin_bytes: Vec<u8> = sin_vals.iter().flat_map(|v| v.to_ne_bytes()).collect();
+        let tables = (|| -> HipResult<(GpuTensor, GpuTensor)> {
+            let cos = gpu.alloc_tensor(&[n_blocks], DType::F32)?;
+            let sin = match gpu.alloc_tensor(&[n_blocks], DType::F32) {
+                Ok(sin) => sin,
+                Err(err) => {
+                    let _ = gpu.free_tensor(cos);
+                    return Err(err);
+                }
+            };
+            if let Err(err) = gpu.hip.memcpy_htod(&cos.buf, &cos_bytes) {
+                let _ = gpu.free_tensor(cos);
+                let _ = gpu.free_tensor(sin);
+                return Err(err);
+            }
+            if let Err(err) = gpu.hip.memcpy_htod(&sin.buf, &sin_bytes) {
+                let _ = gpu.free_tensor(cos);
+                let _ = gpu.free_tensor(sin);
+                return Err(err);
+            }
+            Ok((cos, sin))
+        })();
+        let (cos, sin) = match tables {
+            Ok(tables) => tables,
+            Err(err) => {
+                for tensor in k_gpu.drain(..).chain(v_gpu.drain(..)) {
+                    let _ = gpu.free_tensor(tensor);
+                }
+                return Err(err);
+            }
+        };
+
+        let mut cache = Self {
+            k_gpu,
+            v_gpu,
+            k_scales: vec![],
+            v_scales: vec![],
+            kv_dim,
+            max_seq: max_seq_len,
+            physical_cap,
+            n_kv_heads,
+            head_dim,
+            quantized: true,
+            quant_q8: false,
+            quant_int8: false,
+            quant_hfq4: false,
+            quant_asym4: false,
+            quant_asym3: true,
+            quant_asym2: false,
+            quant_fwht: false,
+            boundary_layers: 0,
+            givens_cos: Some(cos),
+            givens_sin: Some(sin),
+            layer_is_boundary: vec![],
+            compact_offset: 0,
+            v_mode: VMode::Q8,
+        };
+        if let Err(err) = cache.ensure_mapped_capacity(gpu, 1) {
+            cache.free_gpu(gpu);
+            return Err(err);
+        }
+        let n_kv = is_kv_layer.iter().filter(|is_kv| **is_kv).count();
+        let mapped = match cache.mapped_token_capacity() {
+            Ok(capacity) => capacity.unwrap_or(0),
+            Err(err) => {
+                cache.free_gpu(gpu);
+                return Err(err);
+            }
+        };
+        eprintln!(
+            "KV cache: asym3 vmm ({n_kv}/{} layers carry KV; K {k_bytes_per_head}B/head + V {}B/head; mapped_prefix={mapped} / physical_cap={physical_cap} / max_seq={max_seq_len})",
+            is_kv_layer.len(),
+            v_bytes_per_head,
+        );
+        Ok(cache)
     }
 
     /// Filtered variant of fwht3 — signed-FWHT-256 K-rotation, 3-bit centroid,

--- a/crates/hipfire-runtime/src/loader_api.rs
+++ b/crates/hipfire-runtime/src/loader_api.rs
@@ -6,6 +6,7 @@
 //! holds only what the arch crates need to implement a carrier.
 
 use crate::hfq::HfqFile;
+use crate::kv_backend::KvBackend;
 use crate::safetensors_source::SafetensorsSource;
 use rdna_compute::Gpu;
 use std::path::Path;
@@ -62,6 +63,7 @@ pub struct LoadCtx<'a> {
     pub max_seq: usize,
     pub draft_path: Option<&'a str>,
     pub kv_mode_override: Option<&'a str>,
+    pub kv_backend: KvBackend,
     pub kv_adaptive_override: Option<&'a str>,
     pub state_quant_override: Option<&'a str>,
     pub cask: &'a CaskConfig,

--- a/crates/rdna-compute/examples/vmm_tensor_smoke.rs
+++ b/crates/rdna-compute/examples/vmm_tensor_smoke.rs
@@ -3,43 +3,152 @@
 // hipfire - see LICENSE and NOTICE in the project root.
 
 //! Verify that a VMM-backed GpuTensor grows and bypasses the hipFree pool path.
+//!
+//! Proves on hardware:
+//! - page/chunk boundary growth preserves prior bytes
+//! - grow-past-reserve fails without invalidating the allocation
+//! - owner teardown releases the tracked VMM allocation
+//! - unload/recreate (free then alloc) works
+//! - a deterministic map failure leaves no leaked tracked allocation and is
+//!   followed by a successful allocation
+//!
+//! Device selection (parent GPU-2 route):
+//!   HIPFIRE_VMM_SMOKE_DEVICE=2 cargo run -p rdna-compute --example vmm_tensor_smoke
+//! Optional knobs: HIPFIRE_VMM_CHUNK_BYTES (default 2 MiB)
 
 use rdna_compute::{DType, Gpu};
 
-const CHUNK_BYTES: usize = 2 << 20;
+const DEFAULT_CHUNK_BYTES: usize = 2 << 20;
+
+fn chunk_bytes() -> usize {
+    std::env::var("HIPFIRE_VMM_CHUNK_BYTES")
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_CHUNK_BYTES)
+}
+
+fn pattern(len: usize, mul: usize, add: usize) -> Vec<u8> {
+    (0..len).map(|i| ((i * mul + add) % 251) as u8).collect()
+}
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut gpu = Gpu::init()?;
-    let device = gpu.device_id;
-    let mut tensor =
-        unsafe { gpu.alloc_vmm_tensor(&[CHUNK_BYTES * 2], DType::Raw, CHUNK_BYTES, &[device])? };
-    assert_eq!(gpu.vmm_allocation_count(), 1);
-    assert_eq!(gpu.vmm_mapped_bytes(&tensor), Some(CHUNK_BYTES));
-    assert_eq!(tensor.buf.size(), CHUNK_BYTES);
+    let device = std::env::var("HIPFIRE_VMM_SMOKE_DEVICE")
+        .ok()
+        .and_then(|raw| raw.parse::<i32>().ok())
+        .unwrap_or(0);
+    let chunk = chunk_bytes();
+    let access = [device];
 
-    let first: Vec<u8> = (0..CHUNK_BYTES).map(|i| (i % 251) as u8).collect();
+    let mut gpu = Gpu::init_with_device(device)?;
+    assert_eq!(gpu.device_id, device);
+    assert_eq!(gpu.vmm_allocation_count(), 0);
+
+    // --- alloc + boundary growth preserves prior bytes ---
+    let mut tensor = unsafe { gpu.alloc_vmm_tensor(&[chunk * 2], DType::Raw, chunk, &access)? };
+    assert_eq!(gpu.vmm_allocation_count(), 1);
+    assert_eq!(gpu.vmm_mapped_bytes(&tensor), Some(chunk));
+    assert_eq!(tensor.buf.size(), chunk);
+    assert!(tensor.buf.is_vmm_owner());
+
+    let first = pattern(chunk, 1, 0);
     gpu.hip.memcpy_htod(&tensor.buf, &first)?;
 
-    let mapped = gpu.grow_vmm_tensor(&mut tensor, CHUNK_BYTES, &[device])?;
-    assert_eq!(mapped, CHUNK_BYTES * 2);
-    assert_eq!(tensor.buf.size(), CHUNK_BYTES * 2);
-    let second: Vec<u8> = (0..CHUNK_BYTES)
-        .map(|i| ((i * 17 + 3) % 251) as u8)
-        .collect();
-    gpu.hip
-        .memcpy_htod_offset(&tensor.buf, CHUNK_BYTES, &second)?;
+    let mapped = gpu.grow_vmm_tensor(&mut tensor, chunk, &access)?;
+    assert_eq!(mapped, chunk * 2);
+    assert_eq!(gpu.vmm_mapped_bytes(&tensor), Some(chunk * 2));
+    assert_eq!(tensor.buf.size(), chunk * 2);
+    let second = pattern(chunk, 17, 3);
+    gpu.hip.memcpy_htod_offset(&tensor.buf, chunk, &second)?;
 
-    let mut readback = vec![0u8; CHUNK_BYTES * 2];
+    let mut readback = vec![0u8; chunk * 2];
     gpu.hip.memcpy_dtoh(&mut readback, &tensor.buf)?;
-    assert_eq!(&readback[..CHUNK_BYTES], first.as_slice());
-    assert_eq!(&readback[CHUNK_BYTES..], second.as_slice());
+    assert_eq!(&readback[..chunk], first.as_slice());
+    assert_eq!(&readback[chunk..], second.as_slice());
+    println!("vmm_tensor_smoke: BOUNDARY_GROWTH PASS (mapped={mapped})");
 
+    // --- grow past reservation fails; prior mapping + tracking intact ---
+    let gran = gpu
+        .vmm_granularity(&tensor)
+        .expect("registered VMM tensor must expose granularity");
+    let over = gran.max(1);
+    let err = gpu
+        .grow_vmm_tensor(&mut tensor, over, &access)
+        .expect_err("grow past reserve must fail");
+    assert!(
+        err.to_string().contains("exceed reserve") || err.to_string().contains("VMM map"),
+        "unexpected over-reserve error: {err}"
+    );
+    assert_eq!(gpu.vmm_allocation_count(), 1);
+    assert_eq!(gpu.vmm_mapped_bytes(&tensor), Some(chunk * 2));
+    assert!(tensor.buf.is_vmm_owner());
+    let mut still = vec![0u8; chunk * 2];
+    gpu.hip.memcpy_dtoh(&mut still, &tensor.buf)?;
+    assert_eq!(still, readback);
+    println!("vmm_tensor_smoke: OVER_RESERVE_FAIL PASS (allocation intact)");
+
+    // --- borrowed alias must not free the owner ---
     let alias = tensor.shallow_clone();
     assert!(gpu.free_tensor(alias).is_err());
     assert_eq!(gpu.vmm_allocation_count(), 1);
 
+    // --- owner teardown releases tracked allocation ---
     gpu.free_tensor(tensor)?;
     assert_eq!(gpu.vmm_allocation_count(), 0);
+    println!("vmm_tensor_smoke: OWNER_TEARDOWN PASS");
+
+    // --- unload / recreate ---
+    let mut tensor2 = unsafe { gpu.alloc_vmm_tensor(&[chunk], DType::Raw, chunk, &access)? };
+    assert_eq!(gpu.vmm_allocation_count(), 1);
+    let p2 = pattern(chunk, 5, 9);
+    gpu.hip.memcpy_htod(&tensor2.buf, &p2)?;
+    let mut rb2 = vec![0u8; chunk];
+    gpu.hip.memcpy_dtoh(&mut rb2, &tensor2.buf)?;
+    assert_eq!(rb2, p2);
+    gpu.free_tensor(tensor2)?;
+    assert_eq!(gpu.vmm_allocation_count(), 0);
+    println!("vmm_tensor_smoke: UNLOAD_RELOAD PASS");
+
+    // --- deterministic allocation/map failure: no leaked tracking; next alloc ok ---
+    // Non-granular initial map size is rejected before the arena is registered.
+    // Fall back to mapping more than the reserved logical size when granularity == 1.
+    let fail_err = if gran > 1 {
+        let bad_initial = gran.saturating_sub(1).max(1);
+        match unsafe { gpu.alloc_vmm_tensor(&[chunk], DType::Raw, bad_initial, &access) } {
+            Ok(_) => panic!("non-granular initial map must fail"),
+            Err(err) => err,
+        }
+    } else {
+        // Reserve `chunk` but ask to map `chunk + gran` up front.
+        match unsafe { gpu.alloc_vmm_tensor(&[chunk], DType::Raw, chunk + gran, &access) } {
+            Ok(_) => panic!("initial map past reserve must fail"),
+            Err(err) => err,
+        }
+    };
+    assert!(
+        fail_err.to_string().contains("multiple of granularity")
+            || fail_err.to_string().contains("exceed reserve")
+            || fail_err.to_string().contains("VMM map"),
+        "unexpected deterministic failure: {fail_err}"
+    );
+    // Successful cleanup path must not leave a tracked/orphan arena behind.
+    assert_eq!(
+        gpu.vmm_allocation_count(),
+        0,
+        "failed alloc must not leak a tracked VMM arena"
+    );
+    // Follow with a successful allocation.
+    let mut tensor3 = unsafe { gpu.alloc_vmm_tensor(&[chunk], DType::Raw, chunk, &access)? };
+    assert_eq!(gpu.vmm_allocation_count(), 1);
+    assert_eq!(gpu.vmm_mapped_bytes(&tensor3), Some(chunk));
+    let p3 = pattern(chunk, 11, 2);
+    gpu.hip.memcpy_htod(&tensor3.buf, &p3)?;
+    let mut rb3 = vec![0u8; chunk];
+    gpu.hip.memcpy_dtoh(&mut rb3, &tensor3.buf)?;
+    assert_eq!(rb3, p3);
+    gpu.free_tensor(tensor3)?;
+    assert_eq!(gpu.vmm_allocation_count(), 0);
+    println!("vmm_tensor_smoke: CLEANUP_AFTER_FAILURE PASS");
+
     println!("vmm_tensor_smoke: PASS");
     Ok(())
 }

--- a/crates/rdna-compute/examples/vmm_tensor_smoke.rs
+++ b/crates/rdna-compute/examples/vmm_tensor_smoke.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire - see LICENSE and NOTICE in the project root.
+
+//! Verify that a VMM-backed GpuTensor grows and bypasses the hipFree pool path.
+
+use rdna_compute::{DType, Gpu};
+
+const CHUNK_BYTES: usize = 2 << 20;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut gpu = Gpu::init()?;
+    let device = gpu.device_id;
+    let mut tensor =
+        unsafe { gpu.alloc_vmm_tensor(&[CHUNK_BYTES * 2], DType::Raw, CHUNK_BYTES, &[device])? };
+    assert_eq!(gpu.vmm_allocation_count(), 1);
+    assert_eq!(gpu.vmm_mapped_bytes(&tensor), Some(CHUNK_BYTES));
+    assert_eq!(tensor.buf.size(), CHUNK_BYTES);
+
+    let first: Vec<u8> = (0..CHUNK_BYTES).map(|i| (i % 251) as u8).collect();
+    gpu.hip.memcpy_htod(&tensor.buf, &first)?;
+
+    let mapped = gpu.grow_vmm_tensor(&mut tensor, CHUNK_BYTES, &[device])?;
+    assert_eq!(mapped, CHUNK_BYTES * 2);
+    assert_eq!(tensor.buf.size(), CHUNK_BYTES * 2);
+    let second: Vec<u8> = (0..CHUNK_BYTES)
+        .map(|i| ((i * 17 + 3) % 251) as u8)
+        .collect();
+    gpu.hip
+        .memcpy_htod_offset(&tensor.buf, CHUNK_BYTES, &second)?;
+
+    let mut readback = vec![0u8; CHUNK_BYTES * 2];
+    gpu.hip.memcpy_dtoh(&mut readback, &tensor.buf)?;
+    assert_eq!(&readback[..CHUNK_BYTES], first.as_slice());
+    assert_eq!(&readback[CHUNK_BYTES..], second.as_slice());
+
+    let alias = tensor.shallow_clone();
+    assert!(gpu.free_tensor(alias).is_err());
+    assert_eq!(gpu.vmm_allocation_count(), 1);
+
+    gpu.free_tensor(tensor)?;
+    assert_eq!(gpu.vmm_allocation_count(), 0);
+    println!("vmm_tensor_smoke: PASS");
+    Ok(())
+}

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -1770,15 +1770,9 @@ impl Gpu {
 
     // ── Tensor allocation ───────────────────────────────────────
 
-    pub fn ensure_gemv_residual_tmp(
-        &mut self,
-        min_elems: usize,
-    ) -> HipResult<&GpuTensor> {
-        self.scratch.ensure_gemv_residual_tmp(
-            &self.hip,
-            self.device_id,
-            min_elems,
-        )
+    pub fn ensure_gemv_residual_tmp(&mut self, min_elems: usize) -> HipResult<&GpuTensor> {
+        self.scratch
+            .ensure_gemv_residual_tmp(&self.hip, self.device_id, min_elems)
     }
 
     pub fn alloc_tensor(&mut self, shape: &[usize], dtype: DType) -> HipResult<GpuTensor> {
@@ -1851,15 +1845,7 @@ impl Gpu {
     ) -> HipError {
         let cleanup_error = arena.release(&self.hip).err();
         if !arena.is_released() {
-            let key = arena.base_address();
-            match self.vmm_arenas.entry(key) {
-                std::collections::hash_map::Entry::Occupied(_) => {
-                    self.orphan_vmm_arenas.push(arena);
-                }
-                std::collections::hash_map::Entry::Vacant(entry) => {
-                    entry.insert(arena);
-                }
-            }
+            self.orphan_vmm_arenas.push(arena);
         }
         match cleanup_error {
             Some(cleanup) => HipError::new(
@@ -1915,7 +1901,68 @@ impl Gpu {
     /// Returns the number of arenas still pending cleanup.
     pub fn retry_vmm_cleanup(&mut self) -> HipResult<usize> {
         self.bind_thread()?;
-        self.release_registered_vmm()
+        self.release_pending_vmm()
+    }
+
+    /// Retry pending VMM arenas and require a fully idle owner table.
+    ///
+    /// Success means `vmm_allocation_count() == 0`. Any remaining registration
+    /// is an error so unload/load cannot claim a clean handoff.
+    pub fn ensure_vmm_cleaned(&mut self) -> HipResult<()> {
+        let live = self.vmm_arenas.len();
+        if live != 0 {
+            return Err(HipError::new(
+                0,
+                &format!(
+                    "refusing VMM cleanup while {live} live VMM tensor owner(s) remain; unload the active model first"
+                ),
+            ));
+        }
+        match self.retry_vmm_cleanup() {
+            Ok(0) => Ok(()),
+            Ok(n) => Err(HipError::new(
+                0,
+                &format!("VMM teardown incomplete: {n} arena(s) still pending"),
+            )),
+            Err(err) => {
+                let n = self.orphan_vmm_arenas.len();
+                if n == 0 {
+                    Err(err)
+                } else {
+                    Err(HipError::new(
+                        err.code,
+                        &format!("{err}; {n} arena(s) still pending"),
+                    ))
+                }
+            }
+        }
+    }
+
+    fn release_pending_vmm(&mut self) -> HipResult<usize> {
+        let mut first_error = None;
+        let mut orphan_index = 0;
+        while orphan_index < self.orphan_vmm_arenas.len() {
+            let (result, released) = {
+                let arena = &mut self.orphan_vmm_arenas[orphan_index];
+                let result = arena.release(&self.hip);
+                (result, arena.is_released())
+            };
+            if released {
+                let released_arena = self.orphan_vmm_arenas.swap_remove(orphan_index);
+                debug_assert!(released_arena.is_released());
+            } else {
+                orphan_index += 1;
+            }
+            if let Err(err) = result {
+                if first_error.is_none() {
+                    first_error = Some(err);
+                }
+            }
+        }
+        match first_error {
+            Some(err) => Err(err),
+            None => Ok(self.orphan_vmm_arenas.len()),
+        }
     }
 
     fn release_registered_vmm(&mut self) -> HipResult<usize> {
@@ -1936,23 +1983,9 @@ impl Gpu {
                 }
             }
         }
-        let mut orphan_index = 0;
-        while orphan_index < self.orphan_vmm_arenas.len() {
-            let (result, released) = {
-                let arena = &mut self.orphan_vmm_arenas[orphan_index];
-                let result = arena.release(&self.hip);
-                (result, arena.is_released())
-            };
-            if released {
-                let released_arena = self.orphan_vmm_arenas.swap_remove(orphan_index);
-                debug_assert!(released_arena.is_released());
-            } else {
-                orphan_index += 1;
-            }
-            if let Err(err) = result {
-                if first_error.is_none() {
-                    first_error = Some(err);
-                }
+        if let Err(err) = self.release_pending_vmm() {
+            if first_error.is_none() {
+                first_error = Some(err);
             }
         }
         match first_error {
@@ -2029,32 +2062,42 @@ impl Gpu {
         })
     }
 
+    /// Free a tensor. Contiguous buffers return to the pool. VMM owners run
+    /// arena release once: success removes the registration; failure **retains**
+    /// the arena for [`Self::retry_vmm_cleanup`] / [`Self::ensure_vmm_cleaned`]
+    /// and returns the error (never a false clean free).
     pub fn free_tensor(&mut self, tensor: GpuTensor) -> HipResult<()> {
         self.bind_thread()?;
         let key = tensor.buf.as_ptr() as usize;
-        if let Some(arena) = self.vmm_arenas.get_mut(&key) {
+        if self.vmm_arenas.contains_key(&key) {
             if !tensor.buf.is_vmm_owner() {
                 return Err(HipError::new(
                     0,
                     &format!("refusing to free borrowed VMM view at 0x{key:x}"),
                 ));
             }
-            let result = match arena.release(&self.hip) {
-                Err(first) if !arena.is_released() => match arena.release(&self.hip) {
-                    Ok(()) => Ok(()),
-                    Err(retry) => Err(HipError::new(
-                        retry.code,
+            let mut arena = self.vmm_arenas.remove(&key).unwrap();
+            let result = arena.release(&self.hip);
+            if arena.is_released() {
+                result
+            } else {
+                // The tensor owner has been consumed, so keep its still-live
+                // arena only in the pending table. Cleanup retries must never
+                // touch entries in `vmm_arenas`, which are active owners.
+                self.orphan_vmm_arenas.push(arena);
+                match result {
+                    Ok(()) => Err(HipError::new(
+                        0,
                         &format!(
-                            "VMM tensor cleanup failed, then retry failed: {first}; retry: {retry}"
+                            "VMM tensor at 0x{key:x} reported success but arena is still live"
                         ),
                     )),
-                },
-                result => result,
-            };
-            if arena.is_released() {
-                self.vmm_arenas.remove(&key);
+                    Err(err) => Err(HipError::new(
+                        err.code,
+                        &format!("{err}; arena retained for retry"),
+                    )),
+                }
             }
-            result
         } else if tensor.buf.is_borrowed() || tensor.buf.is_vmm_owner() {
             Err(HipError::new(
                 0,
@@ -2116,11 +2159,18 @@ impl Gpu {
             .replay_graph_destroy_all(&self.hip, self.device_id);
     }
 
-    /// Drop captured graph state after a live KV layout switch so the next
-    /// forward captures the current K/V modes and kernarg blobs.
+    /// Drop captured graph state and retained Redline replay after a live KV
+    /// layout switch so the next forward cannot replay stale K/V modes, base
+    /// pointers, or kernarg blobs baked under the prior tier.
     pub fn invalidate_for_kv_mode_switch(&mut self) {
-        // bind_thread: skip — delegates to invalidate_graph_state(), which binds.
+        // bind_thread: skip — invalidate_graph_state binds; replay.poison is CPU.
         self.invalidate_graph_state();
+        // Retained AQL/PM4 tapes capture KV base pointers and tier-dependent
+        // kernargs. Poison so no old tape can run against the new logical layout.
+        if self.replay.is_enabled() || self.replay.state() != crate::replay::ReplayState::Hip {
+            self.replay
+                .poison("KV mode switch invalidated retained Redline replay state");
+        }
     }
 
     // ── Kernel operations ───────────────────────────────────────
@@ -3096,5 +3146,188 @@ mod tests {
             s1,
             "seed 43 should differ from seed 42"
         );
+    }
+
+    fn try_gpu() -> Option<super::Gpu> {
+        super::Gpu::init().ok()
+    }
+
+    #[test]
+    fn ensure_vmm_cleaned_never_releases_a_live_owner() {
+        let Some(mut gpu) = try_gpu() else {
+            eprintln!("skip: no GPU");
+            return;
+        };
+        hip_bridge::clear_vmm_faults();
+        let tensor = match unsafe { gpu.alloc_vmm_tensor(&[4096], super::DType::Raw, 0, &[]) } {
+            Ok(tensor) => tensor,
+            Err(_) => {
+                eprintln!("skip: VMM unavailable");
+                return;
+            }
+        };
+        assert_eq!(gpu.vmm_allocation_count(), 1);
+
+        let err = gpu
+            .ensure_vmm_cleaned()
+            .expect_err("load cleanup must refuse a still-owned VMM arena");
+        assert!(err.to_string().contains("live VMM"), "{err}");
+        assert_eq!(gpu.vmm_allocation_count(), 1);
+        assert_eq!(gpu.vmm_mapped_bytes(&tensor), Some(0));
+
+        gpu.free_tensor(tensor).expect("free live owner");
+        assert_eq!(gpu.vmm_allocation_count(), 0);
+    }
+
+    #[test]
+    fn free_tensor_unmap_failure_retains_owner_for_retry() {
+        let Some(mut gpu) = try_gpu() else {
+            eprintln!("skip: no GPU");
+            return;
+        };
+        hip_bridge::clear_vmm_faults();
+        let chunk = {
+            // Discover granularity via a throwaway arena path.
+            let probe = unsafe { gpu.alloc_vmm_tensor(&[4096], super::DType::Raw, 0, &[]) };
+            match probe {
+                Ok(t) => {
+                    let g = gpu.vmm_granularity(&t).unwrap_or(2 * 1024 * 1024);
+                    let _ = gpu.free_tensor(t);
+                    g
+                }
+                Err(_) => {
+                    eprintln!("skip: VMM unavailable");
+                    return;
+                }
+            }
+        };
+        let access = [gpu.device_id];
+        let tensor = unsafe {
+            gpu.alloc_vmm_tensor(&[chunk], super::DType::Raw, chunk, &access)
+                .expect("alloc vmm")
+        };
+        assert_eq!(gpu.vmm_allocation_count(), 1);
+        hip_bridge::inject_vmm_fault(hip_bridge::VmmFaultKind::Unmap, 1);
+        let err = gpu
+            .free_tensor(tensor)
+            .expect_err("unmap fault must surface");
+        assert!(
+            err.to_string().contains("retained") || err.to_string().contains("injected"),
+            "{err}"
+        );
+        assert_eq!(
+            gpu.vmm_allocation_count(),
+            1,
+            "failed free must keep the arena registered"
+        );
+        // No double-free: retry with faults cleared must release exactly once.
+        hip_bridge::clear_vmm_faults();
+        gpu.ensure_vmm_cleaned().expect("retry cleanup");
+        assert_eq!(gpu.vmm_allocation_count(), 0);
+        // Idle ensure is a no-op success (no double free).
+        gpu.ensure_vmm_cleaned().expect("second ensure on idle");
+    }
+
+    #[test]
+    fn free_tensor_release_failure_retains_owner_for_retry() {
+        let Some(mut gpu) = try_gpu() else {
+            eprintln!("skip: no GPU");
+            return;
+        };
+        hip_bridge::clear_vmm_faults();
+        let access = [gpu.device_id];
+        let chunk = 2 * 1024 * 1024;
+        let tensor =
+            match unsafe { gpu.alloc_vmm_tensor(&[chunk], super::DType::Raw, chunk, &access) } {
+                Ok(t) => t,
+                Err(_) => {
+                    eprintln!("skip: VMM unavailable");
+                    return;
+                }
+            };
+        assert_eq!(gpu.vmm_allocation_count(), 1);
+        hip_bridge::inject_vmm_fault(hip_bridge::VmmFaultKind::Release, 1);
+        let err = gpu
+            .free_tensor(tensor)
+            .expect_err("release fault must surface");
+        assert!(
+            err.to_string().contains("retained") || err.to_string().contains("injected"),
+            "{err}"
+        );
+        assert_eq!(gpu.vmm_allocation_count(), 1);
+        hip_bridge::clear_vmm_faults();
+        assert_eq!(gpu.retry_vmm_cleanup().expect("retry"), 0);
+        assert_eq!(gpu.vmm_allocation_count(), 0);
+    }
+
+    #[test]
+    fn access_reset_failure_does_not_publish_live_owner() {
+        let Some(mut gpu) = try_gpu() else {
+            eprintln!("skip: no GPU");
+            return;
+        };
+        hip_bridge::clear_vmm_faults();
+        let access = [gpu.device_id];
+        let chunk = 2 * 1024 * 1024;
+        let before = gpu.vmm_allocation_count();
+        hip_bridge::inject_vmm_fault(hip_bridge::VmmFaultKind::AccessReset, 1);
+        let err = match unsafe { gpu.alloc_vmm_tensor(&[chunk], super::DType::Raw, chunk, &access) }
+        {
+            Ok(tensor) => {
+                let _ = gpu.free_tensor(tensor);
+                panic!("access-reset fault must fail initial map");
+            }
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string().contains("injected") || err.to_string().contains("access"),
+            "{err}"
+        );
+        hip_bridge::clear_vmm_faults();
+        // Successful cleanup leaves no pending owner; if cleanup itself failed
+        // the arena stays registered and ensure_vmm_cleaned must still drain it.
+        if gpu.vmm_allocation_count() > before {
+            gpu.ensure_vmm_cleaned()
+                .expect("drain retained after access fault");
+        }
+        assert_eq!(gpu.vmm_allocation_count(), before);
+        // Subsequent alloc works (no poisoned process state).
+        let ok = unsafe { gpu.alloc_vmm_tensor(&[chunk], super::DType::Raw, chunk, &access) }
+            .expect("alloc after access fault");
+        let _ = gpu.free_tensor(ok).expect("free");
+        assert_eq!(gpu.vmm_allocation_count(), before);
+    }
+
+    #[test]
+    fn ensure_vmm_cleaned_refuses_while_pending() {
+        let Some(mut gpu) = try_gpu() else {
+            eprintln!("skip: no GPU");
+            return;
+        };
+        hip_bridge::clear_vmm_faults();
+        let access = [gpu.device_id];
+        let chunk = 2 * 1024 * 1024;
+        let tensor =
+            match unsafe { gpu.alloc_vmm_tensor(&[chunk], super::DType::Raw, chunk, &access) } {
+                Ok(t) => t,
+                Err(_) => {
+                    eprintln!("skip: VMM unavailable");
+                    return;
+                }
+            };
+        hip_bridge::inject_vmm_fault(hip_bridge::VmmFaultKind::Unmap, 2); // free + ensure attempt
+        let _ = gpu.free_tensor(tensor).expect_err("fault");
+        let err = gpu
+            .ensure_vmm_cleaned()
+            .expect_err("must refuse while pending");
+        assert!(
+            err.to_string().contains("pending") || err.to_string().contains("injected"),
+            "{err}"
+        );
+        assert!(gpu.vmm_allocation_count() >= 1);
+        hip_bridge::clear_vmm_faults();
+        gpu.ensure_vmm_cleaned()
+            .expect("clears after faults drained");
+        assert_eq!(gpu.vmm_allocation_count(), 0);
     }
 }

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -8,7 +8,7 @@
 use crate::compiler::KernelCompiler;
 use crate::feature_flags::FeatureFlags;
 use crate::kernels;
-use hip_bridge::{DeviceBuffer, HipResult, HipRuntime, Rocblas};
+use hip_bridge::{DeviceBuffer, HipError, HipResult, HipRuntime, Rocblas, VmmArena};
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::sync::atomic::AtomicUsize;
@@ -133,10 +133,23 @@ impl GpuTensor {
     /// `offset_elems` is the number of f32 elements to skip.
     /// The returned tensor is a view — do NOT free it.
     pub fn sub_offset(&self, offset_elems: usize, len_elems: usize) -> GpuTensor {
-        let byte_off = offset_elems * self.dtype.size();
+        let element_size = self.dtype.size();
+        let byte_off = offset_elems
+            .checked_mul(element_size)
+            .expect("tensor sub-view offset overflow");
+        let byte_len = len_elems
+            .checked_mul(element_size)
+            .expect("tensor sub-view length overflow");
+        let byte_end = byte_off
+            .checked_add(byte_len)
+            .expect("tensor sub-view range overflow");
+        assert!(
+            byte_end <= self.buf.size(),
+            "tensor sub-view exceeds accessible buffer prefix"
+        );
         let ptr = unsafe { (self.buf.as_ptr() as *mut u8).add(byte_off) as *mut std::ffi::c_void };
         GpuTensor {
-            buf: unsafe { hip_bridge::DeviceBuffer::from_raw(ptr, len_elems * self.dtype.size()) },
+            buf: unsafe { hip_bridge::DeviceBuffer::from_raw(ptr, byte_len) },
             shape: vec![len_elems],
             dtype: self.dtype,
         }
@@ -406,6 +419,12 @@ pub struct Gpu {
     pub(crate) modules: HashMap<String, hip_bridge::Module>,
     pub(crate) functions: HashMap<String, hip_bridge::Function>,
     pub(crate) pool: crate::pool::GpuPool,
+    /// VMM owners keyed by their base virtual address. VMM-backed tensors use
+    /// non-owning DeviceBuffer views and must bypass GpuPool/hipFree teardown.
+    vmm_arenas: HashMap<usize, VmmArena>,
+    /// Arenas whose cleanup failed before they could enter the owner map.
+    /// They have no tensor owner and are retried during explicit/Gpu teardown.
+    orphan_vmm_arenas: Vec<VmmArena>,
     /// When set, all kernel launches go to this stream instead of null stream.
     pub active_stream: Option<hip_bridge::Stream>,
     /// Scratch buffers for FWHT rotation, FP16/FP8 activation conversion, etc.
@@ -821,6 +840,8 @@ impl Gpu {
             modules: HashMap::new(),
             functions: HashMap::new(),
             pool: crate::pool::GpuPool::new(),
+            vmm_arenas: HashMap::new(),
+            orphan_vmm_arenas: Vec::new(),
             active_stream: None,
             scratch: crate::scratch::ScratchState {
                 mq_signs1: None,
@@ -1772,6 +1793,174 @@ impl Gpu {
         })
     }
 
+    /// Reserve a dense virtual tensor and optionally map its initial prefix.
+    /// The returned tensor follows the normal kernel ABI, but its ownership is
+    /// registered separately so `free_tensor` releases VMM handles instead of
+    /// routing the address through `hipFree`.
+    ///
+    /// # Safety
+    ///
+    /// The returned tensor describes its full reserved shape. The caller must
+    /// keep every operation within the prefix reported by `vmm_mapped_bytes`,
+    /// growing the mapping before any wider access.
+    pub unsafe fn alloc_vmm_tensor(
+        &mut self,
+        shape: &[usize],
+        dtype: DType,
+        initial_mapped_bytes: usize,
+        access_devices: &[i32],
+    ) -> HipResult<GpuTensor> {
+        self.bind_thread()?;
+        let numel = shape
+            .iter()
+            .try_fold(1usize, |product, &dimension| product.checked_mul(dimension))
+            .ok_or_else(|| HipError::new(0, "VMM tensor element count overflowed"))?;
+        let byte_size = numel
+            .checked_mul(dtype.size())
+            .ok_or_else(|| HipError::new(0, "VMM tensor byte size overflowed"))?;
+        let mut arena = VmmArena::reserve(&self.hip, self.device_id, byte_size)?;
+        if initial_mapped_bytes > 0 {
+            if let Err(err) = arena.map_next(&self.hip, initial_mapped_bytes, access_devices) {
+                return Err(self.retain_failed_vmm_arena(arena, err));
+            }
+        }
+        let buf = match arena.owner_buffer(byte_size) {
+            Ok(buf) => buf,
+            Err(err) => {
+                return Err(self.retain_failed_vmm_arena(arena, err));
+            }
+        };
+        let key = buf.as_ptr() as usize;
+        if self.vmm_arenas.contains_key(&key) {
+            let duplicate =
+                HipError::new(0, &format!("duplicate VMM tensor base address 0x{key:x}"));
+            return Err(self.retain_failed_vmm_arena(arena, duplicate));
+        }
+        self.vmm_arenas.insert(key, arena);
+        Ok(GpuTensor {
+            buf,
+            shape: shape.to_vec(),
+            dtype,
+        })
+    }
+
+    fn retain_failed_vmm_arena(
+        &mut self,
+        mut arena: VmmArena,
+        operation_error: HipError,
+    ) -> HipError {
+        let cleanup_error = arena.release(&self.hip).err();
+        if !arena.is_released() {
+            let key = arena.base_address();
+            match self.vmm_arenas.entry(key) {
+                std::collections::hash_map::Entry::Occupied(_) => {
+                    self.orphan_vmm_arenas.push(arena);
+                }
+                std::collections::hash_map::Entry::Vacant(entry) => {
+                    entry.insert(arena);
+                }
+            }
+        }
+        match cleanup_error {
+            Some(cleanup) => HipError::new(
+                0,
+                &format!(
+                    "{operation_error}; cleanup also failed: {cleanup}; arena retained for retry"
+                ),
+            ),
+            None => operation_error,
+        }
+    }
+
+    /// Grow the mapped prefix of a VMM-backed tensor by page-aligned bytes.
+    pub fn grow_vmm_tensor(
+        &mut self,
+        tensor: &mut GpuTensor,
+        additional_bytes: usize,
+        access_devices: &[i32],
+    ) -> HipResult<usize> {
+        self.bind_thread()?;
+        let key = tensor.buf.as_ptr() as usize;
+        let logical_bytes = tensor.byte_size();
+        let arena = self.vmm_arenas.get_mut(&key).ok_or_else(|| {
+            HipError::new(
+                0,
+                &format!("tensor at 0x{key:x} is not a registered VMM owner"),
+            )
+        })?;
+        arena.map_next(&self.hip, additional_bytes, access_devices)?;
+        let mapped_bytes = arena.mapped_bytes();
+        tensor.buf = unsafe { arena.owner_buffer(logical_bytes)? };
+        Ok(mapped_bytes)
+    }
+
+    pub fn vmm_mapped_bytes(&self, tensor: &GpuTensor) -> Option<usize> {
+        self.vmm_arenas
+            .get(&(tensor.buf.as_ptr() as usize))
+            .map(VmmArena::mapped_bytes)
+    }
+
+    /// Return the physical allocation granularity for a registered VMM tensor.
+    pub fn vmm_granularity(&self, tensor: &GpuTensor) -> Option<usize> {
+        self.vmm_arenas
+            .get(&(tensor.buf.as_ptr() as usize))
+            .map(VmmArena::granularity)
+    }
+
+    pub fn vmm_allocation_count(&self) -> usize {
+        self.vmm_arenas.len() + self.orphan_vmm_arenas.len()
+    }
+
+    /// Retry teardown for VMM arenas retained after an earlier cleanup error.
+    /// Returns the number of arenas still pending cleanup.
+    pub fn retry_vmm_cleanup(&mut self) -> HipResult<usize> {
+        self.bind_thread()?;
+        self.release_registered_vmm()
+    }
+
+    fn release_registered_vmm(&mut self) -> HipResult<usize> {
+        let keys: Vec<usize> = self.vmm_arenas.keys().copied().collect();
+        let mut first_error = None;
+        for key in keys {
+            let (result, released) = {
+                let arena = self.vmm_arenas.get_mut(&key).unwrap();
+                let result = arena.release(&self.hip);
+                (result, arena.is_released())
+            };
+            if released {
+                self.vmm_arenas.remove(&key);
+            }
+            if let Err(err) = result {
+                if first_error.is_none() {
+                    first_error = Some(err);
+                }
+            }
+        }
+        let mut orphan_index = 0;
+        while orphan_index < self.orphan_vmm_arenas.len() {
+            let (result, released) = {
+                let arena = &mut self.orphan_vmm_arenas[orphan_index];
+                let result = arena.release(&self.hip);
+                (result, arena.is_released())
+            };
+            if released {
+                let released_arena = self.orphan_vmm_arenas.swap_remove(orphan_index);
+                debug_assert!(released_arena.is_released());
+            } else {
+                orphan_index += 1;
+            }
+            if let Err(err) = result {
+                if first_error.is_none() {
+                    first_error = Some(err);
+                }
+            }
+        }
+        match first_error {
+            Some(err) => Err(err),
+            None => Ok(self.vmm_allocation_count()),
+        }
+    }
+
     pub fn upload_f32(&mut self, data: &[f32], shape: &[usize]) -> HipResult<GpuTensor> {
         self.bind_thread()?;
         let tensor = self.alloc_tensor(shape, DType::F32)?;
@@ -1842,8 +2031,39 @@ impl Gpu {
 
     pub fn free_tensor(&mut self, tensor: GpuTensor) -> HipResult<()> {
         self.bind_thread()?;
-        self.pool.free(tensor.buf);
-        Ok(())
+        let key = tensor.buf.as_ptr() as usize;
+        if let Some(arena) = self.vmm_arenas.get_mut(&key) {
+            if !tensor.buf.is_vmm_owner() {
+                return Err(HipError::new(
+                    0,
+                    &format!("refusing to free borrowed VMM view at 0x{key:x}"),
+                ));
+            }
+            let result = match arena.release(&self.hip) {
+                Err(first) if !arena.is_released() => match arena.release(&self.hip) {
+                    Ok(()) => Ok(()),
+                    Err(retry) => Err(HipError::new(
+                        retry.code,
+                        &format!(
+                            "VMM tensor cleanup failed, then retry failed: {first}; retry: {retry}"
+                        ),
+                    )),
+                },
+                result => result,
+            };
+            if arena.is_released() {
+                self.vmm_arenas.remove(&key);
+            }
+            result
+        } else if tensor.buf.is_borrowed() || tensor.buf.is_vmm_owner() {
+            Err(HipError::new(
+                0,
+                &format!("refusing to pool non-owning tensor at 0x{key:x}"),
+            ))
+        } else {
+            self.pool.free(tensor.buf);
+            Ok(())
+        }
     }
 
     /// Drain the GPU memory pool. Actually calls hipFree on all pooled buffers.
@@ -2698,10 +2918,13 @@ impl Drop for Gpu {
     /// impls call `hipFree` etc. Uses `bind_thread_or_warn` to avoid
     /// panic-in-Drop from `bind_thread`'s `debug_assert!`.
     fn drop(&mut self) {
-        if std::thread::panicking() {
+        if std::thread::panicking() && self.vmm_allocation_count() == 0 {
             return;
         }
         self.bind_thread_or_warn();
+        if let Err(err) = self.release_registered_vmm() {
+            eprintln!("[rdna-compute] failed to release VMM arena during Gpu drop: {err}");
+        }
     }
 }
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -242,8 +242,8 @@ else universal fallback **`q8`**. There is no per-arch implicit FWHT table.
 `kv_adaptive` is opt-in. With adaptive on, `max_seq` is the context guaranteed at the floor tier. Daemon param overrides `HIPFIRE_KV_ADAPTIVE` when set through CLI load path.
 
 `--kv-backend vmm` enables on-demand HIP VMM mapping for single-GPU Qwen3.5
-`q8` and `asym3` KV caches. The default remains `contiguous`. VMM currently
-does not compose with pipeline/expert parallelism or CASK/TriAttention
+`q8`, `asym3`, and `fwht3` KV caches. The default remains `contiguous`. VMM
+currently does not compose with pipeline/expert parallelism or CASK/TriAttention
 eviction.
 
 Legacy one-shot alias: `HIPFIRE_KV_MODE` (see [`env-vars.md`](env-vars.md)).

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -241,6 +241,11 @@ else universal fallback **`q8`**. There is no per-arch implicit FWHT table.
 
 `kv_adaptive` is opt-in. With adaptive on, `max_seq` is the context guaranteed at the floor tier. Daemon param overrides `HIPFIRE_KV_ADAPTIVE` when set through CLI load path.
 
+`--kv-backend vmm` enables on-demand HIP VMM mapping for single-GPU Qwen3.5
+`q8` and `asym3` KV caches. The default remains `contiguous`. VMM currently
+does not compose with pipeline/expert parallelism or CASK/TriAttention
+eviction.
+
 Legacy one-shot alias: `HIPFIRE_KV_MODE` (see [`env-vars.md`](env-vars.md)).
 
 ---

--- a/docs/plans/2026-07-28-pr549-vmm-all-kv-adaptive-design.md
+++ b/docs/plans/2026-07-28-pr549-vmm-all-kv-adaptive-design.md
@@ -1,0 +1,500 @@
+# Design: PR #549 VMM — all static KV modes + adaptive KV
+
+**Date:** 2026-07-28  
+**Status:** design approved (interactive user approval 2026-07-28); merge-complete target for FireMap / PR #549  
+**Claim class:** `planned` (this record) + scoped `measured` MQ4R evidence below (gfx1201 only)  
+**Related:** PR #549 (`feat/firemap-vmm-kv`), `docs/plans/2026-05-31-adaptive-kv-design.md`, `docs/plans/2026-05-31-kv-vquant-fwht-lloyd-v-design.md`, `docs/VALIDATION.md`, `docs/REDLINE.md`
+
+This document is the user-approved merge-complete design for extending PR #549
+VMM beyond Q8/Asym3 to the full single-GPU Qwen3.5/3.6 masked KV matrix,
+including legal Lloyd-V overrides and adaptive KV. It freezes architecture,
+lifecycle, failure, and evidence gates. It does not change code by itself.
+
+**Approval:** design was approved interactively by the user on 2026-07-28.
+
+---
+
+## 1. Status and context
+
+### 1.1 What PR #549 already is
+
+FireMap (PR #549) adds an opt-in HIP VMM backend for single-GPU Qwen3.5 KV:
+
+- Reserve a stable virtual address range up front.
+- Map physical pages in coarse chunks as context grows.
+- Keep dense KV kernels and captured-graph base pointers unchanged.
+- Default remains `contiguous`; enable with `--kv-backend vmm`.
+- Reject unsupported models / PP / TP / CASK / TriAttention / unsupported
+  encodings instead of silent fallback.
+
+Draft PR scope was Q8 + Asym3 only. Merge-complete scope (this design) widens
+**KV encoding** coverage, not weight formats.
+
+### 1.2 Weight quantization vs KV encoding
+
+These are independent axes. Do not conflate them in CLI, logs, or claims.
+
+| Axis | What it selects | Examples |
+|---|---|---|
+| **Weight quantization** | How model weights are stored/decoded | MQ4R, Q8 weights, Paro, HFQ families, Lloyd **weight** dtypes |
+| **KV encoding** | How the attention K/V cache is packed | static `q8`, `asym2/3/4`, `fwht2/3/4`; Lloyd-V overrides; adaptive tier ladder |
+
+VMM is a **KV storage backend**. It does not change weight codecs. MQ4R in the
+evidence section is a **weight** format used on the measured route; the KV
+modes under test are separate.
+
+### 1.3 Why this design exists
+
+Contiguous KV pays full `max_seq × current_stride` physical VRAM at load.
+Adaptive KV already floor-sizes contiguous buffers and downshifts in place, but
+still commits the full floor-sized physical allocation immediately. VMM keeps
+the same logical contract while deferring physical commit to mapped prefixes —
+and, under adaptive, while allowing tier stride changes without replacing the
+stable virtual owners.
+
+---
+
+## 2. Goals
+
+1. **Single-GPU Qwen3.5 / Qwen3.6 masked KV** on VMM for:
+   - all **seven static** KV modes: `q8`, `asym2`, `asym3`, `asym4`, `fwht2`,
+     `fwht3`, `fwht4`;
+   - **legal Lloyd-V overrides** on FWHT-K paths (`lloyd2` / `lloyd3` /
+     `lloyd4` V with the existing FWHT-K + `head_dim=256` guards);
+   - **adaptive KV** (floor-reserved, start FWHT4/Q8, pattern-driven downshift).
+2. **One stable K VMM arena and one stable V VMM arena per real attention
+   layer** for the life of the load. Kernels and retained/graph captures keep
+   base pointers.
+3. **Resolve final layout before allocation.** Load never creates VMM owners
+   then replaces them through contiguous reallocators (`set_v_mode_realloc`,
+   floor realloc that swaps buffers, etc.).
+4. **Tier-aware capacity:** current K and V tier strides independently govern
+   mapping growth and token capacity (min-of-two-buffers, same as adaptive).
+5. **Fail closed** on map/transcode/teardown errors (no log-and-skip; no clean
+   unload/reload with pending arenas; poison on partial transcode).
+6. **Evidence-gated merge:** CPU layout/failure tests, gfx1201 all-seven static
+   hardware, adaptive transition/reset tests, existing Q8/FWHT3 DFlash path
+   proof, MQ4R matched retained-PM4 + VRAM proof (claims scoped gfx1201 only).
+
+---
+
+## 3. Explicit non-goals
+
+Out of scope for this merge-complete design:
+
+| Non-goal | Note |
+|---|---|
+| **Pipeline parallel (PP)** | VMM path remains single-GPU; PP stays contiguous / rejected on VMM |
+| **Multi-GPU / TP** | No multi-device VMM arenas, no cross-GPU pooling |
+| **CASK / TriAttention eviction and compaction** | Reject on VMM; ordinary masked-cache `physical_cap` remains part of VMM reserve sizing |
+| **Flat-Llama carriers** | Masked Qwen3.5/3.6 attention layers only; flat Llama KV constructors stay contiguous |
+| **Adaptive DFlash** | Existing static Q8/FWHT3 DFlash-on-VMM proof stays; adaptive×DFlash is follow-up |
+| **PagedAttention / RadixAttention / prefix sharing** | Still not this PR |
+| **Token-level mappings** | Coarse chunk map growth only |
+| **Default-on VMM or default-on adaptive** | Both remain opt-in |
+| **Kernel ISA changes for VMM** | Dense kernels unchanged; backend/ownership/lifecycle only |
+| **Unscoped perf speedup claims** | No “VMM is faster” product claim; see measured MQ4R table only |
+
+---
+
+## 4. Current defects (must fix in the same merge)
+
+These are known correctness/lifecycle holes the approved design closes. They are
+requirements, not optional polish.
+
+### 4.1 Adaptive controller drop
+
+If adaptive is enabled but the controller is dropped, never installed, or not
+hooked on a path that still writes KV, the cache stays at the start tier while
+`seq_pos` grows past start-tier capacity → overflow / corruption.  
+**Requirement:** adaptive engagement is all-or-nothing at load: controller
+present, floors applied to reserve math, hooks on every committed-write path in
+scope (prefill chunk boundary + decode). Missing controller ⇒ hard load error,
+not silent contiguous-style growth.
+
+### 4.2 Balanced floor mismatch
+
+`Preset::Balanced` must be the genuine middle rung **K=`fwht3`, V=`lloyd3`**
+(not identical to Aggressive `fwht2`/`lloyd2`). Reserve, thresholds, and user
+docs must use the same floors. A preset that advertises balanced but reserves
+aggressive floors (or the reverse) is a merge blocker.
+
+### 4.3 Cache / controller reset desync
+
+Any cold KV reset (context rollover, explicit reset, or failed-generation
+cleanup that clears the cache) **must atomically restore both sides**:
+
+- cache encoding state: K=`fwht4`, V=`q8`;
+- adaptive controller: K=`fwht4`, V=`q8`, step index 0.
+
+Resetting only the controller while leaving `KvCache` flags at a downshifted
+tier is a desynchronization bug, as is resetting cache flags without the
+controller thresholds.
+
+### 4.4 Log-and-skip errors
+
+Map growth failure, transcode failure, and teardown/unreserve failure must
+**propagate**. Logging and continuing is forbidden: it leaves kernels pointing
+at unmapped VA, half-transcoded layers, or process-global pending VMM state.
+
+---
+
+## 5. Considered approaches
+
+### 5.1 Contiguous only (status quo for most modes)
+
+Full physical commit at load. Simple, but pays peak KV VRAM immediately and
+forces adaptive to either over-commit high tiers or reallocate (pointer churn,
+graph invalidation storms, realloc hazard with captured pointers).
+
+### 5.2 Single shared VA arena for K+V
+
+One reserve per layer packing K and V. Fewer HIP VMM objects, but couples K/V
+growth, complicates independent tier strides, and makes min-of-two capacity
+accounting error-prone. Rejected.
+
+### 5.3 Reallocate-on-downshift (replace owners)
+
+On each adaptive step, free and allocate new buffers at the new stride. Breaks
+stable graph/retained base pointers, fights FireMap’s purpose, and reintroduces
+the contiguous realloc path the design forbids for VMM owners. Rejected.
+
+### 5.4 Grow-only VMM at max(current) stride without floor reserve
+
+Reserve only current-tier bytes × max_seq, then try to extend the VA when
+downshift needs more tokens. HIP VA reserve extension is not a portable
+primitive here; would require remap/copy and pointer changes. Rejected.
+
+### 5.5 Selected: floor-reserved, tier-aware dual arenas (K and V)
+
+**Winner.** Per real attention layer:
+
+- One **K** VMM arena + one **V** VMM arena.
+- **Static modes:** reserve at the **current** K/V stride × configured token
+  horizon (`physical_cap` / `max_seq` as today’s constructors define).
+- **Adaptive:** reserve at the **floor** K stride and **floor** V stride ×
+  `max_seq` (guaranteed floor context); start tiers are FWHT4 / Q8; live token
+  capacity is min-of-two at **current** strides; downshift **compacts in place**
+  inside the existing VA, increases token capacity, does **not** unmap or
+  replace owners, and invalidates HipGraph + retained replay.
+
+Matches shipped adaptive capacity math, preserves FireMap’s stable-pointer
+invariant, and composes with independent K/V tier changes.
+
+---
+
+## 6. Storage and capacity invariants
+
+### 6.1 Owners
+
+For each real FA/masked attention layer index `i`:
+
+- `K_arena[i]`: stable VA, VMM-owned, never replaced for the load lifetime.
+- `V_arena[i]`: stable VA, VMM-owned, never replaced for the load lifetime.
+- Non-KV layers keep today’s cheap placeholders (not VMM-backed).
+
+Placeholder layers must not register VMM arenas.
+
+### 6.2 Reserve sizing
+
+Let `bph_k(tier)` / `bph_v(tier)` be bytes-per-head at `head_dim` (existing
+tables: K fwht4=132, fwht3=100, fwht2=68; asym packed layouts as today; V
+q8=272, lloyd4=132, lloyd3=100, lloyd2=68 at hd=256).
+
+```
+static:
+  K_reserve_bytes = physical_cap × n_kv_heads × bph_k(current_k)
+  V_reserve_bytes = physical_cap × n_kv_heads × bph_v(current_v)
+
+adaptive:
+  K_reserve_bytes = max_seq × n_kv_heads × bph_k(k_floor)
+  V_reserve_bytes = max_seq × n_kv_heads × bph_v(v_floor)
+  start: cur_k = fwht4, cur_v = q8
+```
+
+Reserve is virtual. Physical pages commit via mapped-prefix growth only.
+
+### 6.3 Token capacity (min-of-two)
+
+```
+cap(cur_k, cur_v) = min(
+  reserve_tokens_k × bph_k(k_reserve_tier) / bph_k(cur_k),
+  reserve_tokens_v × bph_v(v_reserve_tier) / bph_v(cur_v),
+)
+```
+
+For static, reserve tier = current tier ⇒ `cap = physical_cap` (modulo existing
+constructor rules). For adaptive, reserve tier = floor ⇒ capacity grows as
+strides shrink. **Never** use a shared-pool sum of K+V bytes for capacity;
+lopsided states would over-admit tokens on the binding side.
+
+### 6.4 Mapping vs logical length
+
+- `mapped_tokens_k` / `mapped_tokens_v` track how far physical mapping covers
+  at the **current** stride (chunk-rounded).
+- Before any KV write or attention read that touches position `p`, both arenas
+  must be mapped through `p` at current strides.
+- **Mapping failure aborts before write.** No kernel launch into unmapped VA.
+
+### 6.5 Downshift compaction
+
+On adaptive step:
+
+1. Copy each live source-tier layer prefix `0..seq_pos` to the existing
+   source-sized scratch buffer.
+2. Transcode from scratch into the compacted prefix at the front of the
+   **same** stable K or V VA. Do not rely on overlapping read/write safety.
+3. Update current tier flags / kernarg-facing mode bits only after every real
+   layer succeeds.
+4. Recompute `cap` and mapping high-water in **new** stride units (the same
+   mapped bytes can cover more tokens).
+5. **Do not unmap** solely because stride shrank; do not replace arenas.
+6. Invalidate HipGraph + retained replay (§8).
+
+### 6.6 Seven static modes + Lloyd + adaptive coverage
+
+| Mode | K encoding | Default V | VMM static | Lloyd-V override | Adaptive role |
+|---|---|---|---|---|---|
+| `q8` | Q8_0 K | Q8_0 | yes | no (V already Q8) | V start tier only |
+| `asym2` | rotated 2-bit K | Q8_0 | yes | no (asym≠fwht path) | none |
+| `asym3` | rotated 3-bit K | Q8_0 | yes | no | none |
+| `asym4` | rotated 4-bit K | Q8_0 | yes | no | none |
+| `fwht2` | FWHT 2-bit K | Q8_0 | yes | legal lloyd2/3/4 if guards pass | optional K floor |
+| `fwht3` | FWHT 3-bit K | Q8_0 | yes | legal lloyd2/3/4 | optional K floor |
+| `fwht4` | FWHT 4-bit K | Q8_0 | yes | legal lloyd2/3/4 | mandatory K start; optional K floor |
+
+Lloyd-V remains subject to existing invariants: FWHT-K, `head_dim==256`, and
+any width/pairing asserts already enforced on contiguous paths. Illegal pairs
+fail at load resolution, not mid-session. Adaptive always starts FWHT4/Q8;
+`fwht2` and `fwht3` in this table describe possible floors, not alternate
+start modes.
+
+Adaptive presets (floors):
+
+| Preset | K floor | V floor |
+|---|---|---|
+| conservative | fwht4 | lloyd4 |
+| **balanced** | **fwht3** | **lloyd3** |
+| aggressive | fwht2 | lloyd2 |
+| advanced | user K ∈ {fwht4,fwht3,fwht2}, V ∈ {lloyd4,lloyd3,lloyd2} | |
+
+---
+
+## 7. Load and runtime transition flow
+
+### 7.1 Load (single resolution pass)
+
+```
+parse CLI/config
+  → resolve kv_mode, kv_v, kv_adaptive, kv_backend
+  → reject PP/multi-GPU/CASK/flat-llama/unsupported combos on vmm
+  → if adaptive:
+       require/resolve the start encoding exactly as K=fwht4, V=q8
+       compute floor reserve strides from preset/advanced
+       install controller (mandatory)
+  → else:
+       compute static current-tier strides (incl. Lloyd-V if set)
+  → allocate dual VMM arenas per real layer at resolved reserve
+  → map initial prefix (policy: at least one chunk / prefill needs)
+  → never call contiguous reallocators on those owners afterward
+```
+
+**Invariant:** final K/V layout, backend, and adaptive floors are known
+**before** the first `hipMem*` reserve. No “allocate Q8 contiguous, then
+convert to VMM / lloyd / floor.”
+
+### 7.2 Prefill / decode
+
+```
+ensure_mapped(k, v, through=need_pos)   # fail → abort before write
+write KV at current tier
+attend
+on committed boundary:
+  maybe_downshift(...)                  # adaptive only
+    → compact in place
+    → invalidate graph + retained replay
+    → continue
+```
+
+### 7.3 Static tier changes after load
+
+User mid-load “switch kv mode” that would change reserve stride is out of
+scope. Contiguous `set_v_mode_realloc`-style **owner replacement** is forbidden
+for VMM. Adaptive downshifts are the only approved mid-session tier changes, and
+they keep owners.
+
+---
+
+## 8. Graph and retained-replay invalidation
+
+Any successful adaptive downshift (K or V) **must**:
+
+1. Invalidate HipGraph capture/replay state for affected batch keys
+   (`invalidate_for_kv_mode_switch` or equivalent full clear used today).
+2. Invalidate **retained replay** / Redline tape state that baked KV base
+   pointers, tier flags, or kernargs dependent on K/V mode.
+
+No “graph stays live, only V kernarg changes” optimization in this design:
+K kernel selection and V-mode bits both change across the ladder; retained
+paths must not replay stale packets into a new logical layout.
+
+Static VMM without tier change does **not** require per-chunk invalidation:
+mapped-prefix growth keeps the same base VA (FireMap property). Growth still
+preflights before touch so replay never faults on unmapped tails.
+
+---
+
+## 9. Reset, failure, and unload semantics
+
+### 9.1 Reset
+
+On KV cold reset:
+
+- Clear logical seq/len/watermarks.
+- Reset adaptive controller to start (fwht4/q8, step 0) **with** the cache.
+- Do not free VMM arenas; do not require unmap of the whole reserve.
+- Next prefill rewrites the live prefix at start tiers.
+
+### 9.2 Mapping failure
+
+- Detected in ensure-mapped / grow.
+- **Abort before write or attend.**
+- Error propagates to the generation/load caller.
+- No partial token commit that assumed the map succeeded.
+
+### 9.3 Partial transcode failure
+
+- If any layer fails mid-downshift, **poison the model** until full reload.
+- Do not leave a mixed-tier cache runnable.
+- Scratch discipline must not present half-applied steps as success.
+
+### 9.4 Teardown / unload
+
+- Teardown errors **propagate** (not log-and-skip).
+- Unmap + unreserve every **registered** arena; on failure, **retry** remaining
+  registered arenas; still report error.
+- **No clean unload / no new load** while pending arenas remain registered in
+  process-global VMM ownership tables.
+- Process must not advertise a successful idle unload if arenas leak.
+
+### 9.5 Poison and engagement
+
+- Poisoned model rejects further generate until unload+load.
+- Serve/harness path proofs must show actual VMM engagement markers when
+  `kv_backend=vmm` was requested (fail closed if absent).
+
+---
+
+## 10. CLI / harness review corrections (fold into merge)
+
+Approved review fixes that ship with this design:
+
+1. **Final DFlash draft projection runs after the CLI selector**  
+   Speculator/draft resolution order: CLI speculation selector wins, then draft
+   projection/finalization. Do not project a draft path that the selector has
+   already disabled, and do not let an earlier projection override the selector.
+
+2. **Request-level DFlash proof**  
+   A “draft loaded” marker proves only load-time availability. After requests
+   complete, every harness run that requires DFlash must show a request-level
+   discriminator such as DFlash `tau`/cycle accounting or an exact
+   per-request drafter-route marker. An all-AR run fails even when a draft was
+   loaded successfully.
+
+3. **Current-attempt log slicing**  
+   Capture the serve-log offset before each spawn attempt and evaluate VMM,
+   draft-load, graph, and request-route markers only after that offset. Run
+   request-level assertions after requests return; prior retry attempts must
+   not satisfy the current attempt.
+
+These are merge requirements alongside the KV lifecycle rules above.
+
+---
+
+## 11. Validation and merge gates
+
+No gate is optional for the claim it covers. Vocabulary follows
+`docs/VALIDATION.md` (automatic vs manual; fail closed).
+
+| Gate | Purpose |
+|---|---|
+| **CPU layout / capacity tests** | Every static K mode × legal V tier; reserve math; min-of-two capacity; mapped-token capacity increase after downshift; balanced floor distinct from aggressive; controller/cache reset pairing |
+| **CPU failure tests** | Deterministic `hipMemMap`, `hipMemSetAccess`, `hipMemUnmap`, and `hipMemRelease` failures; map-fail-before-write; constructor rollback; teardown retry and pending-arena refusal; poison on partial transcode |
+| **gfx1201 all-seven static hardware** | Each of `q8`, `asym2`, `asym3`, `asym4`, `fwht2`, `fwht3`, and `fwht4` through load, prefill, AR decode, graph capture/replay, mapping-boundary growth, unload, and reload |
+| **Adaptive hardware** | Conservative/balanced/aggressive transitions during multi-chunk prefill and AR; stable K/V addresses; mapped-token capacity growth after downshift; transcode parity against direct target-tier writes; reset, unload, and reload |
+| **Existing Q8 / FWHT3 DFlash** | Static VMM+DFlash request-level route proof on both already-supported encodings; adaptive DFlash remains rejected |
+| **MQ4R retained-PM4 + VRAM** | Canonical Q8 TG128 route proof; matched contiguous/VMM throughput; max-context load VRAM; exact post-unload idle baseline |
+| **CLI and serve regressions** | Config-off + `run --spec dflash` retains inherited draft; DFlash requires per-request evidence; all serve assertions use the current-attempt log slice |
+| **Final repository gates** | Changed-file rustfmt, workspace clippy, workspace unit suite, GitNexus change-scope report, and independent adversarial rereview |
+
+Claims from hardware evidence are **gfx1201-scoped** unless a future record
+adds another arch with its own table.
+
+---
+
+## 12. Observed MQ4R evidence (gfx1201 only)
+
+Recorded measurements for the matched MQ4R route. Do not generalize to other
+arches, models, or KV modes without new evidence. Not an admission row.
+
+### 12.1 Decode throughput (tok/s) and retained route proof
+
+| Arm | tok/s | Retained route proof |
+|---|---:|---|
+| Golden contiguous | **200.870** | valid route |
+| Matched contiguous | **200.975** | valid at positions 128/255 |
+| VMM arm A | **202.544** | valid at positions 128/255 |
+| VMM arm B | **201.121** | valid at positions 128/255 |
+
+All listed retained route proofs are **valid** at positions **128** and **255**.
+
+These figures are observational matched runs, not a product claim that “VMM is
+faster.” Deltas are within normal stationary noise for this setup; the merge
+bar is **no material regression + valid route proof**, not a speedup admission.
+
+### 12.2 VRAM (Q8 KV, max_seq=32768)
+
+| Backend | Bytes |
+|---|---:|
+| Contiguous | **24,591,974,400** |
+| VMM | **24,256,430,080** |
+| Reduction | **320 MiB** |
+
+### 12.3 Unload
+
+| Check | Bytes |
+|---|---:|
+| Exact idle after unload | **59,912,192** |
+
+Unload must reach this exact idle footprint in the measured configuration;
+pending-arena leaks fail the gate.
+
+---
+
+## 13. Open implementation notes (unavoidable only)
+
+1. **HIP VMM FFI surface** stays behind the existing optional load path; no
+   hard link requirement when `kv_backend=contiguous`.
+2. **Chunk size policy** remains coarse page-aligned growth (FireMap planner);
+   not part of the tier math except through mapping round-up.
+3. **Sign-table width** for fwht2/4 vs fwht3 and lloyd-V follows existing
+   adaptive/contiguous rules (256-wide signs when lloyd or fwht3 requires them).
+4. **Adaptive × DFlash** deliberately open: static Q8/FWHT3 DFlash-on-VMM is in
+   gate; wiring `maybe_downshift` on DFlash committed positions is a follow-up
+   (non-goal: adaptive DFlash).
+5. **Implementation may land in stacked commits** but must not merge with any
+   §4 defect still open or any §11 gate skipped for its claim class.
+
+---
+
+## 14. Summary
+
+Merge-complete PR #549 VMM is **floor-reserved, tier-aware dual arenas** for
+masked single-GPU Qwen3.5/3.6 KV: seven static modes, legal Lloyd-V, and
+adaptive KV with stable K/V VA owners, min-of-two capacity, in-place downshift,
+strict map/transcode/teardown failure semantics, and harness proof order fixes.
+PP, multi-GPU, CASK, flat-Llama carriers, and adaptive DFlash stay out.
+Evidence is explicit; MQ4R numbers above are gfx1201-only and complete as
+recorded.
+
+**User-approved design: 2026-07-28.**

--- a/docs/plans/2026-07-28-pr549-vmm-all-kv-adaptive-plan.md
+++ b/docs/plans/2026-07-28-pr549-vmm-all-kv-adaptive-plan.md
@@ -1,0 +1,178 @@
+# PR #549 VMM all-KV + adaptive implementation plan
+
+**Date:** 2026-07-28  
+**Design contract:** `docs/plans/2026-07-28-pr549-vmm-all-kv-adaptive-design.md`  
+**Execution scope:** single-GPU Qwen3.5/3.6 masked KV only
+
+## Outcome
+
+PR #549 is mergeable only when the VMM backend owns stable K/V virtual addresses for all seven static KV modes, legal Lloyd-V overrides, and adaptive KV; adaptive transitions and resets remain capacity-safe; unload cannot hide pending VMM arenas; and the CLI/serve proof regressions found in review are closed.
+
+This plan deliberately excludes PP, multi-GPU, CASK/TriAttention compaction, flat-Llama carriers, and adaptive DFlash. Static Q8/FWHT3 DFlash remains required.
+
+## Shared contracts
+
+1. **Backend ownership:** a real VMM K/V tensor is never replaced by `gpu.zeros`, `set_v_mode_realloc`, or `set_adaptive_floor_alloc` after publication.
+2. **Stable address:** each real FA layer has one K arena and one V arena for the load lifetime.
+3. **Capacity:** K and V reserve/mapping arithmetic is independent; admitted tokens are the minimum of both current-tier capacities.
+4. **Adaptive schedule:** start is exactly FWHT4/Q8. Reserve tiers come from the controller’s actual floors, not separately parsed hints.
+5. **Failure:** map failure precedes write; partial transcode poisons the model; teardown failure is returned and leaves a registered retry target.
+6. **Execution capture:** static mapping growth preserves capture identity; tier changes/reset invalidate HipGraph and retained replay state.
+7. **Proof:** load markers are not request-route proof. DFlash requires current-attempt, request-level evidence.
+
+## Phase 1 — impact map and API boundary
+
+Before editing each named symbol, run GitNexus upstream impact and warn on HIGH/CRITICAL results as required by `AGENTS.md`. Run LSP references before changing exported signatures.
+
+Establish the narrow API boundary:
+
+- `crates/hipfire-runtime/src/llama.rs`
+  - replace the Q8/Asym3/FWHT3-only layout branching with one validated private K/V layout representation;
+  - keep existing public wrappers where they remain useful, but make layout bytes the single source of truth;
+  - represent reserve bytes separately from current encoding stride so adaptive can reserve at floors while starting FWHT4/Q8.
+- `crates/hipfire-arch-qwen35/src/carrier.rs`
+  - resolve K mode, static V override, and adaptive controller before allocating KV;
+  - pass one resolved storage request into `KvCache`.
+- `crates/hipfire-arch-qwen35/src/carrier.rs` / `crates/hipfire-loader/src/lib.rs`
+  - carry `Option<KvAdaptive>` through `Qwen35Bundle` and attach it to `LoadedModel`.
+
+Do not add a second public configuration surface. Existing `kv_mode`, `HIPFIRE_KV_V`, `kv_adaptive`, and `kv_backend` remain authoritative.
+
+## Phase 2 — all static VMM layouts
+
+### Runtime storage changes
+
+In `crates/hipfire-runtime/src/llama.rs`:
+
+1. Generalize packed K bytes/head for Q8 and asym/FWHT 2/3/4-bit formats.
+2. Generalize V bytes/head for Q8 and Lloyd2/3/4.
+3. Compute checked per-token K/V strides and checked reserve elements independently.
+4. Construct VMM caches for:
+   - `q8`;
+   - `asym2`, `asym3`, `asym4`;
+   - `fwht2`, `fwht3`, `fwht4`;
+   - legal FWHT-K + Lloyd-V combinations.
+5. Reuse existing Givens/FWHT sign-table rules exactly; upgrade to 256-wide signs when the selected Lloyd/FWHT path requires them.
+6. Extend backend validation to the seven static modes while preserving single-GPU, masked-layer, positive-capacity, and no-CASK gates.
+7. Make `vmm_bytes_per_token`, `fast_mapped_token_capacity`, `mapped_token_capacity`, and `ensure_mapped_capacity` derive from current cache flags/V mode for every legal static encoding.
+8. Preserve constructor rollback: every allocated arena is released if a later allocation, initial map, or marker calculation fails.
+
+### Carrier changes
+
+In `crates/hipfire-arch-qwen35/src/carrier.rs`:
+
+- parse `HIPFIRE_KV_V` before cache construction;
+- reject illegal Asym/Lloyd combinations explicitly;
+- for VMM, construct the final static K/V layout directly;
+- for contiguous, preserve existing observable behavior while sharing validation where practical.
+
+### Functional smoke checkpoint
+
+On gfx1201 GPU2, exercise each static mode through load, prefill, AR decode, graph capture/replay, at least one mapping boundary, unload, and reload. Stop and fix source behavior before admitting cleanup work if any mode silently falls back to contiguous or produces incoherent output.
+
+## Phase 3 — adaptive VMM integration
+
+### Resolve one authoritative schedule
+
+In `crates/hipfire-arch-qwen35/src/carrier.rs` and `crates/hipfire-runtime/src/kv_adaptive.rs`:
+
+1. Parse preset/advanced policy once.
+2. Build `KvAdaptive` first and take `k_floor`/`v_floor` from that controller.
+3. Correct Balanced to FWHT3/Lloyd3 everywhere.
+4. Require the adaptive start encoding exactly FWHT4/Q8.
+5. Reject adaptive with explicit Lloyd override, CASK, PP/multi-GPU, unsupported head geometry, insufficient start capacity, or DFlash.
+6. Treat malformed/unsupported explicit adaptive requests as load errors rather than ignored warnings.
+
+### Floor-reserved VMM construction
+
+In `crates/hipfire-runtime/src/llama.rs`:
+
+- reserve K at `max_seq × n_kv_heads × k_floor_bph`;
+- reserve V at `max_seq × n_kv_heads × v_floor_bph`;
+- expose current strides as FWHT4/Q8 initially;
+- map based on current strides and current required positions;
+- after successful downshift, retain mapped pages and recompute token capacity from the new current stride;
+- never call the contiguous adaptive resize path on VMM owners.
+
+### Controller attachment and runtime hooks
+
+- Add `kv_adaptive: Option<KvAdaptive>` to `Qwen35Bundle` or an equivalently narrow load result.
+- Move it into `LoadedModel.kv_adaptive` in `finish_qwen35_load`.
+- Keep prefill-chunk, post-prefill, and linear-decode hooks, but propagate failures.
+- A map-growth error aborts before the next write.
+- A transcode error after any layer may have changed poisons the loaded model; further generation is rejected until unload/reload.
+
+### Reset and capture invalidation
+
+- Replace controller-only reset with one operation that, after the cache is cleared, restores cache flags and controller state to FWHT4/Q8 step 0.
+- Use it for explicit reset, abort cleanup, context rollover, and reload lifecycle.
+- Extend `Gpu::invalidate_for_kv_mode_switch` (or add a narrowly named sibling) to destroy HipGraph state and reset/poison the retained replay controller so no old KV-mode tape can run.
+
+### Functional smoke checkpoint
+
+On gfx1201 GPU2, force conservative, balanced, and aggressive thresholds during multi-chunk prefill and AR decode. Observe stable K/V base addresses, successful tier logs, increased mapped-token capacity after stride reduction, coherent output, reset back to FWHT4/Q8, and clean unload/reload.
+
+## Phase 4 — teardown and retry semantics
+
+Affected files:
+
+- `crates/hipfire-runtime/src/llama.rs`
+- `crates/rdna-compute/src/dispatch.rs`
+- `crates/hipfire-loader/src/lib.rs`
+- `crates/hipfire-runtime/examples/daemon.rs`
+- low-level VMM smoke examples as needed
+
+Required behavior:
+
+1. `KvCache::free_gpu` attempts every tensor and returns cleanup failure instead of discarding it.
+2. `Gpu::free_tensor` continues registering arenas whose release did not complete.
+3. Model unload invokes registered-arena retry after model-specific frees and ordinary pool drain.
+4. The daemon emits unload success only when no pending VMM arena remains.
+5. A new model load retries and then refuses to proceed if prior arenas remain pending.
+6. Initial-map/access failures release all earlier owners; mid-growth failure preserves the prior prefix.
+
+Functional checkpoint: injected map/access/unmap/release failures must never produce a false clean unload, and a successful retry must restore the exact idle allocation count before reload.
+
+## Phase 5 — CLI and serve proof corrections
+
+These are independent of the storage implementation and may execute in parallel once their impact analyses are complete.
+
+### Final DFlash draft projection
+
+In `crates/hipfire-cli/src/main.rs`:
+
+- finalize the CLI speculation selector first;
+- then project inherited `HIPFIRE_DFLASH_DRAFT` when the final selector enables DFlash;
+- cover config-off + inherited draft + `run --spec dflash` without changing config-only behavior.
+
+### Current-attempt, request-level serve proof
+
+In `scripts/serve_harness.py`:
+
+- record the serve-log byte offset before each spawn attempt;
+- evaluate startup VMM/draft/graph markers only in that attempt’s slice;
+- run DFlash route assertions after requests return;
+- require request-level DFlash `tau`/cycle or equivalent exact discriminator;
+- fail an all-AR run even if the draft loaded.
+
+Functional checkpoint: a synthetic stale prior-attempt log cannot satisfy current proof, and a loaded-but-forced-AR DFlash run fails closed.
+
+## Phase 6 — integrated hardware smoke
+
+Use the approved GPU2 route and current source/binary identity.
+
+1. Repeat the all-seven static matrix.
+2. Repeat adaptive conservative/balanced/aggressive transition/reset matrix.
+3. Repeat static Q8 and FWHT3 production serve DFlash with modern speculation TOML and request-level proof.
+4. Repeat graph capture, context growth, unload/reload, and allocation-failure paths.
+5. Repeat MQ4R Q8 TG128 retained-PM4 matched comparison:
+   - valid lifecycle and timed route proof;
+   - contiguous and VMM stationary measurements;
+   - `max_seq=32768` load VRAM;
+   - exact idle footprint after unload.
+
+The existing measured reference is not a guaranteed floor: contiguous 200.975 tok/s, VMM 202.544/201.121 tok/s, 320 MiB lower initial VRAM, idle 59,912,192 B. New evidence must be reported as a fresh matched observation.
+
+## Cleanup admission
+
+Only after the integrated smoke demonstrates the requested behavior may the execution tracker add cleanup tasks for permanent tests, docs reconciliation, rustfmt, clippy, workspace unit checks, GitNexus `detect_changes`, and final adversarial review. This preserves the repository workflow rule that housekeeping cannot steer an unproven implementation.

--- a/scripts/serve_harness.py
+++ b/scripts/serve_harness.py
@@ -121,14 +121,26 @@ def build_config(args):
     think_cap = THINKING_BUDGET.get(args.thinking)
     if think_cap is None:
         sys.exit(f"thinking_budget {args.thinking!r} not a key of {list(THINKING_BUDGET)}")
+    draft = getattr(args, "draft", None)
+    if draft:
+        draft = os.path.abspath(os.path.expanduser(draft))
+    else:
+        # Preserve caller-pinned draft env; do not invent a path.
+        env_draft = os.environ.get("HIPFIRE_DFLASH_DRAFT")
+        draft = os.path.abspath(os.path.expanduser(env_draft)) if env_draft else None
     return {
         "model": args.model, "tag": tag, "kv": args.kv, "mtp": args.mtp,
+        "kv_backend": getattr(args, "kv_backend", "contiguous") or "contiguous",
+        "dflash": getattr(args, "dflash", "off") or "off",
+        "draft": draft,
         "thinking_budget": args.thinking, "thinking_cap_tokens": think_cap,
         "max_tokens": args.max_tokens, "sampling": samp, "sampling_source": samp_src,
         "mode": args.mode, "port": args.port, "seed": getattr(args, "seed", None),
         "prompts_file": getattr(args, "prompts_file", None),
         "replay_route_proof_log": bool(getattr(args, "replay_route_proof_log", False)),
     }
+
+
 
 
 def load_prompt_battery(prompts_file):
@@ -144,7 +156,8 @@ def show_config(cfg):
     print("==================== serve_harness pre-flight (CONFIRM before run) ====================")
     print(f"  model         : {cfg['model']}")
     print(f"  registry tag  : {cfg['tag'] or '(none — sampling cannot be registry-resolved)'}")
-    print(f"  kv_mode       : {cfg['kv']}   mtp_mode: {cfg['mtp']}   mode: {cfg['mode']}")
+    print(f"  kv_mode       : {cfg['kv']}   kv_backend: {cfg.get('kv_backend', 'contiguous')}   mtp_mode: {cfg['mtp']}   mode: {cfg['mode']}")
+    print(f"  dflash        : {cfg.get('dflash', 'off')}   draft: {cfg.get('draft') or '(none / filename auto-match)'}")
     print(f"  seed          : {cfg.get('seed')}   prompts_file: {cfg.get('prompts_file') or '(built-in battery)'}")
     print(f"  thinking_budget: {cfg['thinking_budget']} -> {cfg['thinking_cap_tokens']} tok (CONCRETE cap)")
     _cap = cfg['thinking_cap_tokens']
@@ -158,7 +171,19 @@ def show_config(cfg):
             print(f"      {k:18}= {cfg['sampling'][k]:<8} [{cfg['sampling_source'].get(k,'?')}]")
     notset = [k for k in SAMPLE_KEYS if k not in cfg["sampling"]]
     print(f"  sampling (NOT set, serve/daemon default applies): {', '.join(notset) or '(none)'}")
+    # Surface inherited DFlash/DDTree env knobs the harness must not clobber.
+    for env_key in (
+        "HIPFIRE_DFLASH_DRAFT",
+        "HIPFIRE_DFLASH_TREE",
+        "HIPFIRE_DFLASH_FAST_SAMPLE",
+        "HIPFIRE_DDTREE_BUDGET",
+        "HIPFIRE_DDTREE_TOPK",
+    ):
+        if env_key in os.environ:
+            print(f"  env {env_key}={os.environ[env_key]!r} (pass-through)")
     print("=======================================================================================")
+
+
 
 
 # ---------- serve spawn (robust, self-contained) ----------
@@ -261,7 +286,40 @@ def _write_native_config(cfg, home):
     product_bench isolates HIPFIRE_HOME so the daemon never inherits
     ~/.hipfire/config.toml. Opt-in diagnostics such as route_proof_log are
     requested here as temporary TOML rather than ad-hoc env exports.
+
+    DFlash selection uses the canonical speculation selector:
+      --dflash on  → mode=dflash, dflash=on, mtp=off, ngram=off
+      --dflash auto → mode=auto, dflash=auto (mtp left as requested)
+      --dflash off  → dflash=off (default; mode left auto so other mechanisms stay available)
     """
+    dflash = cfg.get("dflash", "off") or "off"
+    mtp = cfg["mtp"]
+    if dflash == "on":
+        # Exclusive DFlash selector — mirrors apply_speculation_selector("dflash").
+        speculation = (
+            '[speculation]\n'
+            'mode = "dflash"\n'
+            'dflash = "on"\n'
+            'mtp = "off"\n'
+            'ngram = "off"\n'
+        )
+    elif dflash == "auto":
+        speculation = (
+            '[speculation]\n'
+            'mode = "auto"\n'
+            f'dflash = "auto"\n'
+            f'mtp = {json.dumps(mtp)}\n'
+            'ngram = "off"\n'
+        )
+    else:
+        # Default product path: DFlash hard-off; leave mode at schema default (auto)
+        # so MTP/n-gram knobs remain independently selectable via --mtp.
+        speculation = (
+            '[speculation]\n'
+            f'dflash = "off"\n'
+            f'mtp = {json.dumps(mtp)}\n'
+            'ngram = "off"\n'
+        )
     text = f"""[serve]
 host = "127.0.0.1"
 port = {cfg["port"]}
@@ -271,11 +329,7 @@ default_model = {json.dumps(cfg["model"])}
 max_seq = {cfg.get("max_seq", 32768)}
 kv_cache = {json.dumps(cfg["kv"])}
 
-[speculation]
-dflash = "off"
-mtp = {json.dumps(cfg["mtp"])}
-ngram = "off"
-
+{speculation}
 [generation]
 max_tokens = 16384
 
@@ -289,6 +343,206 @@ route_proof_log = true
 """
     with open(os.path.join(home, ".hipfire", "config.toml"), "w") as handle:
         handle.write(text)
+
+
+def _serve_log_offset(log):
+    """Byte size of *log* (0 if missing) — capture immediately before a spawn attempt."""
+    if not os.path.exists(log):
+        return 0
+    return os.path.getsize(log)
+
+
+def _serve_log_text(log, offset=0):
+    """Return log bytes from *offset* onward (current-attempt slice)."""
+    if not os.path.exists(log):
+        return ""
+    with open(log, encoding="utf-8", errors="replace") as handle:
+        handle.seek(max(0, int(offset or 0)))
+        return handle.read()
+
+
+def _startup_path_proof_failures(cfg, txt):
+    """VMM + DFlash draft-load failures for one attempt's log slice (no sys.exit)."""
+    failures = []
+
+    if cfg.get("kv_backend") == "vmm":
+        # KvCache constructors emit e.g. "KV cache: q8 vmm (...", "KV cache: fwht3 vmm (...".
+        if not re.search(r"KV cache:.*\bvmm\b", txt):
+            failures.append(
+                "kv_backend=vmm requested but serve log has no 'KV cache: … vmm' marker"
+            )
+
+    dflash = cfg.get("dflash", "off") or "off"
+    if dflash == "on":
+        loaded = (
+            "DFlash draft loaded:" in txt
+            or "DFlash generic speculator loaded" in txt
+        )
+        skipped = "dflash_mode=off — skipping draft load" in txt
+        failed = "DFlash draft load failed" in txt
+        disabled = "DFlash disabled (dflash_mode=off)" in txt
+        if skipped or disabled:
+            failures.append(
+                "dflash=on requested but serve log shows DFlash disabled/skipped"
+            )
+        elif failed:
+            failures.append(
+                "dflash=on requested but serve log shows 'DFlash draft load failed'"
+            )
+        elif not loaded:
+            failures.append(
+                "dflash=on requested but serve log lacks "
+                "'DFlash draft loaded:' / 'DFlash generic speculator loaded' proof"
+            )
+    return failures
+
+
+def _row_has_dflash_execution(row):
+    """True only for an explicit request-level DFlash route identity."""
+    return isinstance(row, dict) and row.get("dflash") is True
+
+
+# Log-side request-level DFlash route identities. Generic tau/cycle metrics are
+# intentionally excluded: both AR fallback and MTP can emit them.
+_DFLASH_EXEC_LOG_RE = re.compile(
+    r'("dflash"\s*:\s*true)|(?:^|\s)drafter=dflash(?:\s|$)',
+    re.I | re.M,
+)
+
+
+def _log_has_dflash_execution(txt):
+    return bool(txt and _DFLASH_EXEC_LOG_RE.search(txt))
+
+
+def _dflash_request_proof_failures(cfg, rows, log_txt=""):
+    """After requests: dflash=on requires an explicit DFlash route identity."""
+    dflash = cfg.get("dflash", "off") or "off"
+    if dflash != "on":
+        return []
+    rows = rows or []
+    if any(_row_has_dflash_execution(r) for r in rows):
+        return []
+    if _log_has_dflash_execution(log_txt):
+        return []
+    return [
+        "dflash=on requested but no request-level DFlash execution evidence "
+        "(need timings.dflash=true or drafter=dflash); draft-load alone is not sufficient"
+    ]
+
+
+def _emit_path_proof_failure(failures, log, when):
+    for msg in failures:
+        print(f"  [serve path proof FAILED] {msg}", file=sys.stderr)
+    sys.exit(
+        f"serve_harness: production serve path proof failed {when} "
+        f"({'; '.join(failures)}). See {log}"
+    )
+
+
+def _assert_serve_path_proofs(cfg, log, offset=0):
+    """Fail closed when an explicit VMM/DFlash path was requested but the current
+    attempt's warm log slice lacks startup engagement markers (PR #549)."""
+    txt = _serve_log_text(log, offset)
+    failures = _startup_path_proof_failures(cfg, txt)
+    if failures:
+        _emit_path_proof_failure(failures, log, "after warm")
+
+
+def _assert_dflash_request_proofs(cfg, rows, log, offset=0):
+    """Fail closed when dflash=on but no request exercised speculative decode."""
+    txt = _serve_log_text(log, offset)
+    failures = _dflash_request_proof_failures(cfg, rows, txt)
+    if failures:
+        _emit_path_proof_failure(failures, log, "after requests")
+
+
+def _self_test_serve_path_proofs():
+    """Deterministic coverage for current-attempt log slicing + DFlash request proof.
+
+    Run: ``python3 scripts/serve_harness.py --self-test``
+    or ``HIPFIRE_SERVE_HARNESS_SELFTEST=1``.
+    """
+    import tempfile
+
+    def check(cond, msg):
+        if not cond:
+            raise AssertionError(msg)
+
+    with tempfile.NamedTemporaryFile("w+b", delete=False) as tmp:
+        path = tmp.name
+        # Prior attempt / prior run markers (must NOT satisfy current proof).
+        stale = (
+            b"KV cache: q8 vmm (stale prior attempt)\n"
+            b"DFlash draft loaded: /stale/draft.hfq\n"
+            b'{"type":"done","dflash":true,"tau":9.5,"cycles":12}\n'
+        )
+        tmp.write(stale)
+        tmp.flush()
+        offset = tmp.tell()
+
+        # --- stale prior markers alone must fail VMM + draft-load ---
+        cfg_vmm = {"kv_backend": "vmm", "dflash": "off"}
+        stale_txt = _serve_log_text(path, offset)  # empty suffix
+        check(stale_txt == "", "suffix after offset must be empty before current write")
+        fails = _startup_path_proof_failures(cfg_vmm, stale_txt)
+        check(any("vmm" in f for f in fails), f"stale-only VMM must fail, got {fails!r}")
+
+        # Full-file read would false-pass — document the bug we closed.
+        full_false_pass = _startup_path_proof_failures(cfg_vmm, _serve_log_text(path, 0))
+        check(not full_false_pass, "precondition: full log still contains stale VMM marker")
+
+        # --- current-attempt VMM marker after offset passes ---
+        with open(path, "ab") as ap:
+            ap.write(b"KV cache: fwht3 vmm (current attempt)\n")
+        cur = _serve_log_text(path, offset)
+        fails = _startup_path_proof_failures(cfg_vmm, cur)
+        check(not fails, f"current-attempt VMM must pass, got {fails!r}")
+
+        # --- draft-loaded without request execution must fail ---
+        cfg_df = {"kv_backend": "contiguous", "dflash": "on"}
+        with open(path, "ab") as ap:
+            ap.write(b"DFlash draft loaded: /current/draft.hfq\n")
+        cur = _serve_log_text(path, offset)
+        load_fails = _startup_path_proof_failures(cfg_df, cur)
+        check(not load_fails, f"current draft-load startup must pass, got {load_fails!r}")
+        req_fails = _dflash_request_proof_failures(cfg_df, rows=[], log_txt=cur)
+        check(req_fails, f"draft-load without execution must fail, got {req_fails!r}")
+        # Rows without tau/cycles/dflash also fail even if draft loaded.
+        ar_rows = [{"tau": None, "cycles": None, "dflash": None, "gen": 8}]
+        req_fails = _dflash_request_proof_failures(cfg_df, rows=ar_rows, log_txt=cur)
+        check(req_fails, f"all-AR rows must fail DFlash request proof, got {req_fails!r}")
+        # The daemon's explicit AR fallback summary includes tau=1.00. Generic
+        # tau/cycle metrics must not certify DFlash execution.
+        ar_log = cur + "\n[req req-1] drafter=ar tau=1.00 tok/s=88.0 (autoregressive)\n"
+        req_fails = _dflash_request_proof_failures(cfg_df, rows=ar_rows, log_txt=ar_log)
+        check(req_fails, f"AR fallback tau log must fail DFlash proof, got {req_fails!r}")
+
+        # MTP also reports tau/cycles, but is not DFlash.
+        mtp_rows = [{"tau": 3.0, "cycles": 4, "dflash": None, "mtp": True, "gen": 12}]
+        req_fails = _dflash_request_proof_failures(cfg_df, rows=mtp_rows, log_txt=cur)
+        check(req_fails, f"MTP timings must fail DFlash request proof, got {req_fails!r}")
+
+        # --- request-level DFlash success via row tau ---
+        ok_rows = [{"tau": 4.2, "cycles": 3, "dflash": True, "gen": 16}]
+        req_fails = _dflash_request_proof_failures(cfg_df, rows=ok_rows, log_txt=cur)
+        check(not req_fails, f"tau/cycles row must pass, got {req_fails!r}")
+
+        # --- request-level success via log discriminator alone ---
+        with open(path, "ab") as ap:
+            ap.write(b'{"type":"done","dflash":true,"tau":3.25,"cycles":4}\n')
+        cur = _serve_log_text(path, offset)
+        req_fails = _dflash_request_proof_failures(cfg_df, rows=ar_rows, log_txt=cur)
+        check(not req_fails, f"log dflash/tau evidence must pass, got {req_fails!r}")
+
+        # Non-DFlash / non-VMM configs stay silent.
+        plain = {"kv_backend": "contiguous", "dflash": "off"}
+        check(not _startup_path_proof_failures(plain, ""), "plain startup must be no-op")
+        check(not _dflash_request_proof_failures(plain, [], ""), "plain request proof must be no-op")
+
+    os.unlink(path)
+    print("serve_harness: path-proof self-test OK", flush=True)
+
+
 
 def _native_service_warm(port, expected_model=None, proc=None):
     """True only when health is ready for *this* spawn.
@@ -324,8 +578,10 @@ def _native_service_warm(port, expected_model=None, proc=None):
 
 def spawn_serve(cfg, home, log):
     """Spawn native `hipfire serve` with the resolved serve config; retry on the flaky
-    daemon-spawn; return when warm. The per-request sampling is sent by the driver, so
-    one serve handles all recipes/modes."""
+    daemon-spawn; return the successful attempt's pre-launch log byte offset, or None.
+
+    The per-request sampling is sent by the driver, so one serve handles all recipes/modes.
+    Proofs must inspect only ``_serve_log_text(log, offset)`` for that attempt."""
     global _serve_proc, _serve_pgid
     os.makedirs(os.path.join(home, ".hipfire"), exist_ok=True)
     models = os.path.expanduser(os.environ.get("HIPFIRE_MODELS_DIR", "~/.hipfire/models"))
@@ -345,36 +601,46 @@ def spawn_serve(cfg, home, log):
                HIPFIRE_KV_MODE=cfg["kv"], HIPFIRE_CASK_OFF="1", HIPFIRE_MODEL=cfg["model"])
     if cfg["mtp"] == "on":
         env.update(HIPFIRE_QWEN_MTP="1", HIPFIRE_MTP_SAMPLED="1", HIPFIRE_MTP_PREFIX_CACHE="1")
+    # Explicit --draft pins HIPFIRE_DFLASH_DRAFT. When absent, preserve any
+    # caller-inherited value (do not pop/clear) so parent gates can pin the draft.
+    if cfg.get("draft"):
+        env["HIPFIRE_DFLASH_DRAFT"] = cfg["draft"]
+    # Plain DFlash / DDTree knobs (TREE/BUDGET/TOPK/FAST_SAMPLE) pass through
+    # from the parent environment unchanged — harness never rewrites them.
     # Harness-only parent IPC: must never reach hipfire serve / process config
     # (would otherwise lower as developer.serve_harness_pid_file).
     env.pop("HIPFIRE_SERVE_HARNESS_PID_FILE", None)
     cli = _native_cli()
+    serve_cmd = [cli, "serve", "127.0.0.1", str(cfg["port"]),
+                 "--kv-backend", cfg.get("kv_backend", "contiguous")]
     atexit.register(_kill_serve)
+    # Append-only log: prior attempts remain for debugging; proofs use per-attempt offsets.
+    os.makedirs(os.path.dirname(os.path.abspath(log)) or ".", exist_ok=True)
+    open(log, "a").close()
     for attempt in range(1, 5):
         _kill_serve(); time.sleep(3)
-        open(log, "w").close()
         # Drop any stale observer PID before the next CLI process-group leader exists.
         _clear_pid_file()
+        # Capture offset immediately before launch — only this attempt's suffix is proof.
+        log_offset = _serve_log_offset(log)
         _serve_proc = subprocess.Popen(
-            [cli, "serve", "127.0.0.1", str(cfg["port"])],
+            serve_cmd,
             cwd=REPO, env=env, stdout=open(log, "a"), stderr=subprocess.STDOUT,
             start_new_session=True)   # own process group so _kill_serve's group-kill is exact + scoped
         # Leader PID == PGID under start_new_session; retain it for dead-leader cleanup.
         _serve_pgid = _serve_proc.pid
         _write_pid_file(_serve_pgid)
         for _ in range(90):
-            if os.path.exists(log):
-                with open(log, encoding="utf-8", errors="replace") as handle:
-                    txt = handle.read()
-            else:
-                txt = ""
+            txt = _serve_log_text(log, log_offset)
             if _native_service_warm(cfg["port"], expected_model=cfg.get("model"), proc=_serve_proc):
-                return True
+                return log_offset
             if re.search(r"out of memory|error loading|panic", txt, re.I):
                 break
             time.sleep(2)
         print(f"  [serve spawn attempt {attempt} failed]", file=sys.stderr)
-    return False
+    return None
+
+
 
 
 # ---------- request + capture ----------
@@ -442,6 +708,7 @@ def send(cfg, messages):
         "think_words": len(re.findall(r"\S+", think_s)), "ans_words": len(re.findall(r"\S+", visible)),
         "prefill_ms": timings.get("prefill_ms"), "prefill_tok_s": timings.get("prefill_tok_s"),
         "decode_tok_s": decode_ts, "decode_estimated": decode_est, "tau": timings.get("tau"),
+        "cycles": timings.get("cycles"), "dflash": timings.get("dflash"), "mtp": timings.get("mtp"),
         "ttft_s": round(ttft or 0, 3), "wall_s": round(wall, 3),
         "attractor": bad, "empty": (cfg.get("expect_visible", True) and len(visible) == 0),
         "runaway": (finish == "length"),
@@ -500,15 +767,24 @@ def run(cfg, args):
           f"avg_decode={sum(dec)/len(dec):.1f}tok/s" if dec else f"[{label} DONE] turns={len(g)}", flush=True)
     if args.out:
         json.dump(rows, open(args.out, "w"), indent=0)
+    return rows
 
 
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--model", required=True, help="model file path to serve")
+    ap.add_argument("--model", default=None, help="model file path to serve")
     ap.add_argument("--tag", default=None, help="registry tag for recommended_settings (else inferred)")
     ap.add_argument("--registry", default=os.path.join(REPO, "registry/v1.json"))
     ap.add_argument("--kv", default="fwht3")
+    ap.add_argument("--kv-backend", default="contiguous", choices=["contiguous", "vmm"],
+                    help="hipfire serve --kv-backend override (default contiguous; use vmm for PR #549 path)")
     ap.add_argument("--mtp", default="off", choices=["off", "on", "auto"])
+    ap.add_argument("--dflash", default="off", choices=["off", "auto", "on"],
+                    help="DFlash mode written to temporary [speculation] TOML (default off). "
+                         "'on' emits mode=dflash + dflash=on + mtp/ngram off.")
+    ap.add_argument("--draft", default=None,
+                    help="Optional DFlash draft path; sets HIPFIRE_DFLASH_DRAFT for the serve child. "
+                         "When omitted, any caller-inherited HIPFIRE_DFLASH_DRAFT is preserved.")
     ap.add_argument("--thinking", default="med", help="thinking_budget preset key")
     ap.add_argument("--max-tokens", type=int, default=2048)
     ap.add_argument("--max-seq", type=int, default=32768)
@@ -535,7 +811,17 @@ def main():
              "$HIPFIRE_HOME/config.toml so the daemon emits one retained-replay "
              "proof marker per successful serve request (coherence/product gates).",
     )
+    ap.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run deterministic serve path-proof self-tests (no GPU / no serve) and exit.",
+    )
     args = ap.parse_args()
+    if args.self_test or os.environ.get("HIPFIRE_SERVE_HARNESS_SELFTEST") == "1":
+        _self_test_serve_path_proofs()
+        return
+    if not args.model:
+        ap.error("--model is required unless --self-test")
     cfg = build_config(args); cfg["max_seq"] = args.max_seq
     show_config(cfg)
     if args.show_config:
@@ -548,14 +834,18 @@ def main():
             f"{cfg['thinking_cap_tokens']}, lower --thinking (low={THINKING_BUDGET['low']}), "
             f"or use --thinking uncapped."
         )
+    log_offset = 0
     if not args.no_spawn:
-        if not spawn_serve(cfg, args.home, args.serve_log):
+        log_offset = spawn_serve(cfg, args.home, args.serve_log)
+        if log_offset is None:
             sys.exit("serve_harness: serve failed to warm after retries")
         head = subprocess.run(f"grep -c 'MTP head loaded' {args.serve_log}", shell=True,
                               capture_output=True, text=True).stdout.strip()
         print(f"  [serve warm; MTP head loaded lines={head}]", flush=True)
-    run(cfg, args)
+        _assert_serve_path_proofs(cfg, args.serve_log, offset=log_offset)
+    rows = run(cfg, args)
     if not args.no_spawn:
+        _assert_dflash_request_proofs(cfg, rows, args.serve_log, offset=log_offset)
         _kill_serve()
 
 

--- a/scripts/vmm_kv_matrix.py
+++ b/scripts/vmm_kv_matrix.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kaden Schutt
+# hipfire — see LICENSE and NOTICE in the project root.
+
+"""GPU lifecycle matrix for static and adaptive Qwen VMM KV caches.
+
+Exercises every supported static K/V combination plus all adaptive presets
+through long prefill, AR graph capture/replay, reset, unload, and reload.
+This is functional coverage, not a performance benchmark.
+"""
+
+import argparse
+import json
+import os
+import queue
+import re
+import signal
+import subprocess
+import threading
+import time
+from pathlib import Path
+
+STATIC_Q8 = [(mode, None) for mode in ("q8", "asym2", "asym3", "asym4", "fwht2", "fwht3", "fwht4")]
+STATIC_LLOYD = [(k, v) for k in ("fwht2", "fwht3", "fwht4") for v in ("lloyd2", "lloyd3", "lloyd4")]
+ADAPTIVE_EXPECTED_STEPS = {"conservative": 1, "balanced": 3, "aggressive": 4}
+REPO = Path(__file__).resolve().parent.parent
+
+
+class Daemon:
+    def __init__(self, binary, env, stderr_path, timeout):
+        self.timeout = timeout
+        self.stderr_path = Path(stderr_path)
+        self.stderr_handle = self.stderr_path.open("w", encoding="utf-8")
+        self.proc = subprocess.Popen(
+            [binary], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=self.stderr_handle, text=True, bufsize=1, env=env, cwd=REPO,
+            start_new_session=True,
+        )
+        self.rows = []
+        self.q = queue.Queue()
+        self.reader = threading.Thread(target=self._read_stdout, daemon=True)
+        self.reader.start()
+
+    def _read_stdout(self):
+        assert self.proc.stdout is not None
+        for raw in self.proc.stdout:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                self.q.put(RuntimeError(f"non-JSON daemon stdout: {line!r}: {exc}"))
+                continue
+            self.rows.append(row)
+            self.q.put(row)
+        self.q.put(EOFError(f"daemon stdout closed (rc={self.proc.poll()})"))
+
+    def send(self, row):
+        if self.proc.poll() is not None:
+            raise RuntimeError(f"daemon exited before write (rc={self.proc.returncode})")
+        assert self.proc.stdin is not None
+        self.proc.stdin.write(json.dumps(row, separators=(",", ":")) + "\n")
+        self.proc.stdin.flush()
+
+    def wait_for(self, wanted, timeout=None):
+        deadline = time.monotonic() + (timeout or self.timeout)
+        seen = []
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError(f"timed out waiting for {wanted}; seen={seen[-5:]}")
+            try:
+                item = self.q.get(timeout=min(remaining, 1.0))
+            except queue.Empty:
+                if self.proc.poll() is not None:
+                    raise RuntimeError(f"daemon exited waiting for {wanted} (rc={self.proc.returncode})")
+                continue
+            if isinstance(item, BaseException):
+                raise item
+            seen.append(item)
+            typ = item.get("type")
+            if typ == "error":
+                raise RuntimeError(f"daemon error waiting for {wanted}: {item}")
+            if typ in wanted:
+                return item, seen
+
+    def load(self, model, mode, adaptive, max_seq):
+        self.send({
+            "type": "load", "model": model,
+            "params": {
+                "max_seq": max_seq, "kv_mode": mode, "kv_backend": "vmm",
+                "kv_adaptive": adaptive, "dflash_mode": "off", "mtp_mode": "off",
+                "tp": 1, "pp": 1,
+            },
+        })
+        row, _ = self.wait_for({"loaded"})
+        if row.get("cache_capable") is False:
+            raise AssertionError(f"load did not report cache_capable: {row}")
+        return row
+
+    def generate(self, request_id, prompt, max_tokens):
+        self.send({
+            "type": "generate", "id": request_id, "prompt": prompt,
+            "temperature": 0.0, "temp": 0.0, "max_tokens": max_tokens,
+        })
+        row, seen = self.wait_for({"done"}, timeout=self.timeout)
+        emitted = sum(1 for event in seen if event.get("type") == "token")
+        done_tokens = row.get("tokens", row.get("completion_tokens", emitted))
+        if not isinstance(done_tokens, int) or done_tokens <= 0:
+            raise AssertionError(f"generation emitted no tokens: done={row}, events={emitted}")
+        finish = row.get("finish_reason")
+        if finish == "aborted":
+            raise AssertionError(f"generation aborted: {row}")
+        return row, emitted
+
+    def reset(self):
+        self.send({"type": "reset"})
+        row, _ = self.wait_for({"reset"})
+        if row.get("seq_pos") not in (None, 0):
+            raise AssertionError(f"reset did not return seq_pos=0: {row}")
+        return row
+
+    def unload(self):
+        self.send({"type": "unload"})
+        row, _ = self.wait_for({"unloaded"})
+        return row
+
+    def close(self):
+        try:
+            if self.proc.stdin:
+                self.proc.stdin.close()
+        except OSError:
+            pass
+        if self.proc.poll() is None:
+            try:
+                os.killpg(self.proc.pid, signal.SIGTERM)
+                self.proc.wait(timeout=5)
+            except (ProcessLookupError, subprocess.TimeoutExpired):
+                try:
+                    os.killpg(self.proc.pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+        self.stderr_handle.close()
+
+    def stderr(self):
+        self.stderr_handle.flush()
+        return self.stderr_path.read_text(encoding="utf-8", errors="replace")
+
+
+def base_env(gpu, v_mode):
+    env = os.environ.copy()
+    env.update({
+        "HIP_VISIBLE_DEVICES": str(gpu),
+        "HIPFIRE_GRAPH": "1",
+        "HIPFIRE_AR_GRAPH": "1",
+        "HIPFIRE_AR_GRAPH_TRACE": "1",
+        "HIPFIRE_CASK_OFF": "1",
+        "HIPFIRE_DFLASH_DRAFT": "",
+        "HIPFIRE_KV_ADAPTIVE": "off",
+    })
+    if v_mode:
+        env["HIPFIRE_KV_V"] = v_mode
+    else:
+        env.pop("HIPFIRE_KV_V", None)
+    return env
+
+
+def marker_snapshot(text):
+    mapped = [int(x) for x in re.findall(r"mapped_prefix=(\d+)", text)]
+    static_configs = [
+        (mode.lower(), v_mode.lower())
+        for mode, v_mode in re.findall(
+            r"KV cache:\s*(Q8|Asym2|Asym3|Asym4|Fwht2|Fwht3|Fwht4)\s+vmm\s*"
+            r"\([^\n]*?\bV\s+(Q8|lloyd2|lloyd3|lloyd4)\b",
+            text,
+            re.I,
+        )
+    ]
+    graph_captures = re.findall(r"^\[qwen-ar-graph\] capture\b.*$", text, re.M)
+    graph_replays = re.findall(r"^\[qwen-ar-graph\] replay\b.*$", text, re.M)
+    return {
+        "vmm": bool(re.search(r"KV cache:.*\bvmm\b", text, re.I)),
+        "static_vmm": bool(re.search(r"KV cache:\s*(?!adaptive\b)[^\n]*\bvmm\b", text, re.I)),
+        "static_configs": static_configs,
+        "adaptive_vmm": bool(re.search(r"KV cache:\s*adaptive vmm", text, re.I)),
+        "adaptive_engaged": "[adaptive-kv] engaged:" in text,
+        "downshift_lines": re.findall(r"^.*\[adaptive-kv\] downshift.*$", text, re.M),
+        "mapped_prefixes": mapped,
+        "graph_captures": graph_captures,
+        "graph_replays": graph_replays,
+        "graph_lines": graph_captures + graph_replays,
+    }
+
+
+def assert_ar_graph_markers(markers):
+    captures = len(markers["graph_captures"])
+    replays = len(markers["graph_replays"])
+    if captures == 0 or replays == 0:
+        raise AssertionError(
+            f"missing AR graph proof: captures={captures}, replays={replays}"
+        )
+    return {"graph_captures": captures, "graph_replays": replays}
+
+
+def assert_static_markers(markers, prompt_tokens, mode, v_mode):
+    if not markers["static_vmm"]:
+        raise AssertionError("missing current-process static 'KV cache: … vmm' marker")
+    expected_config = (mode.lower(), (v_mode or "q8").lower())
+    if expected_config not in markers["static_configs"]:
+        raise AssertionError(
+            f"requested KV config {expected_config} not loaded; "
+            f"observed={markers['static_configs']}"
+        )
+    if not markers["mapped_prefixes"]:
+        raise AssertionError("static VMM load did not report mapped_prefix")
+    if prompt_tokens is None:
+        raise AssertionError("generation did not report prefill token count")
+    first = markers["mapped_prefixes"][0]
+    if prompt_tokens <= first:
+        raise AssertionError(f"prefill {prompt_tokens} did not cross initial mapped prefix {first}")
+    graph_proof = assert_ar_graph_markers(markers)
+    label = f"{mode}/{v_mode or 'q8'}"
+    return {
+        "label": label,
+        "loaded_config": expected_config,
+        "growth_boundary_proved": True,
+        **graph_proof,
+    }
+
+
+def run_static(args, mode, v_mode, outdir):
+    label = f"static-{mode}-{v_mode or 'q8'}"
+    stderr_path = outdir / f"{label}.stderr.log"
+    daemon = Daemon(args.daemon, base_env(args.gpu, v_mode), stderr_path, args.timeout)
+    result = {"label": label, "kind": "static", "mode": mode, "v_mode": v_mode or "q8"}
+    try:
+        result["load"] = daemon.load(args.model, mode, "off", args.max_seq)
+        long_prompt = "x " * args.static_prompt_repetitions
+        done, emitted = daemon.generate(f"{label}-long", long_prompt, args.max_tokens)
+        result["long_done"] = done
+        result["long_emitted_events"] = emitted
+        result["unload"] = daemon.unload()
+        result["reload"] = daemon.load(args.model, mode, "off", args.max_seq)
+        short_done, short_emitted = daemon.generate(f"{label}-reload", "Say only: VMM reload ok", 8)
+        result["reload_done"] = short_done
+        result["reload_emitted_events"] = short_emitted
+        result["final_unload"] = daemon.unload()
+        markers = marker_snapshot(daemon.stderr())
+        result["markers"] = markers
+        prompt_tokens = done.get("prefill_tokens", done.get("prompt_tokens"))
+        result["proof"] = assert_static_markers(markers, prompt_tokens, mode, v_mode)
+        result["ok"] = True
+    finally:
+        result["stdout_rows"] = daemon.rows
+        daemon.close()
+    return result
+
+
+def run_adaptive(args, preset, outdir):
+    label = f"adaptive-{preset}"
+    stderr_path = outdir / f"{label}.stderr.log"
+    daemon = Daemon(args.daemon, base_env(args.gpu, None), stderr_path, args.timeout)
+    result = {"label": label, "kind": "adaptive", "mode": "fwht4", "preset": preset}
+    try:
+        result["load"] = daemon.load(args.model, "fwht4", preset, args.max_seq)
+        long_prompt = "x " * args.adaptive_prompt_repetitions
+        done, emitted = daemon.generate(f"{label}-long", long_prompt, args.max_tokens)
+        result["long_done"] = done
+        result["long_emitted_events"] = emitted
+        result["reset"] = daemon.reset()
+        reset_done, reset_emitted = daemon.generate(f"{label}-reset", "Say only: adaptive reset ok", 8)
+        result["reset_done"] = reset_done
+        result["reset_emitted_events"] = reset_emitted
+        result["unload"] = daemon.unload()
+        result["reload"] = daemon.load(args.model, "fwht4", preset, args.max_seq)
+        reload_done, reload_emitted = daemon.generate(f"{label}-reload", "Say only: adaptive reload ok", 8)
+        result["reload_done"] = reload_done
+        result["reload_emitted_events"] = reload_emitted
+        result["final_unload"] = daemon.unload()
+        markers = marker_snapshot(daemon.stderr())
+        result["markers"] = markers
+        if not markers["adaptive_vmm"] or not markers["adaptive_engaged"]:
+            raise AssertionError("missing adaptive VMM/engagement load markers")
+        expected = ADAPTIVE_EXPECTED_STEPS[preset]
+        if len(markers["downshift_lines"]) < expected:
+            raise AssertionError(
+                f"{preset} expected >= {expected} downshift steps, saw {len(markers['downshift_lines'])}"
+            )
+        prompt_tokens = done.get("prefill_tokens", done.get("prompt_tokens"))
+        if not markers["mapped_prefixes"]:
+            raise AssertionError("adaptive VMM load did not report mapped_prefix")
+        if prompt_tokens is None:
+            raise AssertionError("adaptive generation did not report prefill token count")
+        if prompt_tokens <= markers["mapped_prefixes"][0]:
+            raise AssertionError("adaptive long prefill did not cross initial mapped prefix")
+        graph_proof = assert_ar_graph_markers(markers)
+        result["proof"] = {
+            "expected_steps": expected,
+            "observed_steps": len(markers["downshift_lines"]),
+            **graph_proof,
+        }
+        result["ok"] = True
+    finally:
+        result["stdout_rows"] = daemon.rows
+        daemon.close()
+    return result
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--daemon", default=str(REPO / "target/release/examples/daemon"))
+    ap.add_argument("--model", default=str(Path("~/.hipfire/models/qwen3.5-9b.mq4").expanduser()))
+    ap.add_argument("--gpu", type=int, default=0)
+    ap.add_argument("--out", default=f"/tmp/vmm-kv-matrix-{int(time.time())}")
+    ap.add_argument("--max-seq", type=int, default=16384)
+    ap.add_argument("--static-prompt-repetitions", type=int, default=9000)
+    ap.add_argument("--adaptive-prompt-repetitions", type=int, default=13000)
+    ap.add_argument("--max-tokens", type=int, default=12)
+    ap.add_argument("--timeout", type=float, default=900.0)
+    ap.add_argument("--only", action="append", help="run labels containing this substring")
+    args = ap.parse_args()
+
+    outdir = Path(args.out)
+    outdir.mkdir(parents=True, exist_ok=True)
+    summary_path = outdir / "summary.json"
+    results = []
+    failures = []
+
+    cells = [("static", mode, v) for mode, v in STATIC_Q8 + STATIC_LLOYD]
+    cells += [("adaptive", preset, None) for preset in ADAPTIVE_EXPECTED_STEPS]
+    for kind, a, b in cells:
+        label = f"static-{a}-{b or 'q8'}" if kind == "static" else f"adaptive-{a}"
+        if args.only and not any(part in label for part in args.only):
+            continue
+        print(f"=== {label} ===", flush=True)
+        try:
+            row = run_static(args, a, b, outdir) if kind == "static" else run_adaptive(args, a, outdir)
+            results.append(row)
+            print(json.dumps({"label": label, "ok": True, "proof": row.get("proof")}), flush=True)
+        except BaseException as exc:
+            failures.append({"label": label, "error": repr(exc)})
+            print(json.dumps({"label": label, "ok": False, "error": repr(exc)}), flush=True)
+        summary_path.write_text(json.dumps({"results": results, "failures": failures}, indent=2), encoding="utf-8")
+
+    print(json.dumps({"summary": str(summary_path), "passed": len(results), "failed": failures}, indent=2))
+    if failures:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

FireMap adds an opt-in HIP VMM backend for the single-GPU Qwen3.5/Qwen3.6 masked KV-cache path. It reserves each cache's full virtual-address range once, then appends physical mappings in coarse chunks as context grows. Kernel arguments and captured graph pointers retain stable K/V virtual addresses.

The default remains `contiguous`; enable this path explicitly with `--kv-backend vmm`.

Rebased onto `warpfront/hipfire:beta@fdf1d46c9e55e06523a5c7a351c927abef49c420`.

## Supported scope

- Static K modes: `q8`, `asym2`, `asym3`, `asym4`, `fwht2`, `fwht3`, `fwht4`.
- All nine legal FWHT K × Lloyd V combinations.
- Adaptive VMM policies: conservative, balanced, aggressive.
- Qwen3.5/Qwen3.6 single-GPU masked-cache load, prefill, AR decode, captured graph replay, unload/reload, and supported DFlash paths.
- Transactional mapping/allocation rollback and idempotent teardown.
- Graph invalidation on true KV representation switches and model unload.

Explicitly rejected rather than silently falling back: pipeline/multi-GPU, CASK/TriAttention, flat-Llama, and adaptive DFlash. VMM defers physical KV commitment; usage converges toward contiguous KV as the configured context fills.

## GPU validation

The final matrix exercises a long prompt beyond the initial mapped prefix, requires exact loaded K/V mode identity, requires successful AR graph capture and replay, then unloads, reloads, and generates again.

- Modern static/adaptive matrix: 18/18 supported cells passed.
- Static FWHT3/Lloyd2 strict proof on Qwen3.5-9B (`max_seq=16384`): 9,010 prompt tokens crossed the 5,242-token initial mapping; 2 graph captures and 16 graph replays; unload/reload/final-unload all passed.
- Low-level `vmm_arena_smoke` and `vmm_tensor_smoke`: growth, over-reserve rejection, cleanup after failure, owner teardown, and unload/reload passed.
- Legacy static asym4 long-prefill still triggers an illegal access; asym4 is legacy/nonblocking and is not included in the modern support claim.

The permanent harness is `scripts/vmm_kv_matrix.py`. It rejects a wrong loaded K/V format and missing capture or replay evidence.

## Verification

- `GITHUB_ACTIONS=true GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=beta bash scripts/ci-rustfmt-changed.sh` — passed (20 changed Rust files)
- `cargo clippy --workspace --all-targets --locked` — passed (warnings only)
- `cargo test --lib --workspace --locked` — 1,281 passed, 1 ignored
- `cargo build --release --workspace --all-targets --locked` — passed
- `cargo test -p hipfire-runtime --example daemon --locked` — 21 passed
- `cargo test -p hipfire-arch-qwen35 --lib --locked` — 156 passed
- `python3 -m py_compile scripts/vmm_kv_matrix.py scripts/serve_harness.py` — passed
- `git diff --check` — passed

## Claim boundary

This does not add PagedAttention, prefix sharing/RadixAttention, token-level mappings, cross-GPU pooling, or new attention kernels. The DFlash cache-hit verify-graph recapture bug is being fixed separately; VMM K/V virtual addresses do not change across cache growth or requests and are not its cause.