### PR TITLE
customized feat(redline): isolate dispatch timestamp write costs for taniguchi-taku-softm's dignosal only!

### DIFF
--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -4056,6 +4056,22 @@ fn main() {
                     .get("validate_correctness")
                     .and_then(|value| value.as_bool())
                     .unwrap_or(true);
+                let arm_name = msg
+                    .get("arm")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("host-legacy-confirm");
+                let Some(arm) = rdna_compute::replay::Pm4DispatchProfileArm::parse(arm_name) else {
+                    let _ = writeln!(
+                        stdout,
+                        "{}",
+                        serde_json::json!({
+                            "type": "error",
+                            "message": format!("unknown redline dispatch-profile arm {arm_name:?}"),
+                        })
+                    );
+                    let _ = stdout.flush();
+                    continue;
+                };
                 let eligible = model.as_ref().is_some_and(|loaded| {
                     loaded.pp == 1
                         && loaded.ep.is_none()
@@ -4076,10 +4092,11 @@ fn main() {
                 }
 
                 let route = gpu.replay.capture_summary();
-                let prepared = match gpu
-                    .replay
-                    .prepare_pm4_dispatch_profile(gpu.device_id as usize, launch_count)
-                {
+                let prepared = match gpu.replay.prepare_pm4_dispatch_profile(
+                    gpu.device_id as usize,
+                    launch_count,
+                    arm,
+                ) {
                     Ok(summary) => summary,
                     Err(reason) => {
                         let _ = writeln!(
@@ -4245,8 +4262,18 @@ fn main() {
                                 "context_tokens": context,
                                 "warmup_replays": warmup_replays,
                                 "sample_replays": sample_replays,
+                                "arm": arm.as_str(),
                                 "steady_state": true,
                                 "exactly_once_per_sample": true,
+                                "timestamp_validation": {
+                                    "memory": arm.timestamp_memory(),
+                                    "dst_scope": arm.dst_scope(),
+                                    "per_write_confirm": arm.per_write_confirm(),
+                                    "tail_release": arm.tail_release(),
+                                    "sentinels_overwritten": true,
+                                    "monotonic": true,
+                                    "complete": true,
+                                },
                                 "timestamp_semantics": "baseline before stream plus post-dispatch stamps; span i is PM4 after timestamp i through dispatch i (entry acquire in span 0; later spans include intervening boundary packets)",
                                 "route": {
                                     "launches": route.launch_count,
@@ -4254,6 +4281,7 @@ fn main() {
                                     "sequence_hash": format!("{:016x}", route.sequence_hash),
                                     "command_dwords": prepared.1,
                                     "timestamp_slots": route.launch_count + 1,
+                                    "tail_fence_slots": usize::from(arm.tail_release()),
                                     "queue_id": prepared.2,
                                 },
                                 "dispatches": dispatches,

--- a/crates/rdna-compute/src/replay.rs
+++ b/crates/rdna-compute/src/replay.rs
@@ -21,11 +21,13 @@ use std::sync::Arc;
 
 use hip_bridge::HipRuntime;
 use redline_dispatch::aql::{
-    load_symbols, BatchFencePolicy, Executable, Gfx10DispatchInitiatorPolicy,
-    Gfx10Pm4CommandBuffer, Gfx11ComputeResourceLimitsPolicy, Gfx11DispatchInterleave,
+    load_symbols, BatchFencePolicy, DispatchTimestampMemory, Executable,
+    Gfx10DispatchInitiatorPolicy, Gfx10Pm4CommandBuffer, Gfx11ComputeResourceLimitsPolicy,
+    Gfx11DispatchInterleave, Gfx12CopyDataDstScope, Gfx12DispatchTimestampConfig,
     Gfx12Pm4CommandBuffer, GpuBatchTiming, GpuDevice, GpuMultiQueueTiming, GpuSelector,
     HeaderPolicy, KernargBuffer, KernargPool, Kernel, LaunchGeometry, PhasedMultiQueuePm4Ib,
-    QueuePolicy, RecordedDispatch, Runtime, SingleQueueBatchGraph, SingleQueuePm4Ib,
+    Pm4DispatchProfileConfig, QueuePolicy, RecordedDispatch, Runtime, SingleQueueBatchGraph,
+    SingleQueuePm4Ib,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -271,7 +273,7 @@ impl Pm4Commands {
         device: &GpuDevice,
         pool: &KernargPool,
         cu_mask: Option<&[u32; 2]>,
-        dispatch_profile: bool,
+        dispatch_profile: Option<Pm4DispatchProfileConfig>,
     ) -> Result<SingleQueuePm4Ib, String> {
         let graph = match self {
             Self::Legacy {
@@ -294,8 +296,15 @@ impl Pm4Commands {
                 // different dword count and sequence hash, so such a run cannot
                 // satisfy a golden fixture — it is a diagnostic, not a
                 // certification.
-                if dispatch_profile || dispatch_profile_enabled() {
-                    SingleQueuePm4Ib::create_dispatch_profiled(device, pool, commands)
+                if let Some(config) = dispatch_profile {
+                    SingleQueuePm4Ib::create_dispatch_profiled(device, pool, commands, config)
+                } else if dispatch_profile_enabled() {
+                    SingleQueuePm4Ib::create_dispatch_profiled(
+                        device,
+                        pool,
+                        commands,
+                        Pm4DispatchProfileConfig::default(),
+                    )
                 } else {
                     SingleQueuePm4Ib::create_profiled(device, pool, commands)
                 }
@@ -1906,6 +1915,79 @@ pub struct Pm4DispatchProfile {
     pub spans_nanoseconds: Vec<u64>,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Pm4DispatchProfileArm {
+    #[default]
+    HostLegacyConfirm,
+    HostSystemConfirm,
+    DeviceConfirm,
+    HostSystemTailConfirm,
+}
+
+impl Pm4DispatchProfileArm {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "host-legacy-confirm" => Some(Self::HostLegacyConfirm),
+            "host-system-confirm" => Some(Self::HostSystemConfirm),
+            "device-confirm" => Some(Self::DeviceConfirm),
+            "host-system-tail-confirm" => Some(Self::HostSystemTailConfirm),
+            _ => None,
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::HostLegacyConfirm => "host-legacy-confirm",
+            Self::HostSystemConfirm => "host-system-confirm",
+            Self::DeviceConfirm => "device-confirm",
+            Self::HostSystemTailConfirm => "host-system-tail-confirm",
+        }
+    }
+
+    pub const fn timestamp_memory(self) -> &'static str {
+        match self {
+            Self::DeviceConfirm => "device-local",
+            _ => "host-fine-grained",
+        }
+    }
+
+    pub const fn dst_scope(self) -> &'static str {
+        match self {
+            Self::HostLegacyConfirm => "legacy-cu",
+            Self::DeviceConfirm => "device",
+            Self::HostSystemConfirm | Self::HostSystemTailConfirm => "system",
+        }
+    }
+
+    pub const fn per_write_confirm(self) -> bool {
+        !matches!(self, Self::HostSystemTailConfirm)
+    }
+
+    pub const fn tail_release(self) -> bool {
+        matches!(self, Self::HostSystemTailConfirm)
+    }
+
+    fn config(self) -> Pm4DispatchProfileConfig {
+        let memory = match self {
+            Self::DeviceConfirm => DispatchTimestampMemory::DeviceLocal,
+            _ => DispatchTimestampMemory::HostFineGrained,
+        };
+        let dst_scope = match self {
+            Self::HostLegacyConfirm => Gfx12CopyDataDstScope::Legacy,
+            Self::DeviceConfirm => Gfx12CopyDataDstScope::Device,
+            Self::HostSystemConfirm | Self::HostSystemTailConfirm => Gfx12CopyDataDstScope::System,
+        };
+        Pm4DispatchProfileConfig {
+            memory,
+            packet: Gfx12DispatchTimestampConfig {
+                dst_scope,
+                per_write_confirm: self.per_write_confirm(),
+                tail_release: self.tail_release(),
+            },
+        }
+    }
+}
+
 pub struct PreparedPm4Replay {
     graph: PreparedPm4Graph,
     // Kernels retain their HSA executables and kernargs retain every pointer
@@ -2520,7 +2602,7 @@ impl ReplayController {
         device_ordinal: usize,
         prefix: usize,
     ) -> Result<(usize, u32, u64), String> {
-        self.prepare_pm4_prefix_inner(device_ordinal, prefix, false)
+        self.prepare_pm4_prefix_inner(device_ordinal, prefix, None)
     }
 
     /// Lower a captured prefix to a single GFX12 IB with per-dispatch timestamps.
@@ -2528,16 +2610,18 @@ impl ReplayController {
         &mut self,
         device_ordinal: usize,
         prefix: usize,
+        arm: Pm4DispatchProfileArm,
     ) -> Result<(usize, u32, u64), String> {
-        self.prepare_pm4_prefix_inner(device_ordinal, prefix, true)
+        self.prepare_pm4_prefix_inner(device_ordinal, prefix, Some(arm.config()))
     }
 
     fn prepare_pm4_prefix_inner(
         &mut self,
         device_ordinal: usize,
         prefix: usize,
-        dispatch_profile: bool,
+        dispatch_profile_config: Option<Pm4DispatchProfileConfig>,
     ) -> Result<(usize, u32, u64), String> {
+        let dispatch_profile = dispatch_profile_config.is_some();
         if self.recorded.is_empty() {
             return Err("no captured launch sequence".to_owned());
         }
@@ -2737,7 +2821,7 @@ impl ReplayController {
             }
             let command_dwords = commands.len_dwords();
             let graph =
-                commands.create_graph(&device, &pool, cu_mask.as_ref(), dispatch_profile)?;
+                commands.create_graph(&device, &pool, cu_mask.as_ref(), dispatch_profile_config)?;
             (PreparedPm4Graph::Single(graph), command_dwords)
         } else {
             let min_parallel_width = pm4_min_parallel_width_from_config();
@@ -4324,5 +4408,23 @@ mod tests {
 
         controller.set_forward_eligible(false);
         assert!(!controller.should_route_aql());
+    }
+
+    #[test]
+    fn dispatch_profile_arms_map_to_one_variable_at_a_time() {
+        let legacy = Pm4DispatchProfileArm::parse("host-legacy-confirm").unwrap();
+        let system = Pm4DispatchProfileArm::parse("host-system-confirm").unwrap();
+        let device = Pm4DispatchProfileArm::parse("device-confirm").unwrap();
+        let tail = Pm4DispatchProfileArm::parse("host-system-tail-confirm").unwrap();
+
+        assert_eq!(legacy.timestamp_memory(), "host-fine-grained");
+        assert_eq!(legacy.dst_scope(), "legacy-cu");
+        assert_eq!(system.timestamp_memory(), legacy.timestamp_memory());
+        assert_eq!(system.dst_scope(), "system");
+        assert_eq!(device.timestamp_memory(), "device-local");
+        assert_eq!(device.dst_scope(), "device");
+        assert!(!tail.per_write_confirm());
+        assert!(tail.tail_release());
+        assert!(Pm4DispatchProfileArm::parse("unknown").is_none());
     }
 }

--- a/crates/redline-dispatch/examples/packet_isolation_2x2.rs
+++ b/crates/redline-dispatch/examples/packet_isolation_2x2.rs
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! GFX12 packet-isolation diagnostic for COPY_DATA × CS_PARTIAL_FLUSH.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Instant;
+
+use redline_dispatch::aql::SingleQueuePm4Ib;
+use redline_rocr::{
+    Executable, Gfx12CopyDataDstScope, Gfx12DispatchTimestampConfig, Gfx12Pm4CommandBuffer,
+    GpuSelector, KernargBuffer, KernargPool, LaunchGeometry, Runtime, load_symbols,
+};
+
+const SENTINEL: u64 = 0xd1a6_7057_dead_beef;
+const ARMS: [(&str, bool, bool); 4] = [
+    ("T00", false, false),
+    ("T10", false, true),
+    ("T01", true, false),
+    ("T11", true, true),
+];
+const ORDERS: [[usize; 4]; 4] = [[0, 1, 3, 2], [1, 2, 0, 3], [2, 3, 1, 0], [3, 0, 2, 1]];
+
+struct Args {
+    hsaco: PathBuf,
+    gpu: usize,
+    replays_per_sample: usize,
+    spin_iterations: u32,
+    warmups: usize,
+    cycles: usize,
+}
+
+struct ArmGraph {
+    name: &'static str,
+    copy_data: bool,
+    wait_compute_idle: bool,
+    graph: SingleQueuePm4Ib,
+    timestamps: KernargBuffer,
+    command_dwords: u32,
+}
+
+fn parse_args() -> Result<Args, String> {
+    let mut values = std::env::args().skip(1);
+    let mut hsaco = None;
+    let mut gpu = 0;
+    let mut replays_per_sample = 307;
+    let mut spin_iterations = 256;
+    let mut warmups = 10;
+    let mut cycles = 40;
+    while let Some(flag) = values.next() {
+        let value = values
+            .next()
+            .ok_or_else(|| format!("missing value after {flag}"))?;
+        match flag.as_str() {
+            "--hsaco" => hsaco = Some(PathBuf::from(value)),
+            "--gpu" => gpu = value.parse().map_err(|_| "invalid --gpu")?,
+            "--replays-per-sample" => {
+                replays_per_sample = value.parse().map_err(|_| "invalid --replays-per-sample")?
+            }
+            "--spin-iterations" => {
+                spin_iterations = value.parse().map_err(|_| "invalid --spin-iterations")?
+            }
+            "--warmups" => warmups = value.parse().map_err(|_| "invalid --warmups")?,
+            "--cycles" => cycles = value.parse().map_err(|_| "invalid --cycles")?,
+            _ => return Err(format!("unknown argument {flag}")),
+        }
+    }
+    if replays_per_sample == 0 || cycles == 0 {
+        return Err("--replays-per-sample and --cycles must be positive".to_owned());
+    }
+    Ok(Args {
+        hsaco: hsaco.ok_or_else(|| "--hsaco is required".to_owned())?,
+        gpu,
+        replays_per_sample,
+        spin_iterations,
+        warmups,
+        cycles,
+    })
+}
+
+fn reset_timestamps(buffer: &mut KernargBuffer) {
+    for word in buffer.as_mut_bytes().chunks_exact_mut(8) {
+        word.copy_from_slice(&SENTINEL.to_le_bytes());
+    }
+}
+
+fn validate_timestamps(buffer: &mut KernargBuffer, expect_factor: bool) -> (bool, bool, u64, u64) {
+    let ticks = buffer
+        .as_mut_bytes()
+        .chunks_exact(8)
+        .map(|word| u64::from_le_bytes(word.try_into().unwrap()))
+        .collect::<Vec<_>>();
+    let complete =
+        ticks[0] != SENTINEL && ticks[1] != SENTINEL && (ticks[2] != SENTINEL) == expect_factor;
+    let monotonic =
+        ticks[1] >= ticks[0] && (!expect_factor || (ticks[2] >= ticks[0] && ticks[1] >= ticks[2]));
+    (complete, monotonic, ticks[0], ticks[1])
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = parse_args().map_err(|reason| format!("packet-isolation: {reason}"))?;
+    let runtime = Runtime::initialize(load_symbols()?)?;
+    let device = runtime.select_gpu(GpuSelector::Ordinal(args.gpu))?;
+    if !device.name().starts_with("gfx12") {
+        return Err(format!("packet-isolation requires gfx12, got {}", device.name()).into());
+    }
+    let pool = KernargPool::discover(&device)?;
+    let code: Arc<[u8]> = std::fs::read(&args.hsaco)?.into();
+    let executable = Executable::load(&device, code)?;
+    let kernel = executable.kernel("redline_packet_isolation_spin.kd")?;
+    let geometry = LaunchGeometry::from_hip_workgroups([64, 1, 1], [64, 1, 1])?;
+
+    let mut output = pool.allocate_executable_bytes(8)?;
+    output.as_mut_bytes().fill(0);
+    let mut kernarg = pool.allocate_for(kernel.metadata())?;
+    let bytes = kernarg.as_mut_bytes();
+    if bytes.len() < 12 {
+        return Err(format!("unexpected kernarg size {}", bytes.len()).into());
+    }
+    bytes.fill(0);
+    let address = output.address() as usize as u64;
+    bytes[..8].copy_from_slice(&address.to_ne_bytes());
+    bytes[8..12].copy_from_slice(&args.spin_iterations.to_ne_bytes());
+
+    let timestamp_config = Gfx12DispatchTimestampConfig {
+        dst_scope: Gfx12CopyDataDstScope::System,
+        per_write_confirm: true,
+        tail_release: false,
+    };
+    let timestamp_frequency_hz = device.gpu_timestamp_frequency_hz()?;
+    let mut arms = Vec::with_capacity(ARMS.len());
+    for (name, copy_data, wait_compute_idle) in ARMS {
+        let mut timestamps = pool.allocate_executable_bytes(24)?;
+        reset_timestamps(&mut timestamps);
+        let timestamp_base = timestamps.address() as usize as u64;
+        let mut commands = Gfx12Pm4CommandBuffer::new_stateful();
+        commands.acquire_system_gfx12();
+        commands.dispatch(&kernel, geometry, 0, kernarg.address())?;
+        commands.diagnostic_packet_isolation_cell(Some(timestamp_base), false, timestamp_config);
+        commands.diagnostic_packet_isolation_cell(
+            copy_data.then_some(timestamp_base + 16),
+            wait_compute_idle,
+            timestamp_config,
+        );
+        commands.diagnostic_packet_isolation_cell(
+            Some(timestamp_base + 8),
+            false,
+            timestamp_config,
+        );
+        // Outside the measured start/end window: safely complete compute before
+        // the enclosing AQL PM4-IB packet publishes its completion signal.
+        commands.wait_compute_idle();
+        let command_dwords = commands.len_dwords();
+        let graph = SingleQueuePm4Ib::create(&device, &pool, &commands)?;
+        arms.push(ArmGraph {
+            name,
+            copy_data,
+            wait_compute_idle,
+            graph,
+            timestamps,
+            command_dwords,
+        });
+    }
+    if arms
+        .iter()
+        .map(|arm| arm.command_dwords)
+        .collect::<std::collections::BTreeSet<_>>()
+        .len()
+        != 1
+    {
+        return Err("2x2 arms do not have equal command DWORD counts".into());
+    }
+
+    println!(
+        "META\tdevice\t{}\tgpu\t{}\treplays_per_sample\t{}\tspin_iterations\t{}\twarmups\t{}\tcycles\t{}\tcommand_dwords\t{}",
+        device.name(),
+        args.gpu,
+        args.replays_per_sample,
+        args.spin_iterations,
+        args.warmups,
+        args.cycles,
+        arms[0].command_dwords,
+    );
+    for _ in 0..args.warmups {
+        for arm in &mut arms {
+            for _ in 0..args.replays_per_sample {
+                reset_timestamps(&mut arm.timestamps);
+                // SAFETY: executable, kernargs, output, and timestamp buffers
+                // remain live until every graph is dropped below.
+                unsafe { arm.graph.replay_and_wait()? };
+            }
+        }
+    }
+
+    let mut seen = BTreeMap::new();
+    for cycle in 0..args.cycles {
+        for (position, arm_index) in ORDERS[cycle % ORDERS.len()].iter().copied().enumerate() {
+            let arm = &mut arms[arm_index];
+            let started = Instant::now();
+            let mut gpu_ns = 0_u64;
+            let mut complete = true;
+            let mut monotonic = true;
+            for _ in 0..args.replays_per_sample {
+                reset_timestamps(&mut arm.timestamps);
+                // SAFETY: all addresses encoded in the retained IB remain live.
+                unsafe { arm.graph.replay_and_wait()? };
+                let validation = validate_timestamps(&mut arm.timestamps, arm.copy_data);
+                complete &= validation.0;
+                monotonic &= validation.1;
+                gpu_ns = gpu_ns.saturating_add(
+                    validation
+                        .3
+                        .saturating_sub(validation.2)
+                        .saturating_mul(1_000_000_000)
+                        / timestamp_frequency_hz,
+                );
+            }
+            let host_ns = started.elapsed().as_nanos();
+            if !complete || !monotonic {
+                return Err(format!(
+                    "{} timestamp validation failed: complete={complete} monotonic={monotonic}",
+                    arm.name
+                )
+                .into());
+            }
+            println!(
+                "SAMPLE\t{cycle}\t{position}\t{}\t{}\t{}\t{}\t{}\t{}\t{}",
+                arm.name,
+                u8::from(arm.copy_data),
+                u8::from(arm.wait_compute_idle),
+                gpu_ns,
+                host_ns,
+                u8::from(complete),
+                u8::from(monotonic),
+            );
+            seen.insert((cycle, arm.name), ());
+        }
+    }
+    if seen.len() != args.cycles * ARMS.len() {
+        return Err("balanced matrix did not emit every cycle/arm pair".into());
+    }
+    Ok(())
+}

--- a/crates/redline-dispatch/src/aql/mod.rs
+++ b/crates/redline-dispatch/src/aql/mod.rs
@@ -15,16 +15,18 @@ pub use redline_rocr::{
     AqlQueue, BARRIER_DEPENDENCY_CAPACITY, CompletionSignal, Executable, FenceScope,
     Gfx10DispatchInitiatorPolicy, Gfx10KernelImage, Gfx10Pm4BuildError, Gfx10Pm4CommandBuffer,
     Gfx11ComputeResourceLimitsPolicy, Gfx11DispatchInterleave, Gfx11Pm4CommandBuffer,
-    Gfx12Pm4CommandBuffer, GpuDevice, GpuSelector, HeaderPolicy, KernargBuffer, KernargPool, Kernel,
-    KernelMetadata, KernelPm4Metadata, LaunchGeometry, LoadError, MissingSymbol, PacketError,
-    PciBusId, PciBusIdParseError, Pm4BuildError, QueueDepthReport, QueueDepthSample,
-    QueueDepthStats, QueueSet, Runtime, RuntimeError, Symbols, load_symbols,
+    Gfx12CopyDataDstScope, Gfx12DispatchTimestampConfig, Gfx12Pm4CommandBuffer, GpuDevice,
+    GpuSelector, HeaderPolicy, KernargBuffer, KernargPool, Kernel, KernelMetadata,
+    KernelPm4Metadata, LaunchGeometry, LoadError, MissingSymbol, PacketError, PciBusId,
+    PciBusIdParseError, Pm4BuildError, QueueDepthReport, QueueDepthSample, QueueDepthStats,
+    QueueSet, Runtime, RuntimeError, Symbols, load_symbols,
 };
 pub use replay::{
-    BatchFencePolicy, GpuBatchTiming, GpuMultiQueueTiming, PhasedMultiQueuePm4Ib, RecordedDispatch,
-    RecordedGraph, ReplayError, ReplaySubmission, SingleQueueBatchGraph,
-    SingleQueueBatchSubmission, SingleQueuePm4Ib, TwoQueueBatchSubmission, TwoQueuePhase,
-    TwoQueuePhasedGraph, TwoQueueSerializedBatchGraph, TwoQueueSubmission,
+    BatchFencePolicy, DispatchTimestampMemory, GpuBatchTiming, GpuMultiQueueTiming,
+    PhasedMultiQueuePm4Ib, Pm4DispatchProfileConfig, RecordedDispatch, RecordedGraph, ReplayError,
+    ReplaySubmission, SingleQueueBatchGraph, SingleQueueBatchSubmission, SingleQueuePm4Ib,
+    TwoQueueBatchSubmission, TwoQueuePhase, TwoQueuePhasedGraph, TwoQueueSerializedBatchGraph,
+    TwoQueueSubmission,
 };
 
 #[cfg(test)]

--- a/crates/redline-dispatch/src/aql/replay.rs
+++ b/crates/redline-dispatch/src/aql/replay.rs
@@ -10,10 +10,33 @@ use redline_rocr::packet::{
     PacketError, PacketImage,
 };
 use redline_rocr::{
-    CompletionSignal, DEFAULT_WAIT_TIMEOUT, Gfx10Pm4CommandBuffer, Gfx12Pm4CommandBuffer,
-    GpuDevice, HeaderPolicy, KernargBuffer, KernargPool, Kernel, Pm4BuildError, QueueDepthReport,
-    QueueSet, RuntimeError,
+    CompletionSignal, DEFAULT_WAIT_TIMEOUT, Gfx10Pm4CommandBuffer, Gfx12DispatchTimestampConfig,
+    Gfx12Pm4CommandBuffer, GpuDevice, HeaderPolicy, KernargBuffer, KernargPool, Kernel,
+    Pm4BuildError, QueueDepthReport, QueueSet, RuntimeError,
 };
+
+const DISPATCH_TIMESTAMP_SENTINEL: u64 = 0xd1a6_7057_dead_beef;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DispatchTimestampMemory {
+    HostFineGrained,
+    DeviceLocal,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Pm4DispatchProfileConfig {
+    pub memory: DispatchTimestampMemory,
+    pub packet: Gfx12DispatchTimestampConfig,
+}
+
+impl Default for Pm4DispatchProfileConfig {
+    fn default() -> Self {
+        Self {
+            memory: DispatchTimestampMemory::HostFineGrained,
+            packet: Gfx12DispatchTimestampConfig::default(),
+        }
+    }
+}
 
 fn retained_queue_size(
     required_packets: usize,
@@ -77,6 +100,8 @@ pub struct SingleQueuePm4Ib {
     batch: Vec<PacketImage>,
     timestamps: Option<KernargBuffer>,
     timestamp_frequency_hz: Option<u64>,
+    dispatch_timestamp_slots: Option<usize>,
+    tail_fence_slot: Option<usize>,
     dispatch_workgroup_offsets: Vec<usize>,
     usable: bool,
 }
@@ -142,6 +167,7 @@ impl SingleQueuePm4Ib {
         device: &GpuDevice,
         pool: &KernargPool,
         commands: &Gfx12Pm4CommandBuffer,
+        config: Pm4DispatchProfileConfig,
     ) -> Result<Self, ReplayError> {
         if commands.is_empty() {
             return Err(ReplayError::EmptyGraph);
@@ -149,21 +175,39 @@ impl SingleQueuePm4Ib {
         let slots = commands
             .timestamp_slot_count()
             .map_err(ReplayError::Pm4Build)?;
-        let mut timestamps = pool.allocate_executable_bytes(slots * 8)?;
-        timestamps.as_mut_bytes().fill(0);
+        let total_slots = slots + usize::from(config.packet.tail_release);
+        let mut timestamps = match config.memory {
+            DispatchTimestampMemory::HostFineGrained => {
+                pool.allocate_executable_bytes(total_slots * 8)?
+            }
+            DispatchTimestampMemory::DeviceLocal => {
+                KernargPool::allocate_device_local_bytes(device, total_slots * 8)?
+            }
+        };
+        for word in timestamps.as_mut_bytes().chunks_exact_mut(8) {
+            word.copy_from_slice(&DISPATCH_TIMESTAMP_SENTINEL.to_le_bytes());
+        }
         let base = timestamps.address() as usize as u64;
+        let tail_fence_slot = config.packet.tail_release.then_some(slots);
         let timed = commands
-            .with_per_dispatch_timestamps(base)
+            .with_per_dispatch_timestamps(
+                base,
+                config.packet,
+                tail_fence_slot.map(|slot| base + slot as u64 * 8),
+            )
             .map_err(ReplayError::Pm4Build)?;
         let frequency_hz = device.gpu_timestamp_frequency_hz()?;
-        Self::create_encoded(
+        let mut graph = Self::create_encoded(
             device,
             pool,
             &timed.as_bytes(),
             timed.len_dwords(),
             Some(timestamps),
             Some(frequency_hz),
-        )
+        )?;
+        graph.dispatch_timestamp_slots = Some(slots);
+        graph.tail_fence_slot = tail_fence_slot;
+        Ok(graph)
     }
 
     pub fn create_profiled(
@@ -254,6 +298,8 @@ impl SingleQueuePm4Ib {
             batch: vec![packet],
             timestamps,
             timestamp_frequency_hz,
+            dispatch_timestamp_slots: None,
+            tail_fence_slot: None,
             dispatch_workgroup_offsets,
             usable: true,
         })
@@ -422,12 +468,29 @@ impl SingleQueuePm4Ib {
             .as_mut()
             .ok_or(ReplayError::ProfilingUnavailable)?
             .as_mut_bytes();
-        let ticks = bytes
+        let all_ticks = bytes
             .chunks_exact(8)
             .map(|word| u64::from_le_bytes(word.try_into().unwrap()))
             .collect::<Vec<_>>();
+        let slots = self.dispatch_timestamp_slots.unwrap_or(all_ticks.len());
+        let ticks = all_ticks
+            .get(..slots)
+            .ok_or(ReplayError::ProfilingUnavailable)?;
         if ticks.len() < 2 {
             return Err(ReplayError::ProfilingUnavailable);
+        }
+        let missing = ticks
+            .iter()
+            .enumerate()
+            .filter_map(|(slot, value)| (*value == DISPATCH_TIMESTAMP_SENTINEL).then_some(slot))
+            .collect::<Vec<_>>();
+        if !missing.is_empty() {
+            return Err(ReplayError::IncompleteGpuTimestamps { missing });
+        }
+        if let Some(slot) = self.tail_fence_slot {
+            if all_ticks.get(slot) == Some(&DISPATCH_TIMESTAMP_SENTINEL) {
+                return Err(ReplayError::IncompleteGpuTimestampFence { slot });
+            }
         }
         let mut spans_nanoseconds = Vec::with_capacity(ticks.len() - 1);
         for pair in ticks.windows(2) {
@@ -3060,6 +3123,12 @@ pub enum ReplayError {
         start: u64,
         end: u64,
     },
+    IncompleteGpuTimestamps {
+        missing: Vec<usize>,
+    },
+    IncompleteGpuTimestampFence {
+        slot: usize,
+    },
     MalformedPm4IndirectBuffer {
         dword: usize,
     },
@@ -3172,6 +3241,14 @@ impl fmt::Display for ReplayError {
             Self::InvalidGpuTimestamp { start, end } => write!(
                 f,
                 "retained PM4 GPU timestamp bracket is invalid: start={start}, end={end}"
+            ),
+            Self::IncompleteGpuTimestamps { missing } => write!(
+                f,
+                "retained PM4 timestamp sentinels were not overwritten at slots {missing:?}"
+            ),
+            Self::IncompleteGpuTimestampFence { slot } => write!(
+                f,
+                "retained PM4 tail-fence sentinel was not overwritten at slot {slot}"
             ),
             Self::MalformedPm4IndirectBuffer { dword } => write!(
                 f,

--- a/crates/redline-rocr/src/lib.rs
+++ b/crates/redline-rocr/src/lib.rs
@@ -36,7 +36,10 @@ pub use packet::{
     BARRIER_DEPENDENCY_CAPACITY, FenceScope, HeaderPolicy, KernelMetadata, LaunchGeometry,
     PacketError,
 };
-pub use pm4::{Gfx12Pm4CommandBuffer, Pm4BuildError, Pm4DispatchSpanAttribution};
+pub use pm4::{
+    Gfx12CopyDataDstScope, Gfx12DispatchTimestampConfig, Gfx12Pm4CommandBuffer, Pm4BuildError,
+    Pm4DispatchSpanAttribution,
+};
 pub use pm4_gfx10::{
     Gfx10DispatchInitiatorPolicy, Gfx10KernelImage, Gfx10Pm4BuildError, Gfx10Pm4CommandBuffer,
     Gfx11ComputeResourceLimitsPolicy, Gfx11DispatchInterleave, Gfx11Pm4CommandBuffer,

--- a/crates/redline-rocr/src/pm4.rs
+++ b/crates/redline-rocr/src/pm4.rs
@@ -13,6 +13,7 @@ use crate::{Kernel, LaunchGeometry};
 
 const PACKET3_SET_SH_REG: u32 = 0x76;
 const PACKET3_DISPATCH_DIRECT: u32 = 0x15;
+const PACKET3_NOP: u32 = 0x10;
 const PACKET3_COPY_DATA: u32 = 0x40;
 const PACKET3_RELEASE_MEM: u32 = 0x49;
 const PACKET3_EVENT_WRITE: u32 = 0x46;
@@ -312,6 +313,31 @@ impl Gfx12Pm4CommandBuffer {
         ]);
     }
 
+    /// Append one packet-isolation diagnostic cell after a dispatch.
+    ///
+    /// Every combination occupies exactly eight DWORDs: either a six-DWORD
+    /// `COPY_DATA(GPU_CLOCK)` or equal-sized NOP, followed by either the
+    /// two-DWORD `CS_PARTIAL_FLUSH` event or equal-sized NOP. This keeps IB
+    /// length and parser work fixed while a diagnostic runner measures the
+    /// two packet factors and their interaction.
+    pub fn diagnostic_packet_isolation_cell(
+        &mut self,
+        timestamp_address: Option<u64>,
+        wait_compute_idle: bool,
+        timestamp_config: Gfx12DispatchTimestampConfig,
+    ) {
+        if let Some(address) = timestamp_address {
+            self.copy_gpu_timestamp(address, timestamp_config);
+        } else {
+            self.nop_dwords(6);
+        }
+        if wait_compute_idle {
+            self.wait_compute_idle();
+        } else {
+            self.nop_dwords(2);
+        }
+    }
+
     /// Same-agent inter-node acquire for one retained gfx12 tape. Kernel code
     /// is immutable and L2/MALL remains coherent, so only scalar/vector read
     /// caches plus forward sequencing are invalidated.
@@ -412,6 +438,13 @@ impl Gfx12Pm4CommandBuffer {
     pub fn wait_compute_idle(&mut self) {
         self.dwords.push(packet3(PACKET3_EVENT_WRITE, 1, false));
         self.dwords.push(0x407); // CS_PARTIAL_FLUSH, event-index 4.
+    }
+
+    fn nop_dwords(&mut self, dwords: u32) {
+        debug_assert!(dwords >= 2);
+        self.dwords.push(packet3(PACKET3_NOP, dwords - 1, false));
+        self.dwords
+            .resize(self.dwords.len() + dwords as usize - 1, 0);
     }
 
     pub fn len_dwords(&self) -> u32 {
@@ -658,6 +691,47 @@ mod tests {
                 .filter(|word| **word == packet3(PACKET3_RELEASE_MEM, 7, false))
                 .count();
             assert_eq!(release_count, usize::from(config.tail_release));
+        }
+    }
+
+    #[test]
+    fn packet_isolation_cells_hold_dword_count_constant_across_two_by_two() {
+        let config = Gfx12DispatchTimestampConfig {
+            dst_scope: Gfx12CopyDataDstScope::System,
+            per_write_confirm: true,
+            tail_release: false,
+        };
+        let mut cells = Vec::new();
+        for copy in [false, true] {
+            for wait in [false, true] {
+                let mut commands = Gfx12Pm4CommandBuffer::new();
+                commands.diagnostic_packet_isolation_cell(
+                    copy.then_some(0x1234_5678),
+                    wait,
+                    config,
+                );
+                assert_eq!(commands.len_dwords(), 8);
+                cells.push((copy, wait, commands.dwords().to_vec()));
+            }
+        }
+
+        for (copy, wait, words) in cells {
+            let first_opcode = (words[0] >> 8) & 0xff;
+            let second_opcode = (words[6] >> 8) & 0xff;
+            assert_eq!(
+                first_opcode,
+                if copy { PACKET3_COPY_DATA } else { PACKET3_NOP }
+            );
+            assert_eq!(
+                second_opcode,
+                if wait {
+                    PACKET3_EVENT_WRITE
+                } else {
+                    PACKET3_NOP
+                }
+            );
+            assert_eq!((words[0] >> 16) & 0x3fff, 4);
+            assert_eq!((words[6] >> 16) & 0x3fff, 0);
         }
     }
 

--- a/crates/redline-rocr/src/pm4.rs
+++ b/crates/redline-rocr/src/pm4.rs
@@ -40,6 +40,45 @@ const SUPPORTED_KERNEL_PROPERTIES: u16 = ENABLE_SGPR_KERNARG_SEGMENT_PTR | ENABL
 const DISPATCH_INITIATOR_BASE: u32 = (1 << 0) | (1 << 2) | (1 << 5);
 const DISPATCH_INITIATOR_CS_W32_EN: u32 = 1 << 15;
 
+/// GFX12 `COPY_DATA.DST_SCOPE` used by the diagnostic timestamp writes.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Gfx12CopyDataDstScope {
+    /// Preserve the original packet encoding (`DST_SCOPE=CU`/zero).
+    #[default]
+    Legacy,
+    Device,
+    System,
+}
+
+impl Gfx12CopyDataDstScope {
+    const fn bits(self) -> u32 {
+        match self {
+            Self::Legacy => 0,
+            Self::Device => 2,
+            Self::System => 3,
+        }
+    }
+}
+
+/// Packet-only controls for one diagnostic per-dispatch timestamp tape.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Gfx12DispatchTimestampConfig {
+    pub dst_scope: Gfx12CopyDataDstScope,
+    pub per_write_confirm: bool,
+    /// Append one confirmed bottom-of-pipe timestamp to `tail_fence_address`.
+    pub tail_release: bool,
+}
+
+impl Default for Gfx12DispatchTimestampConfig {
+    fn default() -> Self {
+        Self {
+            dst_scope: Gfx12CopyDataDstScope::Legacy,
+            per_write_confirm: true,
+            tail_release: false,
+        }
+    }
+}
+
 /// Retained GFX12 PM4 command words suitable for one PM4 indirect buffer.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct Gfx12Pm4CommandBuffer {
@@ -113,7 +152,7 @@ impl Gfx12Pm4CommandBuffer {
     /// timestamp form.
     pub fn with_gpu_timestamps(&self, start_address: u64, end_address: u64) -> Self {
         let mut timed = Self::new();
-        timed.copy_gpu_timestamp(start_address);
+        timed.copy_gpu_timestamp(start_address, Gfx12DispatchTimestampConfig::default());
         timed.dwords.extend_from_slice(&self.dwords);
         timed.release_gpu_timestamp(end_address);
         timed
@@ -134,10 +173,18 @@ impl Gfx12Pm4CommandBuffer {
     /// It answers a question end-to-end throughput cannot: whether a deficit is
     /// spread evenly across dispatches (per-dispatch overhead) or concentrated
     /// in a few (a barrier or cache-release stall).
-    pub fn with_per_dispatch_timestamps(&self, base_address: u64) -> Result<Self, Pm4BuildError> {
+    pub fn with_per_dispatch_timestamps(
+        &self,
+        base_address: u64,
+        config: Gfx12DispatchTimestampConfig,
+        tail_fence_address: Option<u64>,
+    ) -> Result<Self, Pm4BuildError> {
+        if config.tail_release != tail_fence_address.is_some() {
+            return Err(Pm4BuildError::InvalidTimestampConfiguration);
+        }
         let mut timed = Self::new();
         let mut slot = 0_u64;
-        timed.copy_gpu_timestamp(base_address);
+        timed.copy_gpu_timestamp(base_address, config);
         slot += 1;
 
         let mut cursor = 0_usize;
@@ -153,10 +200,13 @@ impl Gfx12Pm4CommandBuffer {
                 .ok_or(Pm4BuildError::MalformedStream { dword: cursor })?;
             timed.dwords.extend_from_slice(&self.dwords[cursor..next]);
             if (header >> 8) & 0xff == PACKET3_DISPATCH_DIRECT {
-                timed.copy_gpu_timestamp(base_address + slot * 8);
+                timed.copy_gpu_timestamp(base_address + slot * 8, config);
                 slot += 1;
             }
             cursor = next;
+        }
+        if let Some(address) = tail_fence_address {
+            timed.release_gpu_timestamp(address);
         }
         Ok(timed)
     }
@@ -222,11 +272,24 @@ impl Gfx12Pm4CommandBuffer {
         Ok(attributions)
     }
 
-    fn copy_gpu_timestamp(&mut self, address: u64) {
-        const COPY_DATA_TIMESTAMP_TO_MEMORY_64: u32 = 9 | (5 << 8) | (1 << 16) | (1 << 20);
+    fn copy_gpu_timestamp(&mut self, address: u64, config: Gfx12DispatchTimestampConfig) {
+        const GPU_CLOCK_COUNT: u32 = 9;
+        const TC_L2_OBSOLETE: u32 = 5 << 8;
+        const COUNT_64_BITS: u32 = 1 << 16;
+        const WR_CONFIRM: u32 = 1 << 20;
+        const DST_SCOPE_SHIFT: u32 = 27;
+        let control = GPU_CLOCK_COUNT
+            | TC_L2_OBSOLETE
+            | COUNT_64_BITS
+            | if config.per_write_confirm {
+                WR_CONFIRM
+            } else {
+                0
+            }
+            | (config.dst_scope.bits() << DST_SCOPE_SHIFT);
         self.dwords.extend_from_slice(&[
             packet3(PACKET3_COPY_DATA, 5, false),
-            COPY_DATA_TIMESTAMP_TO_MEMORY_64,
+            control,
             0,
             0,
             address as u32,
@@ -447,6 +510,7 @@ pub enum Pm4BuildError {
     MalformedStream {
         dword: usize,
     },
+    InvalidTimestampConfiguration,
 }
 
 /// Boundary commands attributed to one per-dispatch timestamp span.
@@ -487,6 +551,10 @@ impl fmt::Display for Pm4BuildError {
             Self::MalformedStream { dword } => {
                 write!(formatter, "malformed PM4 stream at dword {dword}")
             }
+            Self::InvalidTimestampConfiguration => write!(
+                formatter,
+                "timestamp tail-release setting and fence address disagree"
+            ),
         }
     }
 }
@@ -519,7 +587,9 @@ mod tests {
         for n in [1_usize, 3, 8] {
             let plain = synthetic_stream(n);
             assert_eq!(plain.timestamp_slot_count().unwrap(), n + 1);
-            let timed = plain.with_per_dispatch_timestamps(0x1000).unwrap();
+            let timed = plain
+                .with_per_dispatch_timestamps(0x1000, Gfx12DispatchTimestampConfig::default(), None)
+                .unwrap();
 
             // Every original dword survives, in order, as a subsequence.
             let mut it = timed.dwords().iter();
@@ -546,11 +616,83 @@ mod tests {
     }
 
     #[test]
+    fn gfx12_copy_data_scope_and_confirmation_bits_are_explicit() {
+        let plain = synthetic_stream(1);
+        let cases = [
+            (
+                Gfx12DispatchTimestampConfig::default(),
+                9 | (5 << 8) | (1 << 16) | (1 << 20),
+            ),
+            (
+                Gfx12DispatchTimestampConfig {
+                    dst_scope: Gfx12CopyDataDstScope::System,
+                    ..Gfx12DispatchTimestampConfig::default()
+                },
+                9 | (5 << 8) | (1 << 16) | (1 << 20) | (3 << 27),
+            ),
+            (
+                Gfx12DispatchTimestampConfig {
+                    dst_scope: Gfx12CopyDataDstScope::Device,
+                    ..Gfx12DispatchTimestampConfig::default()
+                },
+                9 | (5 << 8) | (1 << 16) | (1 << 20) | (2 << 27),
+            ),
+            (
+                Gfx12DispatchTimestampConfig {
+                    dst_scope: Gfx12CopyDataDstScope::System,
+                    per_write_confirm: false,
+                    tail_release: true,
+                },
+                9 | (5 << 8) | (1 << 16) | (3 << 27),
+            ),
+        ];
+        for (config, expected_control) in cases {
+            let fence = config.tail_release.then_some(0x2000);
+            let timed = plain
+                .with_per_dispatch_timestamps(0x1000, config, fence)
+                .unwrap();
+            assert_eq!(timed.dwords()[1], expected_control);
+            let release_count = timed
+                .dwords()
+                .iter()
+                .filter(|word| **word == packet3(PACKET3_RELEASE_MEM, 7, false))
+                .count();
+            assert_eq!(release_count, usize::from(config.tail_release));
+        }
+    }
+
+    #[test]
+    fn tail_release_requires_a_matching_fence_address() {
+        let plain = synthetic_stream(1);
+        let tail = Gfx12DispatchTimestampConfig {
+            dst_scope: Gfx12CopyDataDstScope::System,
+            per_write_confirm: false,
+            tail_release: true,
+        };
+        assert_eq!(
+            plain.with_per_dispatch_timestamps(0x1000, tail, None),
+            Err(Pm4BuildError::InvalidTimestampConfiguration)
+        );
+        assert_eq!(
+            plain.with_per_dispatch_timestamps(
+                0x1000,
+                Gfx12DispatchTimestampConfig::default(),
+                Some(0x2000),
+            ),
+            Err(Pm4BuildError::InvalidTimestampConfiguration)
+        );
+    }
+
+    #[test]
     fn per_dispatch_timestamps_reject_a_malformed_stream() {
         let mut bad = Gfx12Pm4CommandBuffer::new();
         bad.dwords.push(0x0000_0000); // not a PACKET3 header
         assert!(matches!(
-            bad.with_per_dispatch_timestamps(0x1000),
+            bad.with_per_dispatch_timestamps(
+                0x1000,
+                Gfx12DispatchTimestampConfig::default(),
+                None,
+            ),
             Err(Pm4BuildError::MalformedStream { dword: 0 })
         ));
         // A length running past the end must be rejected, not truncated.
@@ -558,7 +700,15 @@ mod tests {
         overrun
             .dwords
             .push(packet3(PACKET3_DISPATCH_DIRECT, 4, true));
-        assert!(overrun.with_per_dispatch_timestamps(0x1000).is_err());
+        assert!(
+            overrun
+                .with_per_dispatch_timestamps(
+                    0x1000,
+                    Gfx12DispatchTimestampConfig::default(),
+                    None,
+                )
+                .is_err()
+        );
     }
     use super::*;
 
@@ -614,7 +764,9 @@ mod tests {
         // each subsequent stamp immediately after its DISPATCH_DIRECT so span 0
         // covers entry acquire → dispatch 0, span 1 covers wait+acquire →
         // dispatch 1, etc.
-        let timed = plain.with_per_dispatch_timestamps(0x2000).unwrap();
+        let timed = plain
+            .with_per_dispatch_timestamps(0x2000, Gfx12DispatchTimestampConfig::default(), None)
+            .unwrap();
         let copies: Vec<usize> = timed
             .dwords()
             .iter()

--- a/crates/redline-rocr/src/runtime.rs
+++ b/crates/redline-rocr/src/runtime.rs
@@ -1424,6 +1424,7 @@ struct KernargPoolInner {
     runtime: Arc<RuntimeInner>,
     pool: abi::MemoryPool,
     gpu: abi::Agent,
+    access_agent: abi::Agent,
     granule: usize,
     alignment: usize,
 }
@@ -1544,12 +1545,104 @@ impl KernargPool {
                     runtime: device.runtime.clone(),
                     pool,
                     gpu: device.gpu_agent(),
+                    access_agent: device.gpu_agent(),
                     granule,
                     alignment,
                 }),
             });
         }
         Err(RuntimeError::NoKernargPool)
+    }
+
+    /// Allocate a CPU-readable diagnostic buffer from the GPU agent's
+    /// coarse-grained device-local pool.
+    ///
+    /// This is intentionally separate from the retained IB/kernarg pool. It is
+    /// used only to distinguish confirmed host writes from CP packet cost in
+    /// the per-dispatch timestamp diagnostic.
+    pub fn allocate_device_local_bytes(
+        device: &GpuDevice,
+        length: usize,
+    ) -> Result<KernargBuffer, RuntimeError> {
+        let cpu = device.cpu.as_ref().ok_or(RuntimeError::NoCpuAgent)?;
+        unsafe extern "C" fn collect(pool: abi::MemoryPool, data: *mut c_void) -> abi::Status {
+            // SAFETY: context is a live vector for synchronous iteration.
+            unsafe { &mut *data.cast::<Vec<abi::MemoryPool>>() }.push(pool);
+            abi::STATUS_SUCCESS
+        }
+        let mut pools = Vec::new();
+        // SAFETY: callback and context satisfy the synchronous iteration contract.
+        let status = unsafe {
+            (device.runtime.symbols.agent_iterate_memory_pools)(
+                device.gpu_agent(),
+                Some(collect),
+                (&mut pools as *mut Vec<abi::MemoryPool>).cast(),
+            )
+        };
+        check_status(
+            &device.runtime.symbols,
+            "hsa_amd_agent_iterate_memory_pools",
+            status,
+        )?;
+
+        for pool in pools {
+            let mut segment = 0_u32;
+            let mut flags = 0_u32;
+            let mut allowed = false;
+            query_pool(
+                &device.runtime.symbols,
+                pool,
+                abi::AMD_MEMORY_POOL_INFO_SEGMENT,
+                (&mut segment as *mut u32).cast(),
+            )?;
+            query_pool(
+                &device.runtime.symbols,
+                pool,
+                abi::AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS,
+                (&mut flags as *mut u32).cast(),
+            )?;
+            query_pool(
+                &device.runtime.symbols,
+                pool,
+                abi::AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALLOWED,
+                (&mut allowed as *mut bool).cast(),
+            )?;
+            if segment != abi::AMD_SEGMENT_GLOBAL
+                || !allowed
+                || flags & abi::AMD_MEMORY_POOL_GLOBAL_FLAG_COARSE_GRAINED == 0
+            {
+                continue;
+            }
+            let mut granule = 0_usize;
+            let mut alignment = 0_usize;
+            query_pool(
+                &device.runtime.symbols,
+                pool,
+                abi::AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_GRANULE,
+                (&mut granule as *mut usize).cast(),
+            )?;
+            query_pool(
+                &device.runtime.symbols,
+                pool,
+                abi::AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_ALIGNMENT,
+                (&mut alignment as *mut usize).cast(),
+            )?;
+            if granule == 0 || !alignment.is_power_of_two() {
+                continue;
+            }
+            let diagnostic_pool = Self {
+                inner: Arc::new(KernargPoolInner {
+                    runtime: device.runtime.clone(),
+                    pool,
+                    gpu: device.gpu_agent(),
+                    access_agent: cpu.handle,
+                    granule,
+                    alignment,
+                }),
+            };
+            return diagnostic_pool.allocate_bytes(length, 16, abi::AMD_MEMORY_POOL_STANDARD_FLAG);
+        }
+        Err(RuntimeError::NoDeviceLocalPool)
     }
 
     pub fn allocate_for(&self, metadata: KernelMetadata) -> Result<KernargBuffer, RuntimeError> {
@@ -1639,7 +1732,7 @@ impl KernargPool {
         let status = unsafe {
             (self.inner.runtime.symbols.agents_allow_access)(
                 1,
-                &self.inner.gpu,
+                &self.inner.access_agent,
                 ptr::null(),
                 pointer.as_ptr().cast(),
             )
@@ -2243,6 +2336,7 @@ pub enum RuntimeError {
     InvalidCuMask(&'static str),
     InvalidRuntimeObject(&'static str),
     NoKernargPool,
+    NoDeviceLocalPool,
     InvalidKernargAlignment(usize),
     KernargAlignmentNotMet {
         required: usize,
@@ -2339,6 +2433,12 @@ impl fmt::Display for RuntimeError {
                 f,
                 "no allocatable fine-grained host pool with KERNARG_INIT was found"
             ),
+            Self::NoDeviceLocalPool => {
+                write!(
+                    f,
+                    "no CPU-readable device-local coarse-grained pool was found"
+                )
+            }
             Self::InvalidKernargAlignment(alignment) => {
                 write!(f, "kernel reported invalid kernarg alignment {alignment}")
             }

--- a/docs/REDLINE.md
+++ b/docs/REDLINE.md
@@ -429,6 +429,15 @@ Reasons it cannot prove those claims:
 Use product bench / Golden for certification evidence. Use this profiler only
 to attribute relative stall shape across dispatches under the instrumented tape.
 
+For confirmed-write diagnostics, `--matrix` alternates the original
+host-fine-grained/legacy-scope arm with explicit system-scope host writes and
+device-local/device-scope writes. `--include-no-confirm` additionally tests
+unconfirmed per-dispatch host writes followed by one confirmed system-scope
+tail release. Every arm fails closed unless timestamp sentinels are overwritten
+and complete and monotonic, and the default run checks the instrumented shadow
+bit-exactly. The JSON keeps every run and reports time grouped by whether its
+span contains a `wait_compute_idle` boundary.
+
 
 ## 6. PM4 lowering and hazard policy
 

--- a/kernels/src/redline_packet_isolation_spin.hip
+++ b/kernels/src/redline_packet_isolation_spin.hip
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+#include <stdint.h>
+
+// Diagnostic-only independent work. Each retained dispatch receives a
+// different output address, so removing CS_PARTIAL_FLUSH does not introduce
+// cross-dispatch data dependencies.
+extern "C" __global__ void redline_packet_isolation_spin(
+    uint64_t* output,
+    uint32_t iterations
+) {
+    uint64_t value = (uint64_t)threadIdx.x + 0x9e3779b97f4a7c15ULL;
+#pragma unroll 1
+    for (uint32_t i = 0; i < iterations; ++i) {
+        value ^= value >> 12;
+        value ^= value << 25;
+        value ^= value >> 27;
+        value *= 0x2545f4914f6cdd1dULL;
+    }
+    if (threadIdx.x == 0) {
+        output[0] = value;
+    }
+}

--- a/scripts/redline_dispatch_profile.py
+++ b/scripts/redline_dispatch_profile.py
@@ -21,6 +21,12 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 SCHEMA_VERSION = 1
+ARMS = (
+    "host-legacy-confirm",
+    "host-system-confirm",
+    "device-confirm",
+    "host-system-tail-confirm",
+)
 
 
 class Daemon:
@@ -100,6 +106,14 @@ def validate_profile(profile):
         raise ValueError("unsupported RPC schema version")
     if not profile.get("steady_state") or not profile.get("exactly_once_per_sample"):
         raise ValueError("RPC did not guarantee steady-state exactly-once samples")
+    if profile.get("arm") not in ARMS:
+        raise ValueError("RPC returned an unknown diagnostic arm")
+    timestamp_validation = profile.get("timestamp_validation")
+    if not isinstance(timestamp_validation, dict) or not all(
+        timestamp_validation.get(key)
+        for key in ("sentinels_overwritten", "monotonic", "complete")
+    ):
+        raise ValueError("RPC did not prove timestamp completeness and monotonicity")
 
     dispatches = profile.get("dispatches")
     samples = profile.get("samples")
@@ -174,6 +188,25 @@ def analyze(profile):
 
     medians = [row["median_ns"] for row in dispatches]
     tail_count = max(1, math.ceil(len(medians) * 0.05))
+    boundary_groups = {}
+    for name, has_wait in (
+        ("wait_compute_idle", True),
+        ("no_wait_compute_idle", False),
+    ):
+        rows = [
+            row
+            for row in dispatches
+            if row["boundary"]["wait_compute_idle"] is has_wait
+        ]
+        total = sum(row["median_ns"] for row in rows)
+        boundary_groups[name] = {
+            "count": len(rows),
+            "total_median_ns": total,
+            "share_pct": 100.0 * total / dispatch_total,
+            "span_median_ns": statistics.median(
+                [row["median_ns"] for row in rows]
+            ),
+        }
     return {
         "dispatches": dispatches,
         "kernels": kernels,
@@ -188,6 +221,7 @@ def analyze(profile):
             "slowest_5pct_share_pct": (
                 100.0 * sum(sorted(medians)[-tail_count:]) / dispatch_total
             ),
+            "boundary_groups": boundary_groups,
         },
     }
 
@@ -205,10 +239,17 @@ def print_summary(report, top):
     summary = report["summary"]
     gpu = summary["gpu_total"]
     print(
-        f"route={route['sequence_hash']} launches={route['launches']} "
+        f"arm={report['arm']} route={route['sequence_hash']} launches={route['launches']} "
         f"samples={report['request']['sample_replays']} "
         f"gpu_median={gpu['median_ns'] / 1_000:.3f}us "
         f"slowest5%={summary['slowest_5pct_share_pct']:.1f}%"
+    )
+    waits = summary["boundary_groups"]["wait_compute_idle"]
+    no_waits = summary["boundary_groups"]["no_wait_compute_idle"]
+    print(
+        f"boundary totals: wait={waits['total_median_ns'] / 1_000:.3f}us/"
+        f"{waits['count']} no-wait={no_waits['total_median_ns'] / 1_000:.3f}us/"
+        f"{no_waits['count']}"
     )
     correctness = report["correctness"]
     if correctness.get("performed"):
@@ -230,6 +271,33 @@ def print_summary(report, top):
             f"{row['p90_ns'] / 1_000:7.3f}  "
             f"{row['share_pct']:6.2f}  {flags:8s}  {row['kernel']}"
         )
+
+
+def build_report(profile, model_info, args, run_index=None):
+    analysis = analyze(profile)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "type": "hipfire_redline_dispatch_profile_report",
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "arm": profile["arm"],
+        "model": model_info,
+        "request": {
+            "context_tokens": args.context,
+            "warmup_replays": args.warmup_replays,
+            "sample_replays": args.sample_replays,
+            "max_seq": args.max_seq,
+            "kv_mode": args.kv_mode,
+        },
+        "route": profile["route"],
+        "timestamp_validation": profile["timestamp_validation"],
+        "timestamp_semantics": profile["timestamp_semantics"],
+        "correctness": profile["correctness"],
+        "samples": profile["samples"],
+        **analysis,
+    }
+    if run_index is not None:
+        report["run_index"] = run_index
+    return report
 
 
 def main():
@@ -254,6 +322,17 @@ def main():
     parser.add_argument("--timeout", type=float, default=300.0)
     parser.add_argument("--top", type=int, default=25)
     parser.add_argument("--skip-correctness", action="store_true")
+    parser.add_argument("--arm", choices=ARMS, default=ARMS[0])
+    parser.add_argument(
+        "--matrix",
+        action="store_true",
+        help="alternate baseline with host-system and device-local arms",
+    )
+    parser.add_argument(
+        "--include-no-confirm",
+        action="store_true",
+        help="append the higher-risk no-per-write-confirm arm to --matrix",
+    )
     args = parser.parse_args()
     if args.context <= 0 or args.warmup_replays < 0 or args.sample_replays <= 0:
         parser.error("invalid context/warmup/sample count")
@@ -265,6 +344,25 @@ def main():
     if not model.is_file() or not daemon_path.is_file():
         parser.error("model and daemon must exist")
 
+    arm_order = [args.arm]
+    if args.matrix:
+        arm_order = [
+            "host-legacy-confirm",
+            "host-system-confirm",
+            "host-legacy-confirm",
+            "device-confirm",
+            "host-legacy-confirm",
+        ]
+        if args.include_no_confirm:
+            arm_order.extend(
+                ["host-system-tail-confirm", "host-legacy-confirm"]
+            )
+
+    model_info = {
+        "path": str(model),
+        "bytes": model.stat().st_size,
+        "sha256": sha256_file(model),
+    }
     daemon = Daemon(daemon_path, log_path, args.timeout, args.kv_mode)
     try:
         daemon.request(
@@ -287,48 +385,49 @@ def main():
                 "redline_detail": True,
             }
         )["redline_capture"]
-        profile = daemon.request(
-            {
-                "type": "redline_dispatch_profile",
-                "context_tokens": args.context,
-                "warmup_replays": args.warmup_replays,
-                "sample_replays": args.sample_replays,
-                "validate_correctness": not args.skip_correctness,
-            }
-        )
+        profiles = []
+        for arm in arm_order:
+            profile = daemon.request(
+                {
+                    "type": "redline_dispatch_profile",
+                    "context_tokens": args.context,
+                    "warmup_replays": args.warmup_replays,
+                    "sample_replays": args.sample_replays,
+                    "validate_correctness": not args.skip_correctness,
+                    "arm": arm,
+                }
+            )
+            validate_capture(capture, profile)
+            profiles.append(profile)
     finally:
         daemon.close()
 
-    validate_capture(capture, profile)
-    analysis = analyze(profile)
-    report = {
-        "schema_version": SCHEMA_VERSION,
-        "type": "hipfire_redline_dispatch_profile_report",
-        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
-        "model": {
-            "path": str(model),
-            "bytes": model.stat().st_size,
-            "sha256": sha256_file(model),
-        },
-        "request": {
-            "context_tokens": args.context,
-            "warmup_replays": args.warmup_replays,
-            "sample_replays": args.sample_replays,
-            "max_seq": args.max_seq,
-            "kv_mode": args.kv_mode,
-        },
-        "route": profile["route"],
-        "timestamp_semantics": profile["timestamp_semantics"],
-        "correctness": profile["correctness"],
-        "samples": profile["samples"],
-        **analysis,
-    }
+    reports = [
+        build_report(profile, model_info, args, index)
+        for index, profile in enumerate(profiles)
+    ]
+    if args.matrix:
+        report = {
+            "schema_version": SCHEMA_VERSION,
+            "type": "hipfire_redline_dispatch_profile_matrix_report",
+            "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "model": model_info,
+            "request": reports[0]["request"],
+            "arm_order": arm_order,
+            "runs": reports,
+        }
+    else:
+        report = reports[0]
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(json.dumps(report, indent=2) + "\n")
-    print_summary(report, args.top)
+    for arm_report in reports:
+        print_summary(arm_report, args.top)
     print(f"report={output}")
     print(f"daemon_log={log_path}")
-    if report["correctness"].get("bit_exact") is False:
+    if any(
+        arm_report["correctness"].get("bit_exact") is False
+        for arm_report in reports
+    ):
         print("FAIL: instrumented PM4 shadow is not bit-exact", file=sys.stderr)
         return 1
     return 0

--- a/scripts/redline_packet_isolation.py
+++ b/scripts/redline_packet_isolation.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kaden Schutt
+# hipfire — see LICENSE and NOTICE in the project root.
+
+"""Run and analyze the GFX12 COPY_DATA × CS_PARTIAL_FLUSH microbenchmark."""
+
+import argparse
+import datetime
+import hashlib
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+SCHEMA_VERSION = 1
+ARMS = ("T00", "T10", "T01", "T11")
+
+
+def percentile(values, fraction):
+    ordered = sorted(values)
+    position = fraction * (len(ordered) - 1)
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * (position - lower)
+
+
+def statistics_for(values):
+    mean = statistics.fmean(values)
+    return {
+        "min_ns": min(values),
+        "median_ns": statistics.median(values),
+        "p90_ns": percentile(values, 0.90),
+        "max_ns": max(values),
+        "cv": statistics.pstdev(values) / abs(mean) if len(values) > 1 and mean else 0.0,
+    }
+
+
+def parse_runner_output(text):
+    metadata = None
+    samples = []
+    for line in text.splitlines():
+        fields = line.split("\t")
+        if fields[0] == "META":
+            if len(fields) < 3 or len(fields[1:]) % 2:
+                raise ValueError("malformed META line")
+            metadata = dict(zip(fields[1::2], fields[2::2]))
+        elif fields[0] == "SAMPLE":
+            if len(fields) != 10:
+                raise ValueError("malformed SAMPLE line")
+            samples.append(
+                {
+                    "cycle": int(fields[1]),
+                    "position": int(fields[2]),
+                    "arm": fields[3],
+                    "copy_data": bool(int(fields[4])),
+                    "wait_compute_idle": bool(int(fields[5])),
+                    "gpu_ns": int(fields[6]),
+                    "host_ns": int(fields[7]),
+                    "timestamps_complete": bool(int(fields[8])),
+                    "timestamps_monotonic": bool(int(fields[9])),
+                }
+            )
+    if metadata is None:
+        raise ValueError("runner emitted no META line")
+    return metadata, samples
+
+
+def validate_samples(samples):
+    if not samples:
+        raise ValueError("runner emitted no samples")
+    cycles = sorted({sample["cycle"] for sample in samples})
+    if cycles != list(range(len(cycles))):
+        raise ValueError("cycle indices are not contiguous")
+    positions = {arm: [] for arm in ARMS}
+    for cycle in cycles:
+        rows = [sample for sample in samples if sample["cycle"] == cycle]
+        if len(rows) != len(ARMS) or {row["arm"] for row in rows} != set(ARMS):
+            raise ValueError(f"cycle {cycle} does not contain exactly one of every arm")
+        if sorted(row["position"] for row in rows) != list(range(len(ARMS))):
+            raise ValueError(f"cycle {cycle} positions are not contiguous")
+        for row in rows:
+            if not row["timestamps_complete"] or not row["timestamps_monotonic"]:
+                raise ValueError(f"{row['arm']} failed timestamp validation")
+            positions[row["arm"]].append(row["position"])
+    for arm, arm_positions in positions.items():
+        counts = [arm_positions.count(position) for position in range(len(ARMS))]
+        if max(counts) - min(counts) > 1:
+            raise ValueError(f"{arm} is not position-balanced")
+
+
+def paired_effects(samples):
+    validate_samples(samples)
+    cycles = sorted({sample["cycle"] for sample in samples})
+    effects = {
+        "flush_without_copy": [],
+        "flush_with_copy": [],
+        "copy_without_flush": [],
+        "copy_with_flush": [],
+        "interaction": [],
+    }
+    for cycle in cycles:
+        values = {
+            row["arm"]: row["gpu_ns"]
+            for row in samples
+            if row["cycle"] == cycle
+        }
+        effects["flush_without_copy"].append(values["T10"] - values["T00"])
+        effects["flush_with_copy"].append(values["T11"] - values["T01"])
+        effects["copy_without_flush"].append(values["T01"] - values["T00"])
+        effects["copy_with_flush"].append(values["T11"] - values["T10"])
+        effects["interaction"].append(
+            values["T11"] - values["T10"] - values["T01"] + values["T00"]
+        )
+    return effects
+
+
+def analyze(metadata, samples):
+    validate_samples(samples)
+    replays_per_sample = int(metadata["replays_per_sample"])
+    arms = {}
+    for arm in ARMS:
+        rows = [sample for sample in samples if sample["arm"] == arm]
+        arms[arm] = {
+            "copy_data": rows[0]["copy_data"],
+            "wait_compute_idle": rows[0]["wait_compute_idle"],
+            "gpu_total": statistics_for([row["gpu_ns"] for row in rows]),
+            "host_total": statistics_for([row["host_ns"] for row in rows]),
+        }
+    effects = {}
+    for name, values in paired_effects(samples).items():
+        effects[name] = {
+            **statistics_for(values),
+            "per_boundary_median_ns": statistics.median(values) / replays_per_sample,
+            "paired_cycle_values_ns": values,
+        }
+    return {"arms": arms, "effects": effects}
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def command_output(command):
+    return subprocess.run(
+        command,
+        cwd=REPO,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    ).stdout.strip()
+
+
+def resolve_hipcc():
+    rocm_path = os.environ.get("ROCM_PATH")
+    if rocm_path:
+        candidate = Path(rocm_path) / "bin" / "hipcc"
+        if candidate.is_file():
+            return candidate
+    found = shutil.which("hipcc")
+    if found:
+        return Path(found)
+    raise RuntimeError("hipcc not found; set ROCM_PATH or add hipcc to PATH")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="GFX12 packet-isolated COPY_DATA x CS_PARTIAL_FLUSH diagnostic"
+    )
+    parser.add_argument("--arch", default="gfx1201")
+    parser.add_argument("--gpu", type=int, default=0)
+    parser.add_argument("--replays-per-sample", type=int, default=307)
+    parser.add_argument("--spin-iterations", type=int, default=256)
+    parser.add_argument("--warmups", type=int, default=10)
+    parser.add_argument("--cycles", type=int, default=40)
+    parser.add_argument(
+        "--out", default=str(REPO / ".redline-work/packet-isolation-2x2.json")
+    )
+    parser.add_argument(
+        "--log", default=str(REPO / ".redline-work/packet-isolation-2x2.log")
+    )
+    parser.add_argument(
+        "--work-dir", default=str(REPO / ".redline-work/packet-isolation-build")
+    )
+    parser.add_argument("--skip-build", action="store_true")
+    args = parser.parse_args()
+    if (
+        args.replays_per_sample <= 0
+        or args.spin_iterations <= 0
+        or args.warmups < 0
+        or args.cycles < 4
+    ):
+        parser.error("replays-per-sample/spin-iterations must be positive, cycles >= 4")
+
+    output = Path(args.out).expanduser().resolve()
+    log_path = Path(args.log).expanduser().resolve()
+    work_dir = Path(args.work_dir).expanduser().resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    work_dir.mkdir(parents=True, exist_ok=True)
+    source = REPO / "kernels/src/redline_packet_isolation_spin.hip"
+    hsaco = work_dir / f"redline_packet_isolation_spin_{args.arch}.hsaco"
+    binary = REPO / "target/release/examples/packet_isolation_2x2"
+    hipcc = resolve_hipcc()
+
+    if not args.skip_build:
+        subprocess.run(
+            [
+                str(hipcc),
+                "--genco",
+                "-O3",
+                f"--offload-arch={args.arch}",
+                str(source),
+                "-o",
+                str(hsaco),
+            ],
+            cwd=REPO,
+            check=True,
+        )
+        subprocess.run(
+            [
+                "cargo",
+                "build",
+                "--release",
+                "--locked",
+                "-p",
+                "redline-dispatch",
+                "--example",
+                "packet_isolation_2x2",
+            ],
+            cwd=REPO,
+            check=True,
+        )
+    if not hsaco.is_file() or not binary.is_file():
+        parser.error("--skip-build requires existing HSACO and runner binary")
+
+    command = [
+        str(binary),
+        "--hsaco",
+        str(hsaco),
+        "--gpu",
+        str(args.gpu),
+        "--replays-per-sample",
+        str(args.replays_per_sample),
+        "--spin-iterations",
+        str(args.spin_iterations),
+        "--warmups",
+        str(args.warmups),
+        "--cycles",
+        str(args.cycles),
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=REPO,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    log_path.write_text(completed.stderr)
+    if completed.returncode:
+        sys.stderr.write(completed.stderr)
+        return completed.returncode
+    metadata, samples = parse_runner_output(completed.stdout)
+    analysis = analyze(metadata, samples)
+    report = {
+        "schema_version": SCHEMA_VERSION,
+        "type": "hipfire_redline_packet_isolation_2x2",
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "design": {
+            "factors": ["copy_data_gpu_clock", "cs_partial_flush"],
+            "arms": {
+                "T00": {"copy_data_gpu_clock": False, "cs_partial_flush": False},
+                "T10": {"copy_data_gpu_clock": False, "cs_partial_flush": True},
+                "T01": {"copy_data_gpu_clock": True, "cs_partial_flush": False},
+                "T11": {"copy_data_gpu_clock": True, "cs_partial_flush": True},
+            },
+            "equal_dword_nop_padding": True,
+            "gpu_window_brackets_factor_cell_only": True,
+            "common_tail_compute_idle_outside_window": True,
+            "cycle_position_balanced": True,
+            "independent_dispatch_outputs": True,
+        },
+        "request": {
+            "arch": args.arch,
+            "gpu": args.gpu,
+            "replays_per_sample": args.replays_per_sample,
+            "spin_iterations": args.spin_iterations,
+            "warmups": args.warmups,
+            "cycles": args.cycles,
+        },
+        "runner_metadata": metadata,
+        "build": {
+            "git_head": command_output(["git", "rev-parse", "HEAD"]),
+            "cargo": command_output(["cargo", "--version"]),
+            "rustc": command_output(["rustc", "--version", "--verbose"]),
+            "hipcc": command_output([str(hipcc), "--version"]),
+            "kernel_sha256": sha256_file(hsaco),
+            "runner_sha256": sha256_file(binary),
+        },
+        "timestamp_validation": {
+            "all_complete": all(row["timestamps_complete"] for row in samples),
+            "all_monotonic": all(row["timestamps_monotonic"] for row in samples),
+        },
+        "samples": samples,
+        **analysis,
+    }
+    output.write_text(json.dumps(report, indent=2) + "\n")
+
+    print("arm  copy  flush  gpu_median_us  p90_us  cv")
+    for arm in ARMS:
+        row = report["arms"][arm]
+        gpu = row["gpu_total"]
+        print(
+            f"{arm:3s}  {int(row['copy_data']):4d}  "
+            f"{int(row['wait_compute_idle']):5d}  "
+            f"{gpu['median_ns'] / 1_000:13.3f}  "
+            f"{gpu['p90_ns'] / 1_000:7.3f}  {gpu['cv']:.4f}"
+        )
+    print("effect                   median_us  ns/boundary")
+    for name in (
+        "flush_without_copy",
+        "flush_with_copy",
+        "copy_without_flush",
+        "copy_with_flush",
+        "interaction",
+    ):
+        row = report["effects"][name]
+        print(
+            f"{name:24s} {row['median_ns'] / 1_000:9.3f}  "
+            f"{row['per_boundary_median_ns']:11.3f}"
+        )
+    print(f"report={output}")
+    print(f"runner_log={log_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_redline_packet_isolation.py
+++ b/tests/test_redline_packet_isolation.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kaden Schutt
+# hipfire — see LICENSE and NOTICE in the project root.
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts/redline_packet_isolation.py"
+SPEC = importlib.util.spec_from_file_location("redline_packet_isolation", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def synthetic_output(cycles=4):
+    orders = (
+        ("T00", "T10", "T11", "T01"),
+        ("T10", "T01", "T00", "T11"),
+        ("T01", "T11", "T10", "T00"),
+        ("T11", "T00", "T01", "T10"),
+    )
+    values = {"T00": 1000, "T10": 1300, "T01": 1200, "T11": 1700}
+    flags = {
+        "T00": (0, 0),
+        "T10": (0, 1),
+        "T01": (1, 0),
+        "T11": (1, 1),
+    }
+    lines = [
+        "META\tdevice\tgfx1201\tgpu\t0\treplays_per_sample\t10\t"
+        "spin_iterations\t256\twarmups\t1\tcycles\t4\tcommand_dwords\t99"
+    ]
+    for cycle in range(cycles):
+        for position, arm in enumerate(orders[cycle % len(orders)]):
+            copy_data, wait = flags[arm]
+            lines.append(
+                f"SAMPLE\t{cycle}\t{position}\t{arm}\t{copy_data}\t{wait}\t"
+                f"{values[arm]}\t{values[arm] + 10}\t1\t1"
+            )
+    return "\n".join(lines)
+
+
+def test_parser_and_factorial_effects_are_paired_by_cycle():
+    metadata, samples = MODULE.parse_runner_output(synthetic_output())
+    analysis = MODULE.analyze(metadata, samples)
+    assert analysis["effects"]["flush_without_copy"]["median_ns"] == 300
+    assert analysis["effects"]["copy_without_flush"]["median_ns"] == 200
+    assert analysis["effects"]["interaction"]["median_ns"] == 200
+    assert analysis["effects"]["interaction"]["per_boundary_median_ns"] == 20
+    assert MODULE.statistics_for([-3, -2, -1])["cv"] >= 0
+
+
+def test_validation_rejects_incomplete_timestamp_writes():
+    metadata, samples = MODULE.parse_runner_output(synthetic_output())
+    samples[0]["timestamps_complete"] = False
+    try:
+        MODULE.analyze(metadata, samples)
+    except ValueError as error:
+        assert "timestamp validation" in str(error)
+    else:
+        raise AssertionError("incomplete timestamp set was accepted")

--- a/tools/redline/tests/test_dispatch_profile.py
+++ b/tools/redline/tests/test_dispatch_profile.py
@@ -43,8 +43,18 @@ def synthetic_profile():
         "context_tokens": 128,
         "warmup_replays": 10,
         "sample_replays": len(spans),
+        "arm": "host-legacy-confirm",
         "steady_state": True,
         "exactly_once_per_sample": True,
+        "timestamp_validation": {
+            "memory": "host-fine-grained",
+            "dst_scope": "legacy-cu",
+            "per_write_confirm": True,
+            "tail_release": False,
+            "sentinels_overwritten": True,
+            "monotonic": True,
+            "complete": True,
+        },
         "timestamp_semantics": "baseline before stream plus post-dispatch stamps; span i is PM4 after timestamp i through dispatch i",
         "route": {
             "launches": len(dispatches),
@@ -90,6 +100,18 @@ class ProfileTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "total"):
             profile_tool.validate_profile(profile)
 
+    def test_rejects_unknown_arm_or_incomplete_timestamps(self):
+        profile = synthetic_profile()
+        profile["arm"] = "unknown"
+        with self.assertRaisesRegex(ValueError, "unknown diagnostic arm"):
+            profile_tool.validate_profile(profile)
+
+        for field in ("sentinels_overwritten", "monotonic", "complete"):
+            profile = synthetic_profile()
+            profile["timestamp_validation"][field] = False
+            with self.assertRaisesRegex(ValueError, "timestamp completeness"):
+                profile_tool.validate_profile(profile)
+
     def test_capture_must_match_profile_route(self):
         profile = synthetic_profile()
         capture = {
@@ -117,6 +139,11 @@ class ProfileTests(unittest.TestCase):
         gemv = [row for row in analysis["kernels"] if row["kernel"] == "gemv"]
         self.assertEqual(gemv[0]["dispatch_indices"], [1, 2])
         self.assertEqual(gemv[0]["total_median_ns"], 3_000)
+        groups = analysis["summary"]["boundary_groups"]
+        self.assertEqual(groups["wait_compute_idle"]["count"], 1)
+        self.assertEqual(groups["wait_compute_idle"]["total_median_ns"], 400)
+        self.assertEqual(groups["no_wait_compute_idle"]["count"], 3)
+        self.assertEqual(groups["no_wait_compute_idle"]["total_median_ns"], 3_100)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extend the merged steady-state dispatch profiler with an alternating diagnostic matrix that isolates GFX12 `COPY_DATA` destination scope, timestamp memory placement, and per-write `WR_CONFIRM` cost. All arms remain manual diagnostics and fail closed on incomplete/non-monotonic timestamps or shadow mismatch.

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [x] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [x] `crates/hipfire-runtime` (diagnostic daemon RPC only)
- [ ] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy`
- [ ] `crates/hipfire-quantize`
- [x] examples / daemon
- [x] docs / CI / scripts

## Diagnostic arms

- `host-legacy-confirm`: existing host fine-grained destination, legacy zero destination scope, per-write confirmation.
- `host-system-confirm`: same allocation and packets, explicit GFX12 system destination scope.
- `device-confirm`: device-local timestamp allocation, device destination scope, per-write confirmation.
- `host-system-tail-confirm`: host/system writes without per-write confirmation, followed by one confirmed system-scope tail release.

`--matrix --include-no-confirm` runs `A/B/A/C/A/D/A` in one resident daemon. Each arm re-prepares its tape, warms it, executes each measured replay exactly once, checks every sentinel, checks monotonicity/completeness, and performs instrumented shadow bit-exact validation. JSON also groups span medians by `wait_compute_idle`.

## X570 / Radeon AI PRO R9700 (gfx1201)

Latest `beta` base `f3cbf4db`, ROCm/HIP 7.14, `perf_level=auto`, Qwen3.5 0.8B MQ4:

| arm | GPU median | bracketed delta |
|---|---:|---:|
| host legacy confirm (A) | 1787.940 / 1788.040 / 1794.680 / 1793.600 us | A drift |
| host system confirm (B) | 1792.000 us | +0.224% vs adjacent A midpoint |
| device confirm (C) | 1796.700 us | +0.298% vs adjacent A midpoint |
| host system tail confirm (D) | 1792.160 us | -0.110% vs adjacent A midpoint |

All seven runs: route `338/20/f3fb9f6309726bb9`, `bit_exact=true`, timestamp sentinels overwritten, complete, and monotonic. The healthy reference therefore shows no material total-time benefit from any arm; the affected machine is needed for the causal split.

## Test plan

- [ ] `./scripts/no-gpu-ci.sh` — all Rust checks, 371 pytest cases, and 156/157 Redline unittest cases pass; the remaining current-`beta` test is an unrelated base failure: `test_spawn_serve_strips_harness_pid_file_from_child_env` treats the successful first log offset `0` as false.
- [x] `cargo build --release --workspace --features deltanet`
- [x] `cargo test --lib --workspace --features deltanet`
- [x] X570 gfx1201 `A/B/A/C/A/D/A`, 20 steady exactly-once samples per arm, all shadow/timestamp safety checks pass
- [ ] `./scripts/coherence-gate.sh` — not run; no product/default tape changes, and the diagnostic RPC performs bit-exact shadow validation for every arm
- [ ] spec-decode gate — not applicable
- [ ] speed gate — not applicable to an explicitly instrumented attribution-only tape

## Architecture-trait change?

No.
