### PR TITLE
fix(ci): restore clean-checkout beta gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     # Truly advisory: on pushes, ci-rustfmt-changed diffs vs master and surfaces
     # the whole dispatch-effort format backlog (Kevin's in-flight files included),
-    # so this is expected-red until the cleanup pass. Don't fail the run — green
-    # must mean the load-bearing build+test gates pass.
-    continue-on-error: true
+    # so keep the step visible without making the job's status check red.
     steps:
       - uses: actions/checkout@v4
         with:
@@ -109,6 +107,7 @@ jobs:
         with:
           components: rustfmt
       - run: bash scripts/ci-rustfmt-changed.sh
+        continue-on-error: true
 
   clippy:
     name: clippy (advisory)

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,10 @@ CLAUDE.local.md
 # Training artifacts (draft ckpts, converted hfq, prompt files, logs)
 .dflash-runs/
 artifacts/
+!crates/radiowave/tests/artifacts/
+!crates/radiowave/tests/artifacts/*.json
+!crates/radiowave/tests/artifacts/recipes/
+!crates/radiowave/tests/artifacts/recipes/*.json
 .codeinsight
 .codeinsight+research/
 .local-bench-scratch/

--- a/crates/hip-bridge/src/ffi.rs
+++ b/crates/hip-bridge/src/ffi.rs
@@ -744,6 +744,9 @@ impl HipRuntime {
     /// Return the base and byte extent of the HIP allocation containing
     /// `device_ptr`. This is used by retained replay to conservatively treat
     /// distinct subviews of one allocation as aliasing resources.
+    ///
+    /// HIP treats `device_ptr` as an opaque GPU address; Rust never dereferences it.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn mem_get_address_range(
         &self,
         device_ptr: *mut c_void,

--- a/crates/radiowave/tests/artifacts/hipfire-deepseek4-gfx1151-2026-07-25-xor-shuffle.json
+++ b/crates/radiowave/tests/artifacts/hipfire-deepseek4-gfx1151-2026-07-25-xor-shuffle.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "kind": "radiowave_recipe_evidence_summary",
+  "catalog_source_revision": "a064932c345b7ce4f9fe37c775b46c635b6d6e2f",
+  "catalog_source_path": "crates/radiowave/src/recipes.rs",
+  "raw_result_included": false,
+  "architecture": "gfx1151",
+  "date": "2026-07-25",
+  "recipe": "hipfire.cross_lane.wave32_xor_exchange",
+  "verdict": "correctness_only",
+  "raw_bit_comparisons": 41120,
+  "samples_per_row": 3,
+  "throughput_delta_pct": 0.637858,
+  "duration_delta_pct": -0.633817,
+  "projected_whole_token_gain_pct": 0.118,
+  "note": "The stride table was bit-exact, but the projected whole-token gain did not justify promotion. This compact record preserves the vendored catalog evidence; its raw result was not included in the source import."
+}

--- a/crates/radiowave/tests/artifacts/hipfire-deepseek4-mq2r-gfx1151-2026-07-25-e8-temporal-buffer.json
+++ b/crates/radiowave/tests/artifacts/hipfire-deepseek4-mq2r-gfx1151-2026-07-25-e8-temporal-buffer.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "kind": "radiowave_recipe_evidence_summary",
+  "catalog_source_revision": "a064932c345b7ce4f9fe37c775b46c635b6d6e2f",
+  "catalog_source_path": "crates/radiowave/src/recipes.rs",
+  "raw_result_included": false,
+  "architecture": "gfx1151",
+  "date": "2026-07-25",
+  "recipe": "hipfire.cache.mfp4_e8_u4_temporal_buffer",
+  "verdict": "promoted",
+  "correctness": "byte-identical output",
+  "samples_per_row": 3,
+  "baseline_tokens_per_second": 25.87,
+  "candidate_tokens_per_second": 26.63,
+  "throughput_delta_pct": 2.937766,
+  "note": "Temporal cpol0 won; non-temporal cpol20/cpol22 regressed large tensors by 40-50%. This compact record preserves the vendored catalog evidence; its raw result was not included in the source import."
+}

--- a/crates/radiowave/tests/artifacts/hipfire-deepseek4-mq2r-gfx1151-2026-07-25-topk-gather-tiled.json
+++ b/crates/radiowave/tests/artifacts/hipfire-deepseek4-mq2r-gfx1151-2026-07-25-topk-gather-tiled.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 1,
+  "kind": "radiowave_recipe_evidence_summary",
+  "catalog_source_revision": "a064932c345b7ce4f9fe37c775b46c635b6d6e2f",
+  "catalog_source_path": "crates/radiowave/src/recipes.rs",
+  "raw_result_included": false,
+  "architecture": "gfx1151",
+  "date": "2026-07-25",
+  "recipe": "hipfire.memory.topk_gather_lds_transpose",
+  "verdict": "promoted",
+  "correctness": "byte-identical output",
+  "samples_per_row": 3,
+  "baseline_tokens_per_second": 25.57,
+  "candidate_tokens_per_second": 26.43,
+  "throughput_delta_pct": 3.363316,
+  "microbenchmark_baseline_us": 72.311,
+  "microbenchmark_candidate_us": 19.697,
+  "duration_delta_pct": -72.76,
+  "note": "The 21-layer cold-set microbenchmark and product ABBA result are copied from the vendored catalog. This compact record preserves that evidence; its raw result was not included in the source import."
+}

--- a/crates/radiowave/tests/artifacts/hipx-portability-2026-07-14.json
+++ b/crates/radiowave/tests/artifacts/hipx-portability-2026-07-14.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "kind": "radiowave_architecture_portability",
+  "date": "2026-07-14",
+  "host": "hipx",
+  "compiler": {
+    "hip_version": "7.2.53211-671d39a71e",
+    "clang": "22.0.0git",
+    "rocm_path": "/opt/rocm-7.2.2"
+  },
+  "probe": "crates/radiowave/tests/fixtures/portable_buffer_probe.hip",
+  "runtime_binary_sha256": "bf0d7edffb98681dee3c492fe8c8a811b2afb5f719cf99d606073e1f640cca08",
+  "performance_promoted": false,
+  "devices": [
+    {
+      "device": 0,
+      "architecture": "gfx1100",
+      "marketing_name": "AMD Radeon RX 7900 XTX",
+      "runtime_output": 42,
+      "wave32_code_object_sha256": "a0b9394b6b0e4631ff0a5192a6c8d7cee0adaa73a340826c44ec921edb056f3d",
+      "wave64_code_object_sha256": "d786e5166267f28052ad9f607dd9bba58f82908f2dd2580678d30fa68b451676",
+      "buffer_loads": 1,
+      "buffer_stores": 1,
+      "spills": 0,
+      "cache_certification": "vmem_only"
+    },
+    {
+      "device": 1,
+      "architecture": "gfx1151",
+      "marketing_name": "Radeon 8060S Graphics",
+      "runtime_output": 42,
+      "wave32_code_object_sha256": "c5e4939c8fec6d0106ec4db95f5447a7d2520c671d012b50a3cd10820241d564",
+      "wave64_code_object_sha256": "0366a01101f888f0990ecfc01bf67f3b5ae9d114e8de6d1bbe344bdf0b827359",
+      "buffer_loads": 1,
+      "buffer_stores": 1,
+      "spills": 0,
+      "cache_certification": "vmem_only"
+    },
+    {
+      "device": 2,
+      "architecture": "gfx1030",
+      "marketing_name": "AMD Radeon RX 6950 XT",
+      "runtime_output": 42,
+      "wave32_code_object_sha256": "ffcd65d3e0cdb45403baad6a8be9dd06994159015fd9a672110f7b79b9073193",
+      "wave64_code_object_sha256": "2414ef6ba1f4de4f7789093b81262f30f11ccbae1a0db527d1fcb200b21bf0cc",
+      "buffer_loads": 1,
+      "buffer_stores": 1,
+      "spills": 0,
+      "cache_certification": "scalar_or_unknown"
+    },
+    {
+      "device": 3,
+      "architecture": "gfx1010",
+      "marketing_name": "AMD Radeon RX 5700 XT",
+      "runtime_output": 42,
+      "wave32_code_object_sha256": "2c8204059d0a4ad6cfb910efc333d9628b80ca7427628c5ac33a2921fb56f4f6",
+      "wave64_code_object_sha256": "f916509a1638a8f660497f098d08c369c1fe77cd76591c1c4f3c0ce7c8ae2fa3",
+      "buffer_loads": 1,
+      "buffer_stores": 1,
+      "spills": 0,
+      "cache_certification": "scalar_or_unknown"
+    }
+  ],
+  "notes": [
+    "The multi-architecture HIP binary returned 42 from a buffer B32 load/add/store on every device.",
+    "Radiowave compiled and inspected spill-free wave32 and wave64 code objects for every target.",
+    "gfx10 legacy kernarg prologue encoding remains conservatively scalar_or_unknown; this does not weaken Redline's cache boundary.",
+    "Correctness-only evidence leaves all non-gfx1201 performance recipes candidate-only."
+  ]
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1010-2026-07-14-radiowave-candidate-discovery-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1010-2026-07-14-radiowave-candidate-discovery-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 946722,
+  "original_result_path": "examples/hipfire-6409/results/gfx1010/2026-07-14-radiowave-candidate-discovery/results.json",
+  "original_sha256": "277ec26c5cbb9baf84dc968f85c32a3766fc128f080101bf3ce18e50493ea182",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1010-2026-07-14-radiowave-probe-dequant-chunk16-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1010-2026-07-14-radiowave-probe-dequant-chunk16-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 89206,
+  "original_result_path": "examples/hipfire-6409/results/gfx1010/2026-07-14-radiowave-probe-dequant-chunk16/results.json",
+  "original_sha256": "51996960f36bc8e75978131e60775b3dfb8f364a36d044db77e3fa45a4942c46",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1030-2026-07-14-radiowave-candidate-discovery-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1030-2026-07-14-radiowave-candidate-discovery-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 966892,
+  "original_result_path": "examples/hipfire-6409/results/gfx1030/2026-07-14-radiowave-candidate-discovery/results.json",
+  "original_sha256": "ca33c161f1279a97198b0b5df36f1abaa35fc1364d95e1066fbf83b2981975f8",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1030-2026-07-14-radiowave-probe-dequant-chunk16-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1030-2026-07-14-radiowave-probe-dequant-chunk16-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 89561,
+  "original_result_path": "examples/hipfire-6409/results/gfx1030/2026-07-14-radiowave-probe-dequant-chunk16/results.json",
+  "original_sha256": "e5028cbf529dc3cb3f66b869cb53f79011dd18d1d6a0086f2a8851a0b143604d",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-cache-vmem-candidate-geometry-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-cache-vmem-candidate-geometry-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 108641,
+  "original_result_path": "examples/hipfire-6409/results/gfx1100/2026-07-14-radiowave-cache-vmem/candidate-geometry/results.json",
+  "original_sha256": "e1d4fe9e8a9072b20be5cb705dcf735981bc215c21b9b46023c8825b4c0303f2",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-cache-vmem-candidate-reduction-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-cache-vmem-candidate-reduction-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 91169,
+  "original_result_path": "examples/hipfire-6409/results/gfx1100/2026-07-14-radiowave-cache-vmem/candidate-reduction/results.json",
+  "original_sha256": "6aca6660197452d508c839d19c40f7eb24d51d84d04d55bcfef509978446f2ce",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-cache-vmem-replicate2-candidate-geometry-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-cache-vmem-replicate2-candidate-geometry-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 108494,
+  "original_result_path": "examples/hipfire-6409/results/gfx1100/2026-07-14-radiowave-cache-vmem-replicate2/candidate-geometry/results.json",
+  "original_sha256": "e3d22f1a78810d639b36b9b95d1e1701fd04e7a72524d71677c852f2ae6f61af",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-cache-vmem-replicate2-candidate-reduction-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-cache-vmem-replicate2-candidate-reduction-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 91023,
+  "original_result_path": "examples/hipfire-6409/results/gfx1100/2026-07-14-radiowave-cache-vmem-replicate2/candidate-reduction/results.json",
+  "original_sha256": "d854f85d583837fd6786ceed92d28c2dd122858583506f2f461d4036460a09b1",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-candidate-discovery-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-candidate-discovery-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 931819,
+  "original_result_path": "examples/hipfire-6409/results/gfx1100/2026-07-14-radiowave-candidate-discovery/results.json",
+  "original_sha256": "12f63411be83af08b622f464ef55a63deb6a5c9cd82f969ae755973d5eee9fe5",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-dispatch-wg32-candidate-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-dispatch-wg32-candidate-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 113282,
+  "original_result_path": "examples/hipfire-6409/results/gfx1100/2026-07-14-radiowave-dispatch-wg32/candidate/results.json",
+  "original_sha256": "295e9d29bccf9ef57b0e78c5aca4446b308e8ccac8c9137ef9370bb92714e98c",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-dispatch-wg32-replicate2-candidate-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1100-2026-07-14-radiowave-dispatch-wg32-replicate2-candidate-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 113557,
+  "original_result_path": "examples/hipfire-6409/results/gfx1100/2026-07-14-radiowave-dispatch-wg32-replicate2/candidate/results.json",
+  "original_sha256": "dc117029c3a91716abb9cf0668d02819a5449015e21642352e43e1fc4ba95dc8",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-cache-vmem-candidate-geometry-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-cache-vmem-candidate-geometry-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 112191,
+  "original_result_path": "examples/hipfire-6409/results/gfx1151/2026-07-14-radiowave-cache-vmem/candidate-geometry/results.json",
+  "original_sha256": "59e67deb18f698f7fefdf6de10132692976d31cad1293161755b2651b809fc8d",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-cache-vmem-candidate-reduction-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-cache-vmem-candidate-reduction-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 92815,
+  "original_result_path": "examples/hipfire-6409/results/gfx1151/2026-07-14-radiowave-cache-vmem/candidate-reduction/results.json",
+  "original_sha256": "6e7b84f61a6323943684cd1b11b160a419949005fcefa7305dc39240e1852899",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-cache-vmem-replicate2-candidate-geometry-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-cache-vmem-replicate2-candidate-geometry-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 112198,
+  "original_result_path": "examples/hipfire-6409/results/gfx1151/2026-07-14-radiowave-cache-vmem-replicate2/candidate-geometry/results.json",
+  "original_sha256": "c2c75bddd153e7b1b6e5094544d6afcb1530bbd560c3a41c023d6a6c5eb99c97",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-cache-vmem-replicate2-candidate-reduction-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-cache-vmem-replicate2-candidate-reduction-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 92831,
+  "original_result_path": "examples/hipfire-6409/results/gfx1151/2026-07-14-radiowave-cache-vmem-replicate2/candidate-reduction/results.json",
+  "original_sha256": "f27ccd1da74180528f27848afe5aecb3b21b9ff386c66cb4f86f65f6c0009aac",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-candidate-discovery-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-candidate-discovery-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 956593,
+  "original_result_path": "examples/hipfire-6409/results/gfx1151/2026-07-14-radiowave-candidate-discovery/results.json",
+  "original_sha256": "dd315aa0b3d0467a4293eee8b7be94f0fbbc93d45db5897555b938a28f8e2e0e",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-dispatch-wg32-candidate-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-dispatch-wg32-candidate-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 114239,
+  "original_result_path": "examples/hipfire-6409/results/gfx1151/2026-07-14-radiowave-dispatch-wg32/candidate/results.json",
+  "original_sha256": "d8255ad2dc11b40cc8dc7b27dabefc66d7a4ffc2571b2ec5dfc183667724e048",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-dispatch-wg32-replicate2-candidate-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-dispatch-wg32-replicate2-candidate-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 114202,
+  "original_result_path": "examples/hipfire-6409/results/gfx1151/2026-07-14-radiowave-dispatch-wg32-replicate2/candidate/results.json",
+  "original_sha256": "416656fb26c1d831a17d6188a4cc15e94a023fe668876be9bda5fa4cbadf0509",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-probe-dequant-chunk16-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-probe-dequant-chunk16-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 89906,
+  "original_result_path": "examples/hipfire-6409/results/gfx1151/2026-07-14-radiowave-probe-dequant-chunk16/results.json",
+  "original_sha256": "5c073d1958669728d34e442a0c1c87704c9384e493aac4eeadb1b7816d736896",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-probe-wave64-interleave-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-probe-wave64-interleave-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 90983,
+  "original_result_path": "examples/hipfire-6409/results/gfx1151/2026-07-14-radiowave-probe-wave64-interleave/results.json",
+  "original_sha256": "3c49ed975203ea244098e1f687179b37ab818dd043d2c025998e87bb1f64e4a3",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-probe-wave64-vopd-results.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1151-2026-07-14-radiowave-probe-wave64-vopd-results.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 139168,
+  "original_result_path": "examples/hipfire-6409/results/gfx1151/2026-07-14-radiowave-probe-wave64-vopd/results.json",
+  "original_sha256": "5b3f37a1e321fdddd339ec35f645bb896ab1c3f0c01c0a8ce44369e548e67369",
+  "schema_version": 1
+}

--- a/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1201-2026-07-13-radiowave-all-losers-final-u8-aggregate.json
+++ b/crates/radiowave/tests/artifacts/recipes/hipfire-6409-gfx1201-2026-07-13-radiowave-all-losers-final-u8-aggregate.json
@@ -1,0 +1,9 @@
+{
+  "external_archive_sha256": "d4d0911e751e891b952f2983c0a78e05c304b854321ce5f438794ca7a8abda2b",
+  "kind": "radiowave_recipe_provenance",
+  "note": "Full raw result history is externally archived; this fixture is a deterministic provenance record only and does not embed measurement rows.",
+  "original_byte_size": 57244,
+  "original_result_path": "examples/hipfire-6409/results/gfx1201/2026-07-13-radiowave-all-losers/final-u8/aggregate.json",
+  "original_sha256": "4b887eede6536a2967c1436da6f8d779b19f224f34bfb4e7ac6016c9e5021231",
+  "schema_version": 1
+}


### PR DESCRIPTION
## Summary

Restore the `beta` CI baseline on a clean checkout without changing kernels or runtime behavior:

- track the Radiowave fixtures already required by the built-in recipe provenance test;
- document and narrowly suppress a Clippy false positive at the HIP device-pointer wrapper, without changing its API or any caller;
- keep changed-file rustfmt advisory and visible while allowing the job check itself to remain green.

This PR is based directly on `beta@e2169c2d57aa9ebfc4c265162f87a5b35ca4acb4`, the current source head of #534.

Outside the required data fixtures, the net implementation diff is 9 additions and 3 deletions across three files: `.github/workflows/ci.yml`, `.gitignore`, and `crates/hip-bridge/src/ffi.rs`.

## Fixture provenance

Twenty-three compact provenance/portability fixtures are byte-identical to the tracked source at [`warpfront/redline@33683f3d`](https://github.com/warpfront/redline/tree/33683f3d4f302a6c56bcc7a4c33ab8be3262dd2e/crates/radiowave/tests/artifacts).

The three newer DeepSeek recipe artifacts were not present in that import. They are therefore committed as explicit catalog evidence summaries, pinned to `crates/radiowave/src/recipes.rs` at source revision `a064932c345b7ce4f9fe37c775b46c635b6d6e2f` and marked `raw_result_included: false`; this PR does not invent raw-result paths or hashes.

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [ ] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [x] `crates/hip-bridge` (HIP/ROCm FFI safe wrapper)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [ ] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template)
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [x] docs / CI / scripts

Also touched: `crates/radiowave` test fixtures and `.gitignore`.

## Test plan

- [x] `./scripts/no-gpu-ci.sh`
- [x] `cargo build --release --workspace --features deltanet --locked`
- [x] `cargo test --lib --workspace --features deltanet --locked`
- [x] `cargo test --lib --workspace --locked`
- [x] `cargo clippy --workspace --all-targets --locked`
- [x] `cargo build --release --workspace --all-targets --locked`
- [x] `cargo build --release --locked -p hipfire-runtime --example daemon --features arch-qwen35,arch-qwen35-vl,arch-llama,arch-qwen2,arch-deepseek4,arch-dots-ocr`
- [x] Changed Rust files pass rustfmt; all added JSON parses
- [x] Kernel/dispatch coherence gate: not applicable; no kernel source, dispatch routing, or packet behavior changed
- [x] Spec-decode coherence gate: not applicable
- [x] Speed gate: not applicable; no performance-sensitive path changed

The full no-GPU gate includes 371 Python CPU tests, 127 Redline tests, Rust workspace tests, and the env/docs drift check. It passes when run outside a restricted socket sandbox; the restricted sandbox blocks Redline's loopback-port tests at `socket(AF_INET, SOCK_STREAM)`.

Codex 5.3 Spark performed a separate read-only review and found no blocking issue.

## Architecture-trait change?

No. The `Architecture` trait surface is unchanged.
