### PR TITLE
perf(gfx12): reuse Q8 KV across four prefill queries, ~1.7x prefill

### DIFF
--- a/crates/hipfire-dispatch/src/families/attention.rs
+++ b/crates/hipfire-dispatch/src/families/attention.rs
@@ -1238,7 +1238,18 @@ fn dispatch_attend(
             // gives ~16K tokens for head_dim=128. Use 8K threshold for margin.
             KernelKey::AttnQ8_0KvBatchedMasked => {
                 const Q8_BATCHED_LDS_CROSSOVER: usize = 8192;
-                if io.max_ctx_len <= Q8_BATCHED_LDS_CROSSOVER {
+                let use_m4 = io.flash_partials.is_some_and(|partials| {
+                    rdna_compute::attention::q8_prefill_m4_eligible(
+                        &gpu.arch,
+                        io.n_heads,
+                        io.head_dim,
+                        io.max_ctx_len,
+                        io.batch_size,
+                        partials.numel(),
+                        io.tree_bias.is_some(),
+                    )
+                });
+                if io.max_ctx_len <= Q8_BATCHED_LDS_CROSSOVER && !use_m4 {
                     // Fast path: single-launch batched kernel, LDS-backed attention tile.
                     let positions = io.positions.unwrap();
                     hip!(gpu.attention_q8_0_kv_batched_masked(

--- a/crates/rdna-compute/src/attention.rs
+++ b/crates/rdna-compute/src/attention.rs
@@ -4,10 +4,10 @@
 
 //! Attention, KV cache, DFlash, pflash, triattn, kv_compact, and vision attention dispatch.
 
+use crate::kernels;
 use crate::DType;
 use crate::Gpu;
 use crate::GpuTensor;
-use crate::kernels;
 use hip_bridge::{DeviceBuffer, HipResult};
 use std::ffi::c_void;
 use std::sync::OnceLock;
@@ -61,9 +61,7 @@ pub fn q8_flash_tile_size(
                 .and_then(|value| value.parse::<usize>().ok())
                 .filter(|value| matches!(value, 16 | 32 | 64 | 128 | 256))
         })
-        .unwrap_or_else(|| {
-            q8_flash_default_tile_size(arch, n_heads, n_kv_heads, head_dim, max_seq)
-        })
+        .unwrap_or_else(|| q8_flash_default_tile_size(arch, n_heads, n_kv_heads, head_dim, max_seq))
 }
 
 const V_MODE_Q8: i32 = 8;
@@ -86,7 +84,9 @@ fn replay_stable_tile_count(
 fn is_wmma_fa_enabled() -> bool {
     use std::sync::OnceLock;
     static GATE: OnceLock<bool> = OnceLock::new();
-    *GATE.get_or_init(|| hipfire_config::developer_var("HIPFIRE_WMMA_FA").map_or(false, |v| v == "1"))
+    *GATE.get_or_init(|| {
+        hipfire_config::developer_var("HIPFIRE_WMMA_FA").map_or(false, |v| v == "1")
+    })
 }
 
 /// Minimum chunk size to engage the WMMA-FA route.
@@ -99,6 +99,39 @@ fn wmma_fa_min_batch() -> usize {
             .and_then(|s| s.parse::<usize>().ok())
             .unwrap_or(16)
     })
+}
+
+/// Experimental four-query Q8 prefill tile. Default-off while the KV-sharing
+/// layout is being validated across the supported architecture matrix.
+pub fn q8_prefill_m4_enabled() -> bool {
+    static GATE: OnceLock<bool> = OnceLock::new();
+    *GATE.get_or_init(|| {
+        hipfire_config::developer_var("HIPFIRE_Q8_PREFILL_M4").map_or(false, |v| v == "1")
+    })
+}
+
+pub fn q8_prefill_m4_eligible(
+    arch: &str,
+    n_heads: usize,
+    head_dim: usize,
+    max_ctx_len: usize,
+    batch_size: usize,
+    partials_numel: usize,
+    tree_mode: bool,
+) -> bool {
+    let max_tiles = max_ctx_len.div_ceil(128);
+    let floats_per_row = n_heads * max_tiles * (2 + head_dim);
+    let partial_rows = if floats_per_row > 0 {
+        partials_numel / floats_per_row
+    } else {
+        0
+    };
+    q8_prefill_m4_enabled()
+        && arch.starts_with("gfx12")
+        && !tree_mode
+        && batch_size % 4 == 0
+        && matches!(head_dim, 128 | 256)
+        && partial_rows >= 4
 }
 
 impl Gpu {
@@ -1842,10 +1875,32 @@ impl Gpu {
         block_cols: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
+        let use_m4 = q8_prefill_m4_eligible(
+            &self.arch,
+            n_heads,
+            head_dim,
+            max_ctx_len,
+            batch_size,
+            partials.numel(),
+            tree_bias.is_some(),
+        );
+        let (tile_key, tile_src, tile_func) = if use_m4 {
+            (
+                "attention_flash_q8_0_m4_tile_batched",
+                kernels::ATTENTION_FLASH_Q8_0_M4_TILE_BATCHED_SRC,
+                "attention_flash_q8_0_m4_tile_batched",
+            )
+        } else {
+            (
+                "attention_flash_q8_0_tile_batched",
+                kernels::ATTENTION_FLASH_Q8_0_TILE_BATCHED_SRC,
+                "attention_flash_q8_0_tile_batched",
+            )
+        };
         self.launch_asym_flash_batched(
-            "attention_flash_q8_0_tile_batched",
-            kernels::ATTENTION_FLASH_Q8_0_TILE_BATCHED_SRC,
-            "attention_flash_q8_0_tile_batched",
+            tile_key,
+            tile_src,
+            tile_func,
             q,
             k_cache,
             v_cache,
@@ -2048,13 +2103,7 @@ impl Gpu {
         output_gate: Option<&GpuTensor>,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let tile_size = q8_flash_tile_size(
-            &self.arch,
-            n_heads,
-            n_kv_heads,
-            head_dim,
-            max_seq,
-        );
+        let tile_size = q8_flash_tile_size(&self.arch, n_heads, n_kv_heads, head_dim, max_seq);
         // Graph-safe: use max_tiles so the grid is position-independent.
         // The tile kernel exits early for tiles beyond actual seq_len.
         let max_tiles = (max_seq + tile_size - 1) / tile_size;
@@ -2073,7 +2122,8 @@ impl Gpu {
 
         // ── Tile kernel ──
         let gfx1151_tile_dpp = self.arch_caps.is_gfx1151()
-            && hipfire_config::developer_var("HIPFIRE_GFX1151_ATTENTION_TILE_DPP").as_deref() == Ok("1");
+            && hipfire_config::developer_var("HIPFIRE_GFX1151_ATTENTION_TILE_DPP").as_deref()
+                == Ok("1");
         let (tile_module, tile_src) = if gfx1151_tile_dpp {
             (
                 "attention_flash_q8_0_tile_dpp_gfx1151",
@@ -2207,11 +2257,7 @@ impl Gpu {
                 )?;
             } else {
                 const KERNEL: &str = "attention_flash_q8_0_reduce";
-                self.ensure_kernel(
-                    KERNEL,
-                    kernels::ATTENTION_FLASH_Q8_0_REDUCE_SRC,
-                    KERNEL,
-                )?;
+                self.ensure_kernel(KERNEL, kernels::ATTENTION_FLASH_Q8_0_REDUCE_SRC, KERNEL)?;
                 let mut params: Vec<*mut c_void> = vec![
                     &p_ptr as *const _ as *mut c_void,
                     &o_ptr as *const _ as *mut c_void,
@@ -3246,15 +3292,20 @@ impl Gpu {
     ) -> HipResult<()> {
         const TILE_SIZE: usize = 128;
         const WMMA_BLOCK_M: usize = 16;
+        let use_q8_m4_grid = tile_func_name == "attention_flash_q8_0_m4_tile_batched";
         let max_tiles = (max_ctx_len + TILE_SIZE - 1) / TILE_SIZE;
         let stride = 2 + head_dim;
         let per_pos_bytes = n_heads * max_tiles * stride * 4;
         let partials_capacity = partials.numel() * 4;
-        let sub_batch = if per_pos_bytes > 0 {
+        let mut sub_batch = if per_pos_bytes > 0 {
             (partials_capacity / per_pos_bytes).max(1).min(batch_size)
         } else {
             batch_size
         };
+        if use_q8_m4_grid {
+            sub_batch -= sub_batch % 4;
+            sub_batch = sub_batch.max(4);
+        }
 
         let wmma_fa_kernel = if self.arch_caps.has_wmma_w32_gfx12() {
             Some((
@@ -3366,6 +3417,12 @@ impl Gpu {
                 let (grid, lds_bytes): ([u32; 3], u32) = if use_wmma_grid {
                     let m_tiles = (chunk + WMMA_BLOCK_M - 1) / WMMA_BLOCK_M;
                     ([n_heads as u32, m_tiles as u32, max_tiles as u32], 0)
+                } else if use_q8_m4_grid {
+                    let m_tiles = (chunk + 3) / 4;
+                    (
+                        [n_heads as u32, m_tiles as u32, max_tiles as u32],
+                        (4 * TILE_SIZE * 4) as u32,
+                    )
                 } else {
                     (
                         [n_heads as u32, max_tiles as u32, chunk as u32],
@@ -10416,34 +10473,22 @@ mod tests {
 
     #[test]
     fn q8_flash_gfx12_small_dense_shape_uses_tile16_only() {
-        assert_eq!(
-            q8_flash_default_tile_size("gfx1201", 8, 2, 256, 2_048),
-            16
-        );
+        assert_eq!(q8_flash_default_tile_size("gfx1201", 8, 2, 256, 2_048), 16);
         assert_eq!(
             q8_flash_default_tile_size("gfx1201", 16, 2, 256, 2_048),
             128
         );
-        assert_eq!(
-            q8_flash_default_tile_size("gfx1201", 8, 2, 128, 2_048),
-            128
-        );
+        assert_eq!(q8_flash_default_tile_size("gfx1201", 8, 2, 128, 2_048), 128);
     }
 
     #[test]
     fn gfx1151_tile32_default_is_exact_shape_and_arch_only() {
-        assert_eq!(
-            q8_flash_default_tile_size("gfx1151", 16, 2, 256, 2_048),
-            32
-        );
+        assert_eq!(q8_flash_default_tile_size("gfx1151", 16, 2, 256, 2_048), 32);
         assert_eq!(
             q8_flash_default_tile_size("gfx1151", 16, 2, 256, 8_192),
             128
         );
-        assert_eq!(
-            q8_flash_default_tile_size("gfx1100", 1, 1, 64, 8_192),
-            32
-        );
+        assert_eq!(q8_flash_default_tile_size("gfx1100", 1, 1, 64, 8_192), 32);
         assert_eq!(
             q8_flash_default_tile_size("gfx1200", 16, 2, 256, 2_048),
             128

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -1962,22 +1962,20 @@ pub const GEMV_HFQ4G256_MOE_DOWN_K8_INDEXED_BATCHED_EXPANDED_ROW2_CLUSTERED_GFX1
 /// gfx1151 K=512 eight-row schedule. One wave amortizes each activation load
 /// across eight output rows, targeting the APU's bandwidth ceiling without
 /// changing the routed-down ABI or any other architecture's code object.
-pub const GEMV_HFQ4G256_MOE_DOWN_K8_INDEXED_BATCHED_EXPANDED_ROW8_GFX1151_SRC: &str =
-    include_str!(
-        "../../../kernels/src/gemv_hfq4g256_moe_down_k8_indexed_batched_expanded_row8.gfx1151.hip"
-    );
+pub const GEMV_HFQ4G256_MOE_DOWN_K8_INDEXED_BATCHED_EXPANDED_ROW8_GFX1151_SRC: &str = include_str!(
+    "../../../kernels/src/gemv_hfq4g256_moe_down_k8_indexed_batched_expanded_row8.gfx1151.hip"
+);
 
 /// Radiowave gfx1100 cache-policy probe for the atomic-free MoE down stream.
 /// Keep this replay-visible and opt-in until exact-shadow and product-level
 /// certification establish whether SLC helps this access pattern.
-pub const GEMV_HFQ4G256_MOE_DOWN_K8_INDEXED_BATCHED_EXPANDED_CPOL_SLC_GFX1100_SRC: &str =
-    concat!(
-        "#define HIPFIRE_WEIGHT_CPOL_AUX 2\n",
-        "#define HIPFIRE_MOE_DOWN_KERNEL gemv_hfq4g256_moe_down_k8_indexed_batched_expanded_cpol_slc\n",
-        "#define HIPFIRE_GFX12_WEIGHT_CACHE_ELIGIBLE 1\n",
-        include_str!("../../../kernels/src/gfx12_weight_cache_policy.inc"),
-        include_str!("../../../kernels/src/gemv_hfq4g256_moe_down_k8_indexed_batched_expanded.hip")
-    );
+pub const GEMV_HFQ4G256_MOE_DOWN_K8_INDEXED_BATCHED_EXPANDED_CPOL_SLC_GFX1100_SRC: &str = concat!(
+    "#define HIPFIRE_WEIGHT_CPOL_AUX 2\n",
+    "#define HIPFIRE_MOE_DOWN_KERNEL gemv_hfq4g256_moe_down_k8_indexed_batched_expanded_cpol_slc\n",
+    "#define HIPFIRE_GFX12_WEIGHT_CACHE_ELIGIBLE 1\n",
+    include_str!("../../../kernels/src/gfx12_weight_cache_policy.inc"),
+    include_str!("../../../kernels/src/gemv_hfq4g256_moe_down_k8_indexed_batched_expanded.hip")
+);
 
 /// gfx1100 expert-wave-preserving down+combine experiment. Every workgroup
 /// still computes one expert rank; the last arriving rank for each four-row
@@ -3857,9 +3855,8 @@ pub const ATTENTION_FLASH_Q8_0_REDUCE_SRC: &str =
 /// gfx1100-only Qwen attention reduce/gate/MQ epilogue. Kept in a separate
 /// translation unit so its dormant body cannot perturb portable/gfx12 reducer
 /// codegen.
-pub const ATTENTION_FLASH_Q8_0_REDUCE_GATED_MQ_ROTATE_GFX1100_SRC: &str = include_str!(
-    "../../../kernels/src/attention_flash_q8_0_reduce_gated_mq_rotate.gfx1100.hip"
-);
+pub const ATTENTION_FLASH_Q8_0_REDUCE_GATED_MQ_ROTATE_GFX1100_SRC: &str =
+    include_str!("../../../kernels/src/attention_flash_q8_0_reduce_gated_mq_rotate.gfx1100.hip");
 pub const ATTENTION_FLASH_Q8_0_REDUCE_GATED_MQ_ROTATE_GFX1151_SRC: &str = concat!(
     "#define HIPFIRE_ATTENTION_REDUCE_GATED_MQ_KERNEL attention_flash_q8_0_reduce_gated_mq_rotate_gfx1151\n",
     include_str!("../../../kernels/src/attention_flash_q8_0_reduce_gated_mq_rotate.gfx1100.hip")
@@ -3909,6 +3906,8 @@ pub const ATTENTION_FLASH_ASYM2_TILE_BATCHED_SRC: &str =
     include_str!("../../../kernels/src/attention_flash_asym2_tile_batched.hip");
 pub const ATTENTION_FLASH_Q8_0_TILE_BATCHED_SRC: &str =
     include_str!("../../../kernels/src/attention_flash_q8_0_tile_batched.hip");
+pub const ATTENTION_FLASH_Q8_0_M4_TILE_BATCHED_SRC: &str =
+    include_str!("../../../kernels/src/attention_flash_q8_0_m4_tile_batched.hip");
 pub const ATTENTION_FLASH_ASYM_REDUCE_BATCHED_SRC: &str =
     include_str!("../../../kernels/src/attention_flash_asym_reduce_batched.hip");
 
@@ -5333,22 +5332,19 @@ mod dispatch_tests {
     #[test]
     fn qwen2_bias_symbols_are_isolated_from_existing_qkv_modules() {
         assert!(!FUSED_QKV_HFQ4G256_SRC.contains("#define HIPFIRE_QKV_WITH_BIAS 1"));
-        assert!(FUSED_QKV_HFQ4G256_QWEN2_BIAS_SRC
-            .contains("fused_qkv_hfq4g256_qwen2_bias"));
+        assert!(FUSED_QKV_HFQ4G256_QWEN2_BIAS_SRC.contains("fused_qkv_hfq4g256_qwen2_bias"));
         assert!(FUSED_QKV_Q4K_QWEN2_BIAS_SRC.contains("fused_qkv_q4k_qwen2_bias"));
         assert!(FUSED_QKV_Q8_0_QWEN2_BIAS_SRC.contains("fused_qkv_q8_0_qwen2_bias"));
 
         for arch in ["gfx1030", "gfx1100", "gfx1151", "gfx1201"] {
             let caps = make_caps(arch);
             let (_, old_mq4) = fused_qkv_mq4g256_lloyd_for_arch(&caps, false);
-            let (mq4_src, bias_mq4) =
-                fused_qkv_mq4g256_lloyd_qwen2_bias_for_arch(&caps, false);
+            let (mq4_src, bias_mq4) = fused_qkv_mq4g256_lloyd_qwen2_bias_for_arch(&caps, false);
             assert_ne!(old_mq4, bias_mq4);
             assert!(mq4_src.contains("#define HIPFIRE_QKV_WITH_BIAS 1"));
 
             let (_, old_mq3) = fused_qkv_mq3g256_lloyd_for_arch(&caps, false);
-            let (mq3_src, bias_mq3) =
-                fused_qkv_mq3g256_lloyd_qwen2_bias_for_arch(&caps, false);
+            let (mq3_src, bias_mq3) = fused_qkv_mq3g256_lloyd_qwen2_bias_for_arch(&caps, false);
             assert_ne!(old_mq3, bias_mq3);
             assert!(mq3_src.contains("#define HIPFIRE_QKV_WITH_BIAS 1"));
         }

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -826,6 +826,7 @@ Copyable user, developer, and retained-PM4 TOML profiles are in
 | `HIPFIRE_PROMPT_TOKEN_HEAT` | crates/hipfire-runtime/examples/daemon.rs, crates/hipfire-runtime/examples/dflash_spec_demo.rs |
 | `HIPFIRE_Q8_BATCHED_LEGACY` | crates/rdna-compute/src/feature_flags.rs, crates/rdna-compute/src/gemm.rs |
 | `HIPFIRE_Q8_FLASH_TILE` | crates/rdna-compute/src/attention.rs |
+| `HIPFIRE_Q8_PREFILL_M4` | crates/rdna-compute/src/attention.rs |
 | `HIPFIRE_Q8_PREFILL_WMMA` | crates/hipfire-arch-qwen35/src/qwen35.rs |
 | `HIPFIRE_QA_KV_MODES` | crates/hipfire-runtime/examples/test_inferenceQA.rs |
 | `HIPFIRE_QKVZA_BLOCK_SIZE` | crates/rdna-compute/src/kernels.rs |

--- a/kernels/src/attention_flash_q8_0_m4_tile_batched.hip
+++ b/kernels/src/attention_flash_q8_0_m4_tile_batched.hip
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+// Experimental Q8_0 prefill attention tile that processes four adjacent
+// queries per workgroup. K/V values are dequantized once and reused by all
+// four queries, reducing the dominant long-prefill KV traffic versus the
+// one-query-per-workgroup scalar tile.
+//
+// This kernel intentionally keeps the existing partials ABI so the established
+// attention_flash_asym_reduce_batched kernel performs the cross-tile online
+// softmax reduction unchanged.
+//
+// Constraints enforced by the gfx12-only host opt-in route:
+//   - batch chunks are multiples of BLOCK_M
+//   - causal attention only (no tree bias or sliding window)
+//   - head_dim is 128 or 256
+//
+// Grid: [n_heads, ceil(sub_batch/BLOCK_M), max_tiles]. Block: [32, 1, 1].
+#include <hip/hip_runtime.h>
+
+#define BLOCK_M 4
+#define TILE_SIZE 128
+
+extern "C" __launch_bounds__(32, 4)
+__global__ void attention_flash_q8_0_m4_tile_batched(
+    const float* __restrict__ q,
+    const unsigned char* __restrict__ k_cache,
+    const unsigned char* __restrict__ v_cache,
+    float* __restrict__ partials,
+    const int* __restrict__ positions,
+    const float* __restrict__ /*cos_theta*/,
+    const float* __restrict__ /*sin_theta*/,
+    const float* __restrict__ /*tree_bias*/,
+    int n_heads,
+    int n_kv_heads,
+    int head_dim,
+    int max_seq,
+    float scale_attn,
+    int tile_size,
+    int max_tiles,
+    int batch_offset,
+    int /*block_start*/,
+    int /*block_cols*/,
+    int /*v_mode_bits*/,
+    int /*window*/
+) {
+    const int h = blockIdx.x;
+    const int m_start = blockIdx.y * BLOCK_M;
+    const int tile_id = blockIdx.z;
+    if (h >= n_heads) return;
+
+    const int tid = threadIdx.x;
+    const int tile_start = tile_id * tile_size;
+    const int kv_group = n_heads / n_kv_heads;
+    const int kv_h = h / kv_group;
+    const int q_dim = n_heads * head_dim;
+    const int dpt = head_dim / 32;
+    const int d0 = tid * dpt;
+
+    int seq_len[BLOCK_M];
+    int tile_len[BLOCK_M];
+    bool any_work = false;
+    int max_tile_len = 0;
+#pragma unroll
+    for (int m = 0; m < BLOCK_M; m++) {
+        const int global_bid = batch_offset + m_start + m;
+        seq_len[m] = positions[global_bid] + 1;
+        int len = seq_len[m] - tile_start;
+        len = max(0, min(min(tile_size, max_seq - tile_start), len));
+        tile_len[m] = len;
+        any_work |= len > 0;
+        max_tile_len = max(max_tile_len, len);
+    }
+    if (!any_work) return;
+
+    const int blocks_per_head = head_dim / 32;
+    const int total_blocks = n_kv_heads * blocks_per_head;
+    const int kv_head_blk = kv_h * blocks_per_head;
+    const int row_stride = total_blocks * 34;
+
+    float mq[BLOCK_M][8];
+#pragma unroll
+    for (int m = 0; m < BLOCK_M; m++) {
+        const float* q_head =
+            q + (size_t)(m_start + m) * q_dim + h * head_dim;
+        for (int i = 0; i < dpt; i++) mq[m][i] = q_head[d0 + i];
+    }
+
+    extern __shared__ float sdata[];
+    float (*scores)[TILE_SIZE] = (float (*)[TILE_SIZE])sdata;
+
+    for (int t_local = 0; t_local < max_tile_len; t_local++) {
+        const int t = tile_start + t_local;
+        float dot[BLOCK_M] = {0.0f, 0.0f, 0.0f, 0.0f};
+        for (int i = 0; i < dpt; i++) {
+            const int d = d0 + i;
+            const int bi = d / 32;
+            const int bj = d % 32;
+            const unsigned char* kb =
+                k_cache + (size_t)t * row_stride + (kv_head_blk + bi) * 34;
+            const float ks = (float)*((const _Float16*)kb);
+            const float kval = ks * (float)((signed char)kb[2 + bj]);
+#pragma unroll
+            for (int m = 0; m < BLOCK_M; m++) {
+                dot[m] += mq[m][i] * kval;
+            }
+        }
+#pragma unroll
+        for (int m = 0; m < BLOCK_M; m++) {
+            for (int off = 16; off > 0; off >>= 1)
+                dot[m] += __shfl_xor(dot[m], off);
+            if (tid == 0 && t_local < tile_len[m])
+                scores[m][t_local] = dot[m] * scale_attn;
+        }
+    }
+    __syncthreads();
+
+    float tile_max[BLOCK_M];
+    float tile_sum[BLOCK_M];
+#pragma unroll
+    for (int m = 0; m < BLOCK_M; m++) {
+        float local_max = -1e30f;
+        for (int i = tid; i < tile_len[m]; i += 32)
+            local_max = fmaxf(local_max, scores[m][i]);
+        for (int off = 16; off > 0; off >>= 1)
+            local_max = fmaxf(local_max, __shfl_xor(local_max, off));
+        tile_max[m] = local_max;
+
+        float local_sum = 0.0f;
+        for (int i = tid; i < tile_len[m]; i += 32) {
+            const float e = expf(scores[m][i] - local_max);
+            scores[m][i] = e;
+            local_sum += e;
+        }
+        for (int off = 16; off > 0; off >>= 1)
+            local_sum += __shfl_xor(local_sum, off);
+        tile_sum[m] = local_sum;
+    }
+    __syncthreads();
+
+    float out_vec[BLOCK_M][8] = {};
+    for (int t_local = 0; t_local < max_tile_len; t_local++) {
+        const int t = tile_start + t_local;
+        const unsigned char* vb = v_cache + (size_t)t * row_stride;
+        for (int i = 0; i < dpt; i++) {
+            const int d = d0 + i;
+            const int bi = d / 32;
+            const int bj = d % 32;
+            const unsigned char* vbh = vb + (kv_head_blk + bi) * 34;
+            const float vs = (float)*((const _Float16*)vbh);
+            const float vval = vs * (float)((signed char)vbh[2 + bj]);
+#pragma unroll
+            for (int m = 0; m < BLOCK_M; m++) {
+                if (t_local < tile_len[m])
+                    out_vec[m][i] += scores[m][t_local] * vval;
+            }
+        }
+    }
+
+    const int stride = 2 + head_dim;
+#pragma unroll
+    for (int m = 0; m < BLOCK_M; m++) {
+        if (tile_len[m] == 0) continue;
+        float* p = partials
+            + ((long long)(m_start + m) * n_heads + h) * max_tiles * stride
+            + tile_id * stride;
+        if (tid == 0) {
+            p[0] = tile_max[m];
+            p[1] = tile_sum[m];
+        }
+        for (int i = 0; i < dpt; i++)
+            p[2 + d0 + i] = out_vec[m][i];
+    }
+}

--- a/scripts/speed-gate.sh
+++ b/scripts/speed-gate.sh
@@ -84,7 +84,7 @@ if [ -z "$BASELINE_ARCH" ]; then
 fi
 
 BASELINE_FILE="tests/speed-baselines/${BASELINE_ARCH}.txt"
-MODELS_DIR="${HIPFIRE_MODELS_DIR:-/home/kaden/ClaudeCode/autorocm/hipfire/models}"
+MODELS_DIR="${HIPFIRE_MODELS_DIR:-${HIPFIRE_DIR:-$HOME/.hipfire}/models}"
 
 FAST=0
 UPDATE=0

--- a/tools/redline/tests/test_product_bench.py
+++ b/tools/redline/tests/test_product_bench.py
@@ -2362,7 +2362,7 @@ class ServeHarnessWarmTests(unittest.TestCase):
             ):
                 ok = sh.spawn_serve(cfg, home, str(log))
 
-            self.assertTrue(ok)
+            self.assertIsNotNone(ok)
             self.assertIn("env", captured)
             self.assertNotIn("HIPFIRE_SERVE_HARNESS_PID_FILE", captured["env"])
             # Parent still wrote the PID file via its own os.environ.


### PR DESCRIPTION
## Summary

This adds an opt-in gfx12 Q8 prefill attention tile that processes four adjacent causal queries per wave and reuses each dequantized K/V value across those queries. It preserves the existing global partials ABI and established reduce kernel, so the change is isolated to the bandwidth-dominant tile stage.

**No ready and wait in status of draft since gfx11 verification is in progress. And PR #553 had already had similar realization. Thus this PR is frozen to seek more aggressive performance pursuit.**

The route remains default-off behind `HIPFIRE_Q8_PREFILL_M4=1`. It is restricted to gfx12, causal Q8 prefill, head dimensions 128/256, M4-aligned batches, and sufficient partial capacity. Tree attention, sliding-window attention, unsupported shapes, and other architectures continue to use the existing kernels.

No CK shared object or external binary is linked or redistributed. This is a native hipfire kernel using the query-tiling/KV-reuse principle; the existing hipfire/Kaden provenance and SPDX convention are preserved.

## Which crate(s) does this touch?

- [x] `kernels/` (HIP source)
- [x] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [ ] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy`
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [x] docs / CI / scripts

## Performance

Hardware and configuration: Radeon AI PRO R9700 (`gfx1201`, 34.2 GB), HIP 7.14, Q8 KV, context limit 32,768, temperature 0, DFlash/MTP off, fresh daemon per condition, byte-identical prompts inside every A/B cell.

The full LongBench-v2 hard20 matrix used 20 complete 20.5K–30.2K-token contexts:

| Model / mode | Baseline prefill | M4 prefill | Speedup | Prefill reduction | End-to-end reduction |
|---|---:|---:|---:|---:|---:|
| 27B / no-think | 3,315.7 s | 1,895.5 s | 1.749x | 42.83% | 38.07% |
| 27B / think | 3,359.0 s | 1,943.2 s | 1.729x | 42.15% | 25.86% |
| 35B-A3B / no-think | 1,284.7 s | 707.2 s | 1.817x | 44.96% | 42.53% |
| 35B-A3B / think | 1,298.4 s | 708.1 s | 1.834x | 45.46% | 53.23% |

Summed prefill time fell from 9,257.8 s to 5,254.0 s: **1.762x overall / 43.25% lower**. Per-item median speedups were 1.732x–1.828x.

That matrix was collected on clean `beta@94d0bf2b`. After rebasing onto the current `beta@9fa33b33` compiler changes, I rebuilt two true binaries and repeated a final 29,788-token pair:

- baseline: 202,618.3 ms, 147.0 prefill tok/s
- M4: 114,074.7 ms, 261.1 prefill tok/s
- result: **1.776x / 43.70% lower prefill time**
- decode: 29.0 → 29.5 tok/s
- prompt MD5: `51156095f76ddd012929d547eb3ea912`
- baseline daemon SHA-256: `f07639ed311b4bb8ffb243aa69efb94195fa55b29ec29187deba752a18f4c77b`
- optimized daemon SHA-256: `67f3a459c13d0596033691aef05c79a642244c4ddd9b020e7eb4e9df6b58347a`

PP32K peak global VRAM was unchanged within sampling resolution:

- baseline: 8,578,019,328 bytes
- M4: 8,578,002,944 bytes
- delta: -16,384 bytes (effectively 0%)

The additional storage is 2 KiB dynamic LDS per workgroup rather than a new global allocation.

## Correctness

- Final-source `test_kernels` on gfx1201: 16 passed, 0 failed, 0 skipped.
- Final 29,788-token A/B produced the same correct answer and byte-identical transcript (`f53db75b24c2949d5c7babff223cf778`).
- Model-level final-logit checks at PP256/PP4096/PP16384 retained the same argmax and 10/10 top-token overlap; maximum absolute differences were 0.0262/0.0206/0.0182 from the changed floating-point reduction order.
- A deterministic 10% audit of the 160 LongBench outputs found coherent English, no token attractor, no repetitive degeneration, and no corrupted text.
- LongBench no-think strict score was 16/40 baseline versus 15/40 M4 on this deliberately hard sample. Thinking quality was not scored because 18–19/20 runs reached the 2,048-token cap before the required final-answer line.

## Test plan

- [ ] `./scripts/no-gpu-ci.sh` passes, or equivalent CI job is green
  - Rust checks, workspace library tests, and 371 Python CPU tests pass. The script currently has one unrelated beta failure in unchanged `ServeHarnessWarmTests.test_spawn_serve_strips_harness_pid_file_from_child_env`: a successful spawn returns log offset `0`, while the test uses `assertTrue(ok)`.
- [x] `cargo build --release --workspace --features deltanet` clean
- [x] `cargo test --lib --workspace --features deltanet` passes
- [x] `cargo clippy --workspace --all-targets --features deltanet` exits 0 (existing workspace warnings remain)
- [x] Changed-file rustfmt check passes
- [x] Final-source gfx1201 `test_kernels` passes
- [x] Runtime output and long-prefill A/B validation described above passes
- [ ] Legacy coherence scripts
  - N/A: current `beta@9fa33b33` removed `scripts/coherence-gate-dflash.sh`, and `CLAUDE.md` now requires actual runtime harness validation instead.
- [ ] `./scripts/speed-gate.sh --fast` checks a locked baseline
  - The pre-commit hook ran, but the local 4B fixture was absent, so it reported `NO METRICS CHECKED`. The gfx12 actual-path A/B above is the relevant performance gate; the new route is default-off and does not dispatch on gfx11.
- [x] Pre-commit agentic fast gate passes: 1 cell, 0 soft warnings

## Architecture-trait change?

No.
