### PR TITLE
fix(client): clear beta Clippy failure and dummy spawn race

### DIFF
--- a/crates/hipfire-client/src/lib.rs
+++ b/crates/hipfire-client/src/lib.rs
@@ -3184,22 +3184,9 @@ done
 
     #[cfg(unix)]
     fn dummy_child() -> Child {
-        use std::os::unix::fs::PermissionsExt;
-        use std::sync::atomic::{AtomicU64, Ordering};
-        static N: AtomicU64 = AtomicU64::new(0);
-        let n = N.fetch_add(1, Ordering::Relaxed);
-        let root = env::temp_dir().join(format!(
-            "hipfire-client-dummy-child-{}-{}",
-            std::process::id(),
-            n
-        ));
-        let _ = fs::create_dir_all(&root);
-        let path = root.join("sleep");
-        // Tiny forever-reader so Drop kill is clean.
-        // Unique path per call avoids ETXTBSY when tests race on rewrite.
-        fs::write(&path, "#!/bin/sh\ncat >/dev/null\n").unwrap();
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
-        Command::new(&path)
+        // A system executable avoids racing a prior test process that still
+        // has a generated script open, which can make spawn fail with ETXTBSY.
+        Command::new("cat")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())

--- a/crates/hipfire-client/src/lib.rs
+++ b/crates/hipfire-client/src/lib.rs
@@ -1481,17 +1481,12 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn jsonl_transport_frames_ping_and_unload() {
-        use std::os::unix::fs::PermissionsExt;
         let root = env::temp_dir().join(format!("hipfire-client-test-{}", std::process::id()));
-        fs::create_dir_all(&root).unwrap();
-        let daemon = root.join("daemon");
-        fs::write(
-            &daemon,
+        let daemon = write_fake_daemon(
+            &root,
             "#!/bin/sh\nwhile IFS= read -r line; do\n case \"$line\" in *'\"ping\"'*) echo '{\"type\":\"pong\"}' ;; *'\"unload\"'*) echo '{\"type\":\"unloaded\"}'; exit 0 ;; esac\ndone\n",
-        )
-        .unwrap();
-        fs::set_permissions(&daemon, fs::Permissions::from_mode(0o755)).unwrap();
-        let mut engine = Engine::spawn(&daemon, &BTreeMap::new()).unwrap();
+        );
+        let mut engine = spawn_fake_engine(&daemon);
         engine.ping().unwrap();
         engine.unload().unwrap();
         let _ = fs::remove_dir_all(root);
@@ -1500,19 +1495,14 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn configured_spawn_sends_process_policy_before_ping() {
-        use std::os::unix::fs::PermissionsExt;
         let root = env::temp_dir().join(format!(
             "hipfire-client-configured-test-{}",
             std::process::id()
         ));
-        fs::create_dir_all(&root).unwrap();
-        let daemon = root.join("daemon");
-        fs::write(
-            &daemon,
+        let daemon = write_fake_daemon(
+            &root,
             "#!/bin/sh\nconfigured=0\nwhile IFS= read -r line; do\n case \"$line\" in *'\"configure\"'*) if [ \"$HIP_VISIBLE_DEVICES\" = '0,1' ] && [ \"$ROCR_VISIBLE_DEVICES\" = '2,3' ]; then configured=1; echo '{\"type\":\"configured\"}'; else echo '{\"type\":\"error\",\"message\":\"device visibility is not synchronized\"}'; fi ;; *'\"ping\"'*) if [ \"$configured\" = 1 ]; then echo '{\"type\":\"pong\"}'; else echo '{\"type\":\"error\",\"message\":\"not configured\"}'; fi ;; *'\"unload\"'*) echo '{\"type\":\"unloaded\"}'; exit 0 ;; esac\ndone\n",
-        )
-        .unwrap();
-        fs::set_permissions(&daemon, fs::Permissions::from_mode(0o755)).unwrap();
+        );
         let mut layer = hipfire_config::ConfigLayer::default();
         layer.set_cli("hardware.devices", "2,3").unwrap();
         let resolved = hipfire_config::resolve([hipfire_config::NamedLayer {
@@ -1523,7 +1513,7 @@ mod tests {
         }])
         .unwrap();
         let config = hipfire_config::ProcessConfig::from_resolved(&resolved).unwrap();
-        let mut engine = Engine::spawn_configured(&daemon, &BTreeMap::new(), &config).unwrap();
+        let mut engine = spawn_fake_engine_configured(&daemon, &config);
         engine.ping().unwrap();
         engine.unload().unwrap();
         let _ = fs::remove_dir_all(root);
@@ -1974,7 +1964,7 @@ done
         )
         .unwrap();
         fs::set_permissions(&daemon, fs::Permissions::from_mode(0o755)).unwrap();
-        let mut engine = Engine::spawn(&daemon, &BTreeMap::new()).unwrap();
+        let mut engine = spawn_fake_engine(&daemon);
         engine.reset(5).unwrap();
         assert_eq!(engine.last_state_epoch(), Some(1));
         assert_eq!(engine.last_retry_reset_eligible(), Some(true));
@@ -2057,7 +2047,7 @@ done
         )
         .unwrap();
         fs::set_permissions(&daemon, fs::Permissions::from_mode(0o755)).unwrap();
-        let mut engine = Engine::spawn(&daemon, &BTreeMap::new()).unwrap();
+        let mut engine = spawn_fake_engine(&daemon);
         let loaded = engine
             .load(Path::new("/tmp/m.hfq"), serde_json::json!({}))
             .unwrap();
@@ -2152,6 +2142,35 @@ done
         }
         panic!(
             "spawn_fake_engine exhausted ETXTBSY retries: {}",
+            last.map(|e| e.to_string()).unwrap_or_default()
+        );
+    }
+
+    /// Same bounded ETXTBSY retry as `spawn_fake_engine`, for the configured path.
+    #[cfg(unix)]
+    fn spawn_fake_engine_configured(
+        daemon: &std::path::Path,
+        config: &hipfire_config::ProcessConfig,
+    ) -> Engine {
+        const ETXTBSY: i32 = 26;
+        const MAX_ATTEMPTS: usize = 8;
+        let mut last = None;
+        for attempt in 0..MAX_ATTEMPTS {
+            match Engine::spawn_configured(daemon, &BTreeMap::new(), config) {
+                Ok(engine) => return engine,
+                Err(ClientError::Spawn { source, path })
+                    if source.raw_os_error() == Some(ETXTBSY) =>
+                {
+                    last = Some(ClientError::Spawn { path, source });
+                    std::thread::sleep(std::time::Duration::from_millis(
+                        5u64.saturating_mul(1 + attempt as u64),
+                    ));
+                }
+                Err(err) => panic!("spawn_fake_engine_configured non-retryable: {err}"),
+            }
+        }
+        panic!(
+            "spawn_fake_engine_configured exhausted ETXTBSY retries: {}",
             last.map(|e| e.to_string()).unwrap_or_default()
         );
     }


### PR DESCRIPTION
## Summary

Fix the `beta` Clippy job's denied `clippy::never_loop` error in `hipfire-client` without changing the committed-response protocol, and remove an `ETXTBSY` race in the same crate's dummy-child test fixture discovered while running the required change gate.

`drain_committed_done` already returned for every possible first post-commit event, so the removed `loop` never performed a second iteration. The updated implementation makes that existing single-event contract explicit. The test fixture now runs the system `cat` executable instead of repeatedly writing and executing a temporary shell script that could still be open in a rapidly reused test process.

Original failing Clippy job: https://github.com/warpfront/hipfire/actions/runs/30679257074/job/91312811656

## Which crate(s) does this touch?

- [x] `crates/hipfire-client`
- [ ] `kernels/` (HIP source)
- [ ] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [ ] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template — touch only when refining the new-arch reference)
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [ ] docs / CI / scripts

## Test plan

- [x] `cargo clippy --workspace --all-targets --locked`
- [x] `bash scripts/ci-rustfmt-changed.sh`
- [x] `cargo test --lib --workspace --locked`
- [x] `cargo build --release --workspace --features deltanet --locked`
- [x] `cargo test --lib --workspace --features deltanet --locked`
- [x] `cargo test -p hipfire-client --lib --locked` — 37/37
- [x] Change gate passed both selected control-plane routes
- [x] No performance-relevant code; speed gate not applicable
- [x] No blocked routes

The first sandboxed change-gate attempt could not bind localhost test ports. After rerunning with localhost access, one run also exposed the temporary-script `ETXTBSY` race fixed by the second commit. The final committed-tree gate below is green.

<details><summary>change_gate telemetry</summary>

```text
**change_gate: PASS**

host gfx=`gfx1100` rocm=`6.19.14` models_dir=`/home/husrcf/.hipfire/models` · `e2f7dd1a47be23873d72090ac778e4f5197b7fe2`..`8ff835d4cf8a45b4d53de8e1aeb929181dd1e56a` · est=2.3min actual=4.5s

### Routes RUN
| route               | status | duration |
| ------------------- | ------ | -------- |
| unit.hipfire-cli    | pass   | 1.8s     |
| unit.no-gpu-control | pass   | 2.8s     |

### Routes NOT RUN
| route | reason |
| ----- | ------ |
| —     | —      |

verdict=pass
```

</details>

## Architecture-trait change?

No.
