### PR TITLE
fix(attention): bounded-LDS Q8 KV attention kernel; drop unconditional >15k flash switch

### DIFF
--- a/crates/hipfire-dispatch/src/families/kv_tier.rs
+++ b/crates/hipfire-dispatch/src/families/kv_tier.rs
@@ -359,7 +359,7 @@ impl KvTierPlan {
 /// `is_boundary` and `quant_q8` branches of `derive`.
 fn q8_attend_key(pos: usize, flash_mode: usize, capture_mode: bool) -> KernelKey {
     let use_flash =
-        capture_mode || flash_mode == 2 || (flash_mode == 1 && pos + 1 >= 2048) || pos + 1 > 15000;
+        capture_mode || flash_mode == 2 || (flash_mode == 1 && pos + 1 >= 2048);
     if use_flash {
         KernelKey::AttnFlashQ8_0
     } else {

--- a/crates/rdna-compute/src/attention.rs
+++ b/crates/rdna-compute/src/attention.rs
@@ -5501,11 +5501,12 @@ impl Gpu {
             &mut ms as *mut _ as *mut c_void,
             &mut sc as *mut _ as *mut c_void,
         ];
-        let block_size = (seq_len_hint.max(head_dim) as u32)
-            .next_power_of_two()
-            .min(256);
-        // Extra shared mem for Q head vector preloaded into shared memory
-        let shared_mem = ((seq_len_hint + block_size as usize + head_dim) * 4) as u32;
+        // Fixed-size launch: block 256, LDS = (ATT_Q8_TILE + head_dim + block)
+        // floats regardless of seq_len (v2 kernel tiles positions with online
+        // softmax — O(seq_len) LDS previously faulted past ~15.9k on gfx1100).
+        const ATT_Q8_KV_TILE: usize = 2048;
+        let block_size: u32 = 256;
+        let shared_mem = ((ATT_Q8_KV_TILE + head_dim + block_size as usize) * 4) as u32;
         let bytes =
             crate::profile::attention_q8_0_kv_bytes(n_heads, n_kv_heads, head_dim, seq_len_hint);
         let timer = crate::profile::begin_timer(&self.hip, "attention", "attention_q8_0_kv", bytes);

--- a/kernels/src/attention_q8_0_kv.hip
+++ b/kernels/src/attention_q8_0_kv.hip
@@ -2,13 +2,26 @@
 // Copyright (c) 2026 Kaden Schutt
 // hipfire — see LICENSE and NOTICE in the project root.
 
+// Q8_0 KV attention, single-token decode, BOUNDED shared memory.
+//
+// v2 (2026-07-31, long-context fix): v1 kept `scores[seq_len]` in LDS —
+// O(seq_len) shared memory — exceeding gfx1100's 64 KiB LDS cap at
+// seq_len ~ 15872 (16 KiB * 4 B) and faulting the GPU. v2 processes
+// positions in fixed ATT_Q8_TILE-sized tiles with online softmax, so LDS =
+// [ATT_Q8_TILE + head_dim + block] floats regardless of seq_len: safe at any
+// context, and graph-safe (fixed LDS + position-independent grid).
+//
+// Grid: [n_heads, 1, 1]. Block: [256, 1, 1] (any power-of-two block works).
 #include <hip/hip_runtime.h>
 
+#define ATT_Q8_TILE 2048
+#define ATT_Q8_ACC_MAX 16
+
 extern "C" __global__ void attention_q8_0_kv(
-    const float* __restrict__ q,
-    const unsigned char* __restrict__ k_cache,
+    const float* __restrict__ q,         // [n_heads, head_dim]
+    const unsigned char* __restrict__ k_cache,  // [max_seq, n_kv_heads*blocks_per_head*34]
     const unsigned char* __restrict__ v_cache,
-    float* __restrict__ out,
+    float* __restrict__ out,             // [n_heads, head_dim]
     const int* __restrict__ pos_buf,
     int n_heads,
     int n_kv_heads,
@@ -16,7 +29,7 @@ extern "C" __global__ void attention_q8_0_kv(
     int max_seq,
     float scale_attn
 ) {
-    int seq_len = pos_buf[0] + 1;
+    const int seq_len = pos_buf[0] + 1;
     extern __shared__ float sdata[];
 
     const int h = blockIdx.x;
@@ -32,74 +45,109 @@ extern "C" __global__ void attention_q8_0_kv(
     const int total_blocks_per_pos = n_kv_heads * blocks_per_head;
     const int kv_head_block_start = kv_h * blocks_per_head;
 
-    float* scores = sdata;
-    float* workspace = sdata + seq_len;
+    float* scores = sdata;                    // [ATT_Q8_TILE]
+    float* q_shared = sdata + ATT_Q8_TILE;    // [head_dim]
+    float* workspace = sdata + ATT_Q8_TILE + head_dim;  // [nthreads]
 
-    // Preload Q head into shared memory (loaded once, used for all positions)
-    float* q_shared = workspace + nthreads;  // after workspace
+    // Load Q into shared memory (once, used for all tiles).
     for (int d = tid; d < head_dim; d += nthreads)
         q_shared[d] = q_head[d];
     __syncthreads();
 
-    // Phase 1: Q @ K^T with Q8_0 dequant (Q preloaded in shared memory)
-    float local_max = -1e30f;
-    for (int t = tid; t < seq_len; t += nthreads) {
-        float dot = 0.0f;
-        for (int bi = 0; bi < blocks_per_head; bi++) {
-            const unsigned char* block = k_cache + (size_t)t * total_blocks_per_pos * 34
-                                        + (kv_head_block_start + bi) * 34;
-            float d = (float)*((const _Float16*)block);
-            const float* qb = q_shared + bi * 32;
-            for (int j = 0; j < 32; j++) {
-                dot += qb[j] * (d * (float)((signed char)block[2 + j]));
+    // V accumulator: thread tid owns dims d = tid + i*nthreads.
+    const int n_acc = (head_dim + nthreads - 1) / nthreads;
+    float acc[ATT_Q8_ACC_MAX];
+    for (int i = 0; i < n_acc && i < ATT_Q8_ACC_MAX; i++) acc[i] = 0.0f;
+
+    // Online-softmax running stats (per block).
+    float m = -1e30f;
+    float l = 0.0f;
+
+    for (int tile_start = 0; tile_start < seq_len; tile_start += ATT_Q8_TILE) {
+        const int tile_len = (seq_len - tile_start < ATT_Q8_TILE)
+                                 ? (seq_len - tile_start)
+                                 : ATT_Q8_TILE;
+
+        // Phase A: Q @ K^T for this tile -> LDS scores.
+        for (int t = tid; t < tile_len; t += nthreads) {
+            const int pos = tile_start + t;
+            float dot = 0.0f;
+            for (int bi = 0; bi < blocks_per_head; bi++) {
+                const unsigned char* block =
+                    k_cache + (size_t)pos * total_blocks_per_pos * 34
+                            + (kv_head_block_start + bi) * 34;
+                const float d = (float)*((const _Float16*)block);
+                const float* qb = q_shared + bi * 32;
+                for (int j = 0; j < 32; j++)
+                    dot += qb[j] * (d * (float)((signed char)block[2 + j]));
+            }
+            scores[t] = dot * scale_attn;
+        }
+        __syncthreads();
+
+        // Tile max via LDS tree reduction (block-wide, any power-of-two size).
+        float tmax = -1e30f;
+        for (int t = tid; t < tile_len; t += nthreads)
+            tmax = fmaxf(tmax, scores[t]);
+        workspace[tid] = tmax;
+        __syncthreads();
+        for (int s = nthreads / 2; s > 0; s >>= 1) {
+            if (tid < s) workspace[tid] = fmaxf(workspace[tid], workspace[tid + s]);
+            __syncthreads();
+        }
+        tmax = workspace[0];
+        __syncthreads();  // workspace free for reuse
+
+        // Merge into running stats and rescale the V accumulator.
+        const float new_m = fmaxf(m, tmax);
+        const float rescale = expf(m - new_m);
+        l *= rescale;
+        for (int i = 0; i < n_acc && i < ATT_Q8_ACC_MAX; i++) acc[i] *= rescale;
+
+        float tsum = 0.0f;
+        for (int t = tid; t < tile_len; t += nthreads) {
+            const float e = expf(scores[t] - new_m);
+            scores[t] = e;
+            tsum += e;
+        }
+        workspace[tid] = tsum;
+        __syncthreads();
+        for (int s = nthreads / 2; s > 0; s >>= 1) {
+            if (tid < s) workspace[tid] += workspace[tid + s];
+            __syncthreads();
+        }
+        tsum = workspace[0];
+        l += tsum;
+        m = new_m;
+        __syncthreads();  // protect LDS scores before Phase B reads
+
+        // Phase B: V-weighted accumulation for this tile.
+        for (int t = tid; t < tile_len; t += nthreads) {
+            const float w = scores[t];
+            const int pos = tile_start + t;
+            const int v_blk_off = kv_head_block_start * 34;
+            for (int i = 0; i < n_acc && i < ATT_Q8_ACC_MAX; i++) {
+                const int d = tid + i * nthreads;
+                if (d >= head_dim) break;
+                const int bi = d / 32;
+                const int bj = d % 32;
+                const unsigned char* block =
+                    v_cache + (size_t)pos * total_blocks_per_pos * 34
+                            + v_blk_off + bi * 34;
+                const float vd = (float)*((const _Float16*)block)
+                               * (float)(signed char)block[2 + bj];
+                acc[i] += w * vd;
             }
         }
-        float s = dot * scale_attn;
-        scores[t] = s;
-        local_max = fmaxf(local_max, s);
+        __syncthreads(); // protect LDS scores before the next tile overwrites
     }
 
-    workspace[tid] = local_max;
-    __syncthreads();
-    for (int s = nthreads / 2; s > 0; s >>= 1) {
-        if (tid < s) workspace[tid] = fmaxf(workspace[tid], workspace[tid + s]);
-        __syncthreads();
-    }
-    float max_val = workspace[0];
-    __syncthreads();
-
-    float local_sum = 0.0f;
-    for (int t = tid; t < seq_len; t += nthreads) {
-        float e = expf(scores[t] - max_val);
-        scores[t] = e;
-        local_sum += e;
-    }
-    workspace[tid] = local_sum;
-    __syncthreads();
-    for (int s = nthreads / 2; s > 0; s >>= 1) {
-        if (tid < s) workspace[tid] += workspace[tid + s];
-        __syncthreads();
-    }
-    float sum_val = workspace[0];
-    __syncthreads();
-
-    for (int t = tid; t < seq_len; t += nthreads) {
-        scores[t] /= sum_val;
-    }
-    __syncthreads();
-
-    // Phase 2: weighted sum of V with Q8_0 dequant
+    // Normalize and write out.
     float* out_head = out + h * head_dim;
-    for (int d = tid; d < head_dim; d += nthreads) {
-        float val = 0.0f;
-        int bi = d / 32;
-        int bj = d % 32;
-        for (int t = 0; t < seq_len; t++) {
-            const unsigned char* block = v_cache + (size_t)t * total_blocks_per_pos * 34
-                                        + (kv_head_block_start + bi) * 34;
-            float vd = (float)*((const _Float16*)block) * (float)(signed char)block[2 + bj];
-            val += scores[t] * vd;
-        }
-        out_head[d] = val;
+    const float inv_l = 1.0f / l;
+    for (int i = 0; i < n_acc && i < ATT_Q8_ACC_MAX; i++) {
+        const int d = tid + i * nthreads;
+        if (d >= head_dim) break;
+        out_head[d] = acc[i] * inv_l;
     }
 }


### PR DESCRIPTION
## Summary

The Qwen3.5/3.6 native MTP head faults the GPU at ~16k context, killing the daemon. Root-caused and fixed in three small changes.

Reproduced on **pure upstream beta (16b9554)**, gfx1100 (RX 7900 XTX), ROCm 7.14 — no local patches involved.

## The bug

`hipfire serve` + `HIPFIRE_QWEN_MTP=1` + `<trunk>.mtp` sidecar, then a prompt >~15k tokens:

- 14.5k prompt: works, decode 50.6 tok/s, tau 2.07
- 15.2k prompt: **"Memory access fault by GPU node-1 ... Page not present or supervisor privilege"** — daemon dies

Bisect placed the boundary at exactly **15000** tokens.

Two contributing defects:

1. **O(seq_len) shared memory in the naive Q8 attention kernel** (`kernels/src/attention_q8_0_kv.hip`): `scores[seq_len]` floats in LDS. gfx1100's 64 KiB LDS cap is hit at `seq_len ~ 15872` — the kernel would fault there even without the dispatch issue.
2. **Unconditional flash switch past 15k** (`hipfire-dispatch/src/families/kv_tier.rs` `q8_attend_key`): `use_flash = capture || flash_mode == 2 || (flash_mode == 1 && pos+1 >= 2048) || pos + 1 > 15000`. The MTP head's `KvCache::tier_inputs()` hardcodes `flash_mode: 0`, so the `pos + 1 > 15000` clause fires unconditionally for the head and forces `AttnFlashQ8_0`, which faults with the head's single-layer Q8 KV/partials invocation at ~16k.

## The fix (3 files, +113/-64)

1. **`kernels/src/attention_q8_0_kv.hip` — v2 rewrite**: positions processed in fixed 2048-token tiles with online softmax. LDS = `[2048 + head_dim + block]` floats (~9 KiB) regardless of `seq_len`. Bonus: the kernel is now graph-safe (fixed LDS, position-independent grid), which was previously why capture forced flash.
2. **`crates/rdna-compute/src/attention.rs`**: `attention_q8_0_kv` launcher uses a fixed 256-thread block and fixed LDS sizing (was `seq_len`-scaled).
3. **`crates/hipfire-dispatch/src/families/kv_tier.rs`**: `q8_attend_key` no longer forces flash past 15k — flash only when the caller opts in (`flash_mode >= 1`) or graph capture demands a position-independent launch. Trunk Q8-KV decode behavior is unchanged (trunk call sites pass their real `flash_mode`, default auto → flash at `pos+1 >= 2048` as before).

## Verification (gfx1100, Qwopus3.6-27B-Fusion MQ4 + .mtp sidecar, fwht3 KV, max_seq 87040)

| prompt | before | after (mtpfix) |
|---|---|---|
| 14.5k | 50.6 tok/s | 46.1 tok/s, tau 2.07 |
| 15.2k | **GPU fault, daemon dies** | 45.7 tok/s, tau 2.07 |
| 34k | GPU fault | 36.2 tok/s, tau 1.94 |
| 64k | — | 28.2 tok/s, tau 1.94 |

Zero faults across the full curve; MTP speculation engaged at every length. Trunk q8-KV decode at 16k/34k (the same `AttnFlashQ8_0` path, `flash_mode >= 1`) verified unaffected.

## Notes

- The `attention_q8_0_kv_timed` DIAGNOSTIC kernel (profiling-only, not on the serve/MTP path) still carries v1's O(seq_len) LDS — flagged, not fixed here.
- Kernel hipcc-compiled clean under the ROCm 7.14 toolchain; Rust side builds clean.
