### PR TITLE
perf(qwen3, gfx11/gfx12): route Q8 prompts through M16 batched prefill and tiled flash decode (1.65–2.69× PP4K/8K; 7.73–15.88× long-context decode)

### DIFF
--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -13838,6 +13838,73 @@ fn select_generation_route(i: &GenerationRouteInputs) -> GenerationRoute {
     }
 }
 
+#[inline]
+fn llama_qwen3_batched_prefill_eligible(
+    gpu_arch: &str,
+    model_arch: llama::ModelArch,
+    prefill_batched_enabled: bool,
+    quant_q8: bool,
+    has_eviction: bool,
+    token_count: usize,
+) -> bool {
+    model_arch == llama::ModelArch::Qwen3
+        && (gpu_arch.starts_with("gfx11") || gpu_arch == "gfx1201")
+        && prefill_batched_enabled
+        && quant_q8
+        && !has_eviction
+        && token_count >= 4
+}
+
+#[inline]
+fn llama_prefill_sample_seed(mut seed: u32, token_count: usize, temperature: f32) -> u32 {
+    // The legacy sequential prefill sampled after every prompt token. Sampling
+    // at temperature=0 does not advance xorshift32; sampled generation advances
+    // once per token. Batched prefill only samples the final logits, so advance
+    // over the discarded intermediate draws to preserve the final draw + state.
+    if temperature > 1e-6 {
+        for _ in 1..token_count {
+            seed ^= seed << 13;
+            seed ^= seed >> 17;
+            seed ^= seed << 5;
+        }
+    }
+    seed
+}
+
+#[cfg(test)]
+mod llama_batched_prefill_tests {
+    use super::{llama_prefill_sample_seed, llama_qwen3_batched_prefill_eligible};
+    use hipfire_runtime::llama::ModelArch;
+
+    #[test]
+    fn route_stays_inside_validated_qwen3_q8_envelope() {
+        let cases = [
+            ("gfx1100", ModelArch::Qwen3, true, true, false, 256, true),
+            ("gfx1201", ModelArch::Qwen3, true, true, false, 4, true),
+            ("gfx1200", ModelArch::Qwen3, true, true, false, 256, false),
+            ("gfx1100", ModelArch::Llama, true, true, false, 256, false),
+            ("gfx1100", ModelArch::Qwen3, true, false, false, 256, false),
+            ("gfx1100", ModelArch::Qwen3, true, true, true, 256, false),
+            ("gfx1100", ModelArch::Qwen3, true, true, false, 3, false),
+            ("gfx1100", ModelArch::Qwen3, false, true, false, 256, false),
+        ];
+        for (arch, model, enabled, q8, eviction, tokens, expected) in cases {
+            assert_eq!(
+                llama_qwen3_batched_prefill_eligible(arch, model, enabled, q8, eviction, tokens,),
+                expected,
+                "arch={arch} model={model:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn sampled_prefill_preserves_discarded_xorshift_draws() {
+        assert_eq!(llama_prefill_sample_seed(42, 4, 0.0), 42);
+        assert_eq!(llama_prefill_sample_seed(42, 1, 1.0), 42);
+        assert_eq!(llama_prefill_sample_seed(42, 4, 1.0), 476_557_059);
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn generate(
     m: &mut LoadedModel,
@@ -16755,6 +16822,7 @@ fn generate(
         emit_staged_terminal_done(stdout, &pending_done);
     } else {
         // LLaMA path -- multi-turn aware
+        let has_eviction = m.eviction.is_some();
         let ModelState::Llama(b) = m.state.as_mut().unwrap() else {
             unreachable!()
         };
@@ -16764,26 +16832,62 @@ fn generate(
         let kv = &mut b.kv;
 
         let mut rng_state = 42u32;
-        for (i, &tok) in new_tokens.iter().enumerate() {
-            let pos = m.seq_pos + i;
-            let (_, rng) = llama::forward_scratch(
-                gpu, weights, config, tok, pos, kv, scratch, temp, top_p, rng_state, 0, 1.0,
+        let batched_prefill = llama_qwen3_batched_prefill_eligible(
+            &gpu.arch,
+            config.arch,
+            hipfire_runtime::config::get().prefill_batched,
+            kv.quant_q8,
+            has_eviction,
+            new_tokens.len(),
+        );
+        let (mut next_token, sampled_rng) = if batched_prefill {
+            llama::forward_prefill_batch(
+                gpu,
+                weights,
+                config,
+                &new_tokens,
+                m.seq_pos,
+                kv,
+                scratch,
+                None,
             )
             .unwrap();
-            rng_state = rng;
-        }
+            let sample_seed = llama_prefill_sample_seed(rng_state, new_tokens.len(), temp);
+            gpu.sample_top_p(
+                &scratch.logits,
+                &scratch.sample_buf,
+                &scratch.repeat_buf,
+                config.vocab_size,
+                temp,
+                top_p,
+                sample_seed,
+                0,
+                1.0,
+            )
+            .unwrap()
+        } else {
+            for (i, &tok) in new_tokens.iter().enumerate() {
+                let pos = m.seq_pos + i;
+                let (_, rng) = llama::forward_scratch(
+                    gpu, weights, config, tok, pos, kv, scratch, temp, top_p, rng_state, 0, 1.0,
+                )
+                .unwrap();
+                rng_state = rng;
+            }
+            let mut out_bytes = [0u8; 8];
+            gpu.hip
+                .memcpy_dtoh(&mut out_bytes, &scratch.sample_buf.buf)
+                .unwrap();
+            (
+                u32::from_ne_bytes([out_bytes[0], out_bytes[1], out_bytes[2], out_bytes[3]]),
+                u32::from_ne_bytes([out_bytes[4], out_bytes[5], out_bytes[6], out_bytes[7]]),
+            )
+        };
+        rng_state = sampled_rng;
         let this_turn_prompt_len_llama = new_tokens.len();
         m.seq_pos += new_tokens.len();
         m.conversation_tokens.extend_from_slice(&new_tokens);
         let ngram_scope_start_llama = m.conversation_tokens.len() - this_turn_prompt_len_llama;
-
-        let mut out_bytes = [0u8; 8];
-        gpu.hip
-            .memcpy_dtoh(&mut out_bytes, &scratch.sample_buf.buf)
-            .unwrap();
-        let mut next_token =
-            u32::from_ne_bytes([out_bytes[0], out_bytes[1], out_bytes[2], out_bytes[3]]);
-        rng_state = u32::from_ne_bytes([out_bytes[4], out_bytes[5], out_bytes[6], out_bytes[7]]);
         // Prefill ends here: prompt is processed AND first token is ready (D2H
         // sync is the user-observable "time to first token" boundary). Decode
         // below measures the pure forward+sample steady-state.

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -1762,7 +1762,12 @@ pub const PREFILL_MAX_BATCH: usize = 256;
 pub fn is_batchable_la(dt: DType, arch: &str) -> bool {
     let always_ok = matches!(
         dt,
-        DType::MQ4G256 | DType::HFQ4G256 | DType::MQ6G256 | DType::HFQ6G256 | DType::Q8_0
+        DType::MQ4G256
+            | DType::HFQ4G256
+            | DType::HFQ4G128
+            | DType::MQ6G256
+            | DType::HFQ6G256
+            | DType::Q8_0
     );
     if always_ok {
         return true;
@@ -2268,6 +2273,21 @@ pub fn forward_prefill_batch_chunk_captured(
     )
 }
 
+#[inline]
+fn q8_prefill_family_eligible(
+    gpu_arch: &str,
+    model_arch: ModelArch,
+    quant_q8: bool,
+    is_tree: bool,
+    batch_size: usize,
+) -> bool {
+    model_arch == ModelArch::Qwen3
+        && (gpu_arch.starts_with("gfx11") || gpu_arch == "gfx1201")
+        && quant_q8
+        && !is_tree
+        && batch_size > 1
+}
+
 #[allow(clippy::too_many_arguments)]
 fn forward_prefill_chunk(
     gpu: &mut Gpu,
@@ -2317,7 +2337,7 @@ fn forward_prefill_chunk(
     // 1. Embed N tokens into pbs.x_batch.
     if matches!(
         weights.embd_format,
-        EmbeddingFormat::HFQ4G256 | EmbeddingFormat::Q8_0
+        EmbeddingFormat::HFQ4G256 | EmbeddingFormat::HFQ4G128 | EmbeddingFormat::Q8_0
     ) {
         if !pre_uploaded {
             let tokens_host: Vec<i32> = tokens.iter().map(|&t| t as i32).collect();
@@ -2327,6 +2347,13 @@ fn forward_prefill_chunk(
         }
         match weights.embd_format {
             EmbeddingFormat::HFQ4G256 => gpu.embedding_lookup_hfq4g256_batched(
+                &weights.token_embd,
+                &pbs.x_batch,
+                &pbs.tokens,
+                n,
+                dim,
+            )?,
+            EmbeddingFormat::HFQ4G128 => gpu.embedding_lookup_hfq4g128_batched(
                 &weights.token_embd,
                 &pbs.x_batch,
                 &pbs.tokens,
@@ -2345,16 +2372,15 @@ fn forward_prefill_chunk(
     } else {
         for (i, &tok) in tokens.iter().enumerate() {
             match weights.embd_format {
-                EmbeddingFormat::HFQ4G128 => {
-                    gpu.embedding_lookup_hfq4g128(&weights.token_embd, &s.x, tok, dim)?
-                }
                 EmbeddingFormat::Q4K => {
                     gpu.embedding_lookup_q4k(&weights.token_embd, &s.x, tok, dim)?
                 }
                 EmbeddingFormat::F32 => {
                     gpu.embedding_lookup(&weights.token_embd, &s.x, tok, dim)?
                 }
-                EmbeddingFormat::HFQ4G256 | EmbeddingFormat::Q8_0 => unreachable!(),
+                EmbeddingFormat::HFQ4G256 | EmbeddingFormat::HFQ4G128 | EmbeddingFormat::Q8_0 => {
+                    unreachable!()
+                }
             }
             gpu.hip.memcpy_dtod_at(
                 &pbs.x_batch.buf,
@@ -2379,6 +2405,14 @@ fn forward_prefill_chunk(
     } else {
         start_pos + n
     };
+    let q8_family_eligible = q8_prefill_family_eligible(
+        &gpu.arch,
+        config.arch,
+        kv_cache.quant_q8,
+        tree_mask.is_some(),
+        n,
+    );
+    let q8_attn_ctx = q8_family_eligible.then(|| DispatchCtx::new(gpu));
 
     // 2. Per-layer loop.
     for layer_idx in 0..config.n_layers {
@@ -2414,9 +2448,40 @@ fn forward_prefill_chunk(
         }
 
         let qkv_is_q8 = matches!(layer.wq.gpu_dtype, DType::Q8_0);
+        let qkv_is_hfq4g128 = matches!(layer.wq.gpu_dtype, DType::HFQ4G128);
 
         // 3-way fused QKV projection.
-        if qkv_is_6bit {
+        if qkv_is_hfq4g128 {
+            debug_assert!(
+                matches!(layer.wk.gpu_dtype, DType::HFQ4G128)
+                    && matches!(layer.wv.gpu_dtype, DType::HFQ4G128),
+                "llama HFQ4G128 QKV batch requires one uniform wire layout",
+            );
+            gpu.gemm_hfq4g128(
+                &layer.wq.buf,
+                &pbs.x_rot_batch,
+                &pbs.fa_q_batch,
+                layer.wq.m,
+                layer.wq.k,
+                n,
+            )?;
+            gpu.gemm_hfq4g128(
+                &layer.wk.buf,
+                &pbs.x_rot_batch,
+                &pbs.fa_k_batch,
+                layer.wk.m,
+                layer.wk.k,
+                n,
+            )?;
+            gpu.gemm_hfq4g128(
+                &layer.wv.buf,
+                &pbs.x_rot_batch,
+                &pbs.fa_v_batch,
+                layer.wv.m,
+                layer.wv.k,
+                n,
+            )?;
+        } else if qkv_is_6bit {
             gpu.gemm_qkv_hfq6g256(
                 &layer.wq.buf,
                 &layer.wk.buf,
@@ -2612,7 +2677,7 @@ fn forward_prefill_chunk(
                 config.head_dim,
                 n,
             )?;
-        } else {
+        } else if !q8_family_eligible {
             gpu.kv_cache_write_q8_0_batched(
                 &kv_cache.k_gpu[layer_idx],
                 &pbs.fa_k_batch,
@@ -2629,6 +2694,12 @@ fn forward_prefill_chunk(
                 config.head_dim,
                 n,
             )?;
+        } else {
+            debug_assert!(kv_cache.quant_q8);
+            // Standard causal Q8 prefill is paired with its attention launch
+            // below through `AttentionFamily`; that entry point owns K/V writes.
+            // A singleton tail stays on the legacy path above because the
+            // family treats batch_size=1 as decode and expects decode params.
         }
 
         // Batched flash attention (causal, or tree-masked when `tree_mask` is
@@ -2707,6 +2778,48 @@ fn forward_prefill_chunk(
                 n,
                 &pbs.flash_partials,
             )?;
+        } else if q8_family_eligible {
+            debug_assert!(kv_cache.quant_q8);
+            // Ordinary causal Q8 prefill now shares the same paired dispatch
+            // used by Qwen3.5, enabling the existing gfx11/gfx1201 M16 kernel.
+            // Tree verify and singleton tails remain on their legacy paths.
+            let plan = KvTierPlan::derive(KvTierInputs {
+                pos: start_pos,
+                capture_mode: gpu.graphs.capture_mode,
+                batch_size: n,
+                is_tree: false,
+                ..kv_cache.tier_inputs()
+            })
+            .map_err(|e| hip_bridge::HipError::new(0, &e.to_string()))?;
+            let io = AttnParams {
+                q: &pbs.fa_q_batch,
+                k: &pbs.fa_k_batch,
+                v: &pbs.fa_v_batch,
+                k_cache: &kv_cache.k_gpu[layer_idx],
+                v_cache: &kv_cache.v_gpu[layer_idx],
+                k_scales: None,
+                v_scales: None,
+                pos_buf: &s.pos_buf,
+                pos: start_pos,
+                positions: Some(&pbs.positions),
+                n_heads: config.n_heads,
+                n_kv_heads: config.n_kv_heads,
+                head_dim: config.head_dim,
+                physical_cap: kv_cache.physical_cap,
+                batch_size: n,
+                max_ctx_len,
+                flash_partials: Some(&pbs.flash_partials),
+                givens_cos: kv_cache.givens_cos.as_ref(),
+                givens_sin: kv_cache.givens_sin.as_ref(),
+                tree_bias: None,
+                block_start: 0,
+                block_cols: 0,
+                output_gate: None,
+                output: &pbs.fa_attn_out_batch,
+            };
+            attention_family()
+                .run_attention(q8_attn_ctx.as_ref().unwrap(), gpu, &plan, &io)
+                .map_err(|e| hip_bridge::HipError::new(0, &e.to_string()))?;
         } else if max_ctx_len > LDS_CTX_LIMIT {
             // Tree-masked verify is not yet validated in the long-context Q8
             // regime (ctx > LDS_CTX_LIMIT). The batched-masked kernel below DOES
@@ -2767,6 +2880,7 @@ fn forward_prefill_chunk(
         let wo_is_mq3 = matches!(layer.wo.gpu_dtype, DType::MQ3G256);
         let wo_is_fp4 = matches!(layer.wo.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
         let wo_is_q8 = matches!(layer.wo.gpu_dtype, DType::Q8_0);
+        let wo_is_hfq4g128 = matches!(layer.wo.gpu_dtype, DType::HFQ4G128);
         let wo_input = if wo_is_mq {
             // F2: AWQ-aware rotate for wo (FullAttention output projection) input.
             rotate_x_mq_batched_for(
@@ -2781,7 +2895,21 @@ fn forward_prefill_chunk(
         } else {
             &pbs.fa_attn_out_batch
         };
-        if wo_is_6bit {
+        if wo_is_hfq4g128 {
+            // The generic G128 GEMM has overwrite semantics. Reuse x_rot_batch
+            // as a dead-after-QKV temporary, then add into the residual stream.
+            let projected = pbs.x_rot_batch.sub_offset(0, n * layer.wo.m);
+            gpu.gemm_hfq4g128(
+                &layer.wo.buf,
+                wo_input,
+                &projected,
+                layer.wo.m,
+                layer.wo.k,
+                n,
+            )?;
+            let x_n = pbs.x_batch.sub_offset(0, n * layer.wo.m);
+            gpu.add_inplace_f32(&x_n, &projected)?;
+        } else if wo_is_6bit {
             gpu.gemm_hfq6g256_residual(
                 &layer.wo.buf,
                 wo_input,
@@ -2844,6 +2972,7 @@ fn forward_prefill_chunk(
         let ffn_is_mq3 = matches!(layer.w_gate.gpu_dtype, DType::MQ3G256);
         let ffn_is_fp4 = matches!(layer.w_gate.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
         let ffn_is_q8 = matches!(layer.w_gate.gpu_dtype, DType::Q8_0);
+        let ffn_is_hfq4g128 = matches!(layer.w_gate.gpu_dtype, DType::HFQ4G128);
         if ffn_is_mq {
             gpu.fused_rmsnorm_rotate_mq_batched(
                 &pbs.x_batch,
@@ -2863,7 +2992,28 @@ fn forward_prefill_chunk(
                 config.norm_eps,
             )?;
         }
-        if ffn_is_6bit {
+        if ffn_is_hfq4g128 {
+            debug_assert!(
+                matches!(layer.w_up.gpu_dtype, DType::HFQ4G128),
+                "llama HFQ4G128 gate/up batch requires one uniform wire layout",
+            );
+            gpu.gemm_hfq4g128(
+                &layer.w_gate.buf,
+                &pbs.x_rot_batch,
+                &pbs.gate_ffn_batch,
+                layer.w_gate.m,
+                layer.w_gate.k,
+                n,
+            )?;
+            gpu.gemm_hfq4g128(
+                &layer.w_up.buf,
+                &pbs.x_rot_batch,
+                &pbs.up_batch,
+                layer.w_up.m,
+                layer.w_up.k,
+                n,
+            )?;
+        } else if ffn_is_6bit {
             gpu.gemm_gate_up_hfq6g256(
                 &layer.w_gate.buf,
                 &layer.w_up.buf,
@@ -2953,6 +3103,7 @@ fn forward_prefill_chunk(
         let w_down_is_mq3 = matches!(layer.w_down.gpu_dtype, DType::MQ3G256);
         let w_down_is_fp4 = matches!(layer.w_down.gpu_dtype, DType::HFP4G32 | DType::MFP4G32);
         let w_down_is_q8 = matches!(layer.w_down.gpu_dtype, DType::Q8_0);
+        let w_down_is_hfq4g128 = matches!(layer.w_down.gpu_dtype, DType::HFQ4G128);
         if w_down_is_mq {
             // F2: AWQ-aware silu_mul+rotate for w_down input.
             fused_silu_mul_rotate_mq_batched_for(
@@ -2967,7 +3118,21 @@ fn forward_prefill_chunk(
         } else {
             gpu.silu_mul_f32(&pbs.gate_ffn_batch, &pbs.up_batch, &pbs.ffn_hidden_batch)?;
         }
-        if w_down_is_6bit {
+        if w_down_is_hfq4g128 {
+            // gate_ffn_batch is dead after silu_mul and is larger than the
+            // dim-wide down projection output, so it is a safe residual temp.
+            let projected = pbs.gate_ffn_batch.sub_offset(0, n * layer.w_down.m);
+            gpu.gemm_hfq4g128(
+                &layer.w_down.buf,
+                &pbs.ffn_hidden_batch,
+                &projected,
+                layer.w_down.m,
+                layer.w_down.k,
+                n,
+            )?;
+            let x_n = pbs.x_batch.sub_offset(0, n * layer.w_down.m);
+            gpu.add_inplace_f32(&x_n, &projected)?;
+        } else if w_down_is_6bit {
             gpu.gemm_hfq6g256_residual(
                 &layer.w_down.buf,
                 &pbs.ffn_hidden_batch,
@@ -11019,6 +11184,7 @@ mod tests {
             "gfx900", "gfx906", "gfx1010", "gfx1030", "gfx1100", "gfx1200", "gfx942",
         ] {
             assert!(is_batchable_la(DType::HFQ4G256, arch));
+            assert!(is_batchable_la(DType::HFQ4G128, arch));
             assert!(is_batchable_la(DType::MQ4G256, arch));
             assert!(is_batchable_la(DType::HFQ6G256, arch));
             assert!(is_batchable_la(DType::MQ6G256, arch));
@@ -11176,6 +11342,20 @@ mod tests {
         }
     }
     // ── KvCache::tier_inputs() accessor pin test ─────────────────
+
+    #[test]
+    fn q8_prefill_family_stays_inside_validated_qwen3_arch_envelope() {
+        let eligible =
+            |arch, model, q8, tree, batch| q8_prefill_family_eligible(arch, model, q8, tree, batch);
+        assert!(eligible("gfx1100", ModelArch::Qwen3, true, false, 256));
+        assert!(eligible("gfx1201", ModelArch::Qwen3, true, false, 2));
+        assert!(!eligible("gfx1030", ModelArch::Qwen3, true, false, 256));
+        assert!(!eligible("gfx1200", ModelArch::Qwen3, true, false, 256));
+        assert!(!eligible("gfx1100", ModelArch::Llama, true, false, 256));
+        assert!(!eligible("gfx1100", ModelArch::Qwen3, true, true, 256));
+        assert!(!eligible("gfx1100", ModelArch::Qwen3, true, false, 1));
+        assert!(!eligible("gfx1100", ModelArch::Qwen3, false, false, 256));
+    }
 
     #[test]
     fn tier_inputs_q8_is_byte_identical_to_legacy_literal() {

--- a/crates/hipfire-runtime/src/llama.rs
+++ b/crates/hipfire-runtime/src/llama.rs
@@ -3505,8 +3505,8 @@ impl ForwardScratch {
     }
 
     /// `max_seq` MUST be ≥ the KV cache's `physical_cap` — the flash-decoding
-    /// partials buffer is sized `n_heads × ceil(max_seq/128) × (2 + head_dim)`
-    /// and the asym/flash attends index it by `ceil(physical_cap/128)` tiles.
+    /// partials buffer is sized from the architecture/shape-selected Q8 tile
+    /// and must cover every tile addressable by the cache.
     /// (Was hardcoded to 16 chunks = max_seq 2048; running at a larger cap
     /// overflowed it → silent OOB / garbage on the flash-attention path.)
     pub fn new_with_max_seq(
@@ -3518,10 +3518,16 @@ impl ForwardScratch {
         let q_dim = config.n_heads * config.head_dim;
         let kv_dim = config.n_kv_heads * config.head_dim;
         // Flash-decoding partials: n_heads × max_chunks × (2 + head_dim) floats.
-        // TILE_SIZE = 128 matches the flash attend kernels (attention.rs).
-        let max_chunks = max_seq.div_ceil(128);
-        let partial_stride = 2 + config.head_dim;
-        let partials_size = config.n_heads * max_chunks * partial_stride;
+        // The gfx1100 Q8 kernel uses tile32 (and selected gfx12 shapes tile16),
+        // so a historical fixed tile128 allocation under-sized this buffer by
+        // up to 8x and faulted as soon as llama-family Q8 decode selected flash.
+        let partials_size = llama_flash_partials_len(
+            &gpu.arch,
+            config.n_heads,
+            config.n_kv_heads,
+            config.head_dim,
+            max_seq,
+        );
         Ok(Self {
             x: gpu.alloc_tensor(&[dim], DType::F32)?,
             tmp: gpu.alloc_tensor(&[dim], DType::F32)?,
@@ -3644,12 +3650,39 @@ fn llama_forward_lowered_enabled() -> bool {
     })
 }
 
-/// KV-cache write + single-token attention, extracted verbatim from the hand
-/// [`forward_scratch_layers`] 7-way KV-tier ladder so the lowered path (N5
-/// Phase A3a) can reuse it unchanged. The hand body keeps its own inline copy
-/// (left untouched as the byte-exact reference). Phase A3b replaces this
-/// helper's body with `attention_family()` + `KvTierPlan`; until then it is a
-/// pure extraction (same kernels, same order → byte-identical).
+#[inline]
+fn llama_attention_flash_mode_for(mode: &str, gpu_arch: &str) -> usize {
+    match mode {
+        "never" | "0" | "off" => 0,
+        "always" | "2" | "force" => 2,
+        _ if gpu_arch.starts_with("gfx11") || gpu_arch.starts_with("gfx12") => 2,
+        _ => 1,
+    }
+}
+
+#[inline]
+fn llama_attention_flash_mode(gpu_arch: &str) -> usize {
+    llama_attention_flash_mode_for(crate::config::get().attention_flash_mode.as_str(), gpu_arch)
+}
+
+#[inline]
+fn llama_flash_partials_len(
+    gpu_arch: &str,
+    n_heads: usize,
+    n_kv_heads: usize,
+    head_dim: usize,
+    max_seq: usize,
+) -> usize {
+    let flash_tile = rdna_compute::attention::q8_flash_tile_size(
+        gpu_arch, n_heads, n_kv_heads, head_dim, max_seq,
+    );
+    n_heads * max_seq.div_ceil(flash_tile) * (2 + head_dim)
+}
+
+/// KV-cache write + single-token attention for the lowered decode path.
+/// Asym and Q8 tiers use the paired `AttentionFamily` plan; legacy cache
+/// formats retain the hand ladder below. The hand body keeps its own inline
+/// copy as the byte-exact `HIPFIRE_FORWARD_LOWERED=0` reference.
 fn llama_kv_write_attend(
     gpu: &mut Gpu,
     kv_cache: &KvCache,
@@ -3661,15 +3694,15 @@ fn llama_kv_write_attend(
     head_dim: usize,
     kv_dim: usize,
 ) -> HipResult<()> {
-    if kv_cache.quant_asym4 || kv_cache.quant_asym3 || kv_cache.quant_asym2 {
-        // Asym/Givens KV: this hand ladder has no asym kernels, so route
-        // KV-write + flash-attend through the dispatch attention family (the
-        // same path qwen35 uses). tier_inputs() classifies the tier from the
-        // cache's quant flags; run_attention does both write and single-token
-        // attend. (This is the Phase A3b migration the helper doc anticipated.)
+    if kv_cache.quant_asym4 || kv_cache.quant_asym3 || kv_cache.quant_asym2 || kv_cache.quant_q8 {
+        // Route tiers with an established paired plan through the same family
+        // used by qwen35. In particular, Q8 switches from the single-block-per-
+        // head kernel to tiled flash attention according to the shared mode
+        // policy instead of leaving small-head Qwen3 models under-parallelized.
         let ctx = DispatchCtx::new(gpu);
         let plan = KvTierPlan::derive(KvTierInputs {
             pos,
+            flash_mode: llama_attention_flash_mode(&gpu.arch),
             ..kv_cache.tier_inputs()
         })
         .map_err(|e| hip_bridge::HipError::new(0, &e.to_string()))?;
@@ -3923,6 +3956,7 @@ fn forward_scratch_layers_lowered(
         config,
         scratch,
         kv_cache: &*kv_cache,
+        flash_mode: llama_attention_flash_mode(&gpu.arch),
         knobs,
         pos,
     };
@@ -3969,6 +4003,7 @@ struct LlamaDense<'a> {
     config: &'a LlamaConfig,
     scratch: &'a ForwardScratch,
     kv_cache: &'a KvCache,
+    flash_mode: usize,
     knobs: crate::arch_spec::DenseKnobs,
     pos: usize,
 }
@@ -4043,6 +4078,7 @@ impl crate::arch_spec::DenseArch for LlamaDense<'_> {
         let c = self.config;
         let plan = KvTierPlan::derive(KvTierInputs {
             pos: self.pos,
+            flash_mode: self.flash_mode,
             ..kv.tier_inputs()
         })
         .map_err(|e| hip_bridge::HipError::new(0, &e.to_string()))?;
@@ -10864,6 +10900,27 @@ mod tests {
     // state between a reset and the draw, breaking determinism). Serialize all
     // RNG-touching `sample_full_dist` tests behind this mutex.
     static RNG_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn qwen3_flash_mode_policy_matches_rdna_generation() {
+        assert_eq!(llama_attention_flash_mode_for("auto", "gfx1100"), 2);
+        assert_eq!(llama_attention_flash_mode_for("auto", "gfx1201"), 2);
+        assert_eq!(llama_attention_flash_mode_for("auto", "gfx1030"), 1);
+        assert_eq!(llama_attention_flash_mode_for("never", "gfx1100"), 0);
+        assert_eq!(llama_attention_flash_mode_for("always", "gfx1030"), 2);
+    }
+
+    #[test]
+    fn qwen3_flash_partials_follow_selected_q8_tile() {
+        let max_seq = 32_768;
+        let expected_tile =
+            rdna_compute::attention::q8_flash_tile_size("gfx1100", 16, 8, 128, max_seq);
+        assert_eq!(expected_tile, 32);
+        assert_eq!(
+            llama_flash_partials_len("gfx1100", 16, 8, 128, max_seq),
+            16 * max_seq.div_ceil(expected_tile) * 130
+        );
+    }
 
     // hunt3 M-B (FinalFix): greedy argmax must drop NaN like the GPU kernel
     // (argmax.hip `data[i] > lmax`), never selecting a NaN-indexed token and

--- a/crates/rdna-compute/examples/channel_test_hfq4g128_batched.rs
+++ b/crates/rdna-compute/examples/channel_test_hfq4g128_batched.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! Element-wise channel test for the HFQ4-G128 batched embedding + GEMM path.
+
+use rdna_compute::{DType, Gpu};
+
+const GROUP: usize = 128;
+const GROUP_BYTES: usize = 72;
+
+fn append_group(dst: &mut Vec<u8>, scale: f32, zero: f32, codes: &[u8; GROUP]) {
+    dst.extend_from_slice(&scale.to_le_bytes());
+    dst.extend_from_slice(&zero.to_le_bytes());
+    for pair in codes.chunks_exact(2) {
+        dst.push(pair[0] | (pair[1] << 4));
+    }
+}
+
+fn main() {
+    let mut gpu = Gpu::init().expect("GPU init");
+
+    // Embedding: vary token, group and element independently so row/group
+    // swaps cannot hide behind invariant synthetic data.
+    let vocab = 4usize;
+    let dim = 256usize;
+    let token_ids = [3i32, 1, 0, 2];
+    let mut table = Vec::with_capacity(vocab * (dim / GROUP) * GROUP_BYTES);
+    let mut reference = vec![0.0f32; token_ids.len() * dim];
+    for token in 0..vocab {
+        for group in 0..(dim / GROUP) {
+            let scale = 0.03125 * (1 + token + group) as f32;
+            let zero = -0.125 * (1 + group) as f32;
+            let mut codes = [0u8; GROUP];
+            for (within, code) in codes.iter_mut().enumerate() {
+                *code = ((token * 7 + group * 5 + within * 3) & 15) as u8;
+            }
+            append_group(&mut table, scale, zero, &codes);
+        }
+    }
+    for (batch, &token) in token_ids.iter().enumerate() {
+        for elem in 0..dim {
+            let group = elem / GROUP;
+            let within = elem % GROUP;
+            let scale = 0.03125 * (1 + token as usize + group) as f32;
+            let zero = -0.125 * (1 + group) as f32;
+            let code = ((token as usize * 7 + group * 5 + within * 3) & 15) as f32;
+            reference[batch * dim + elem] = scale * code + zero;
+        }
+    }
+    let token_bytes: Vec<u8> = token_ids
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect();
+    let table_gpu = gpu
+        .upload_raw(&table, &[table.len()])
+        .expect("table upload");
+    let tokens_gpu = gpu
+        .upload_raw(&token_bytes, &[token_bytes.len()])
+        .expect("token upload");
+    let output_gpu = gpu
+        .zeros(&[token_ids.len() * dim], DType::F32)
+        .expect("output alloc");
+    gpu.embedding_lookup_hfq4g128_batched(
+        &table_gpu,
+        &output_gpu,
+        &tokens_gpu,
+        token_ids.len(),
+        dim,
+    )
+    .expect("batched embedding");
+    let output = gpu.download_f32(&output_gpu).expect("embedding download");
+    let embed_max = output
+        .iter()
+        .zip(&reference)
+        .map(|(got, want)| (got - want).abs())
+        .fold(0.0f32, f32::max);
+    assert!(embed_max <= 1.0e-6, "embedding max abs error {embed_max}");
+
+    // GEMM: row- and batch-varying values expose output-lane or batch-tile
+    // permutations. This is the exact kernel admitted by llama batched prefill.
+    let m = 32usize;
+    let k = 256usize;
+    let batch_size = 8usize;
+    let mut weights = Vec::with_capacity(m * (k / GROUP) * GROUP_BYTES);
+    let mut dequant = vec![0.0f32; m * k];
+    for row in 0..m {
+        for group in 0..(k / GROUP) {
+            let scale = 0.0025 * (1 + row % 7 + group) as f32;
+            let zero = -0.01 * (1 + row % 3) as f32;
+            let mut codes = [0u8; GROUP];
+            for (within, code) in codes.iter_mut().enumerate() {
+                *code = ((row * 11 + group * 5 + within * 7) & 15) as u8;
+                dequant[row * k + group * GROUP + within] = scale * *code as f32 + zero;
+            }
+            append_group(&mut weights, scale, zero, &codes);
+        }
+    }
+    let x: Vec<f32> = (0..batch_size * k)
+        .map(|index| {
+            let batch = index / k;
+            let col = index % k;
+            ((batch * 13 + col * 3) % 29) as f32 * 0.001 - 0.014
+        })
+        .collect();
+    let mut gemm_reference = vec![0.0f32; batch_size * m];
+    for batch in 0..batch_size {
+        for row in 0..m {
+            gemm_reference[batch * m + row] = (0..k)
+                .map(|col| dequant[row * k + col] * x[batch * k + col])
+                .sum();
+        }
+    }
+    let weights_gpu = gpu
+        .upload_raw(&weights, &[weights.len()])
+        .expect("weight upload");
+    let x_gpu = gpu.upload_f32(&x, &[batch_size, k]).expect("x upload");
+    let y_gpu = gpu.zeros(&[batch_size, m], DType::F32).expect("y alloc");
+    gpu.gemm_hfq4g128(&weights_gpu, &x_gpu, &y_gpu, m, k, batch_size)
+        .expect("G128 GEMM");
+    let y = gpu.download_f32(&y_gpu).expect("GEMM download");
+    let gemm_max = y
+        .iter()
+        .zip(&gemm_reference)
+        .map(|(got, want)| (got - want).abs())
+        .fold(0.0f32, f32::max);
+    assert!(gemm_max <= 2.0e-5, "GEMM max abs error {gemm_max}");
+
+    println!("PASS embedding_max_abs={embed_max:.3e} gemm_max_abs={gemm_max:.3e}");
+}

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -2661,6 +2661,10 @@ impl Gpu {
             kernels::EMBEDDING_HFQ4G128_SRC.to_string(),
         ));
         specs.push((
+            "embedding_hfq4g128_batched",
+            kernels::EMBEDDING_HFQ4G128_BATCHED_SRC.to_string(),
+        ));
+        specs.push((
             "embedding_hfq4g256_batched",
             kernels::EMBEDDING_HFQ4G256_BATCHED_SRC.to_string(),
         ));

--- a/crates/rdna-compute/src/embedding.rs
+++ b/crates/rdna-compute/src/embedding.rs
@@ -325,4 +325,49 @@ impl Gpu {
             )
         }
     }
+
+    /// Batched HFQ4-G128 embedding lookup. `output` is `[n × dim]` row-major
+    /// and `token_ids` is a device-resident i32-compatible buffer.
+    pub fn embedding_lookup_hfq4g128_batched(
+        &mut self,
+        table: &GpuTensor,
+        output: &GpuTensor,
+        token_ids: &GpuTensor,
+        n: usize,
+        dim: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_kernel(
+            "embedding_hfq4g128_batched",
+            kernels::EMBEDDING_HFQ4G128_BATCHED_SRC,
+            "embedding_hfq4g128_batched",
+        )?;
+
+        let mut tp = table.buf.as_ptr();
+        let mut op = output.buf.as_ptr();
+        let mut tidp = token_ids.buf.as_ptr();
+        let mut d = dim as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut tp as *mut _ as *mut c_void,
+            &mut op as *mut _ as *mut c_void,
+            &mut tidp as *mut _ as *mut c_void,
+            &mut d as *mut _ as *mut c_void,
+        ];
+
+        self.launch_maybe_blob(
+            "embedding_hfq4g128_batched",
+            [n as u32, 1, 1],
+            [256, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(tp);
+                b.push_ptr(op);
+                b.push_ptr(tidp);
+                b.push_i32(d);
+                b
+            },
+        )
+    }
 }

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -4617,6 +4617,11 @@ pub const DSPARK_STAGE_KV_SRC: &str = include_str!("../../../kernels/src/dspark_
 pub const EMBEDDING_HFQ4G128_SRC: &str =
     include_str!("../../../kernels/src/embedding_hfq4g128.hip");
 
+/// Batched HFQ4-G128 embedding lookup. Mirrors the G256 device-token-id
+/// contract while using the 72-byte / 128-element wire layout.
+pub const EMBEDDING_HFQ4G128_BATCHED_SRC: &str =
+    include_str!("../../../kernels/src/embedding_hfq4g128_batched.hip");
+
 /// Q4_LUT GEMV: 4-bit with LDS codebook lookup.
 /// Block: f16 codebook[16] (32 bytes) + u8 quants[16] (16 bytes) = 48 bytes per 32 elements.
 /// Dequant: nibble → LDS[nibble] → f16 → FMA. No scale arithmetic per element.

--- a/kernels/src/embedding_hfq4g128_batched.hip
+++ b/kernels/src/embedding_hfq4g128_batched.hip
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+
+// Batched HFQ4-G128 embedding lookup. Layout per group:
+// [f32 scale][f32 zero][64 B packed nibbles] = 72 B / 128 elements.
+// One block owns one token row; device-resident token ids keep graph capture
+// semantics identical to the existing HFQ4-G256 batched embedding kernel.
+extern "C" __global__ void embedding_hfq4g128_batched(
+    const unsigned char* __restrict__ table,
+    float* __restrict__ output,
+    const int* __restrict__ token_ids,
+    int dim
+) {
+    const int batch_idx = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int groups_per_row = dim / 128;
+    const int bytes_per_row = groups_per_row * 72;
+    const int token_id = token_ids[batch_idx];
+    const unsigned char* row = table + (size_t)token_id * bytes_per_row;
+    float* out_row = output + (size_t)batch_idx * dim;
+
+    for (int elem = tid; elem < dim; elem += blockDim.x) {
+        const int group = elem / 128;
+        const int within = elem % 128;
+        const unsigned char* gptr = row + group * 72;
+        const float scale = __builtin_bit_cast(float, *(const unsigned int*)(gptr));
+        const float zero = __builtin_bit_cast(float, *(const unsigned int*)(gptr + 4));
+        const unsigned char packed = gptr[8 + within / 2];
+        const int nibble = (within & 1) == 0 ? (packed & 0xF) : (packed >> 4);
+        out_row[elem] = scale * (float)nibble + zero;
+    }
+}


### PR DESCRIPTION
## Summary

This PR routes eligible dense Qwen3 Q8 prompts on gfx11/gfx12 through production batched prefill and the existing M16 attention family, adds the missing HFQ4G128 batched embedding path, and routes Q8 single-token attention through tiled flash decode. It retains the existing fallbacks for eviction, tree/speculative verification, singleton tails, non-Q8 KV, unsupported architectures, and explicitly disabled flash/prefill modes.

The two changes are split into independently reviewable commits:

1. `397d193b` — batched Q8 prefill, HFQ4G128 embedding/GEMM wiring, and production daemon routing.
2. `db4e31f8` — tiled Q8 flash decode and architecture/shape-correct partial-buffer sizing, including the tile32 rollover/OOB fix.

## Which crate(s) does this touch?

- [x] `kernels/` (HIP source)
- [x] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [x] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [ ] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template — touch only when refining the new-arch reference)
- [ ] `crates/hipfire-quantize`
- [x] examples / daemon
- [ ] docs / CI / scripts

## Performance

Fresh-process Qwen3-8B prefill medians:

| GPU | Context | Baseline | Candidate | Speedup |
|---|---:|---:|---:|---:|
| R9700 gfx1201 | PP4K | 3275 ms | 1988 ms | 1.650× |
| R9700 gfx1201 | PP8K | 12597 ms | 5706 ms | 2.207× |
| W7900 gfx1100 | PP4K | 3274 ms | 1918 ms | 1.707× |
| W7900 gfx1100 | PP8K | 14168 ms | 5261 ms | 2.693× |

Exploratory R9700 PP4K model-size coverage:

| Qwen3 model | Baseline | Candidate | Speedup |
|---|---:|---:|---:|
| 0.6B | 73509 ms | 73875 ms | 0.995× |
| 4B | 2778 ms | 1501 ms | 1.851× |
| 8B | 3275 ms | 1988 ms | 1.650× |
| 14B | 5330 ms | 3354 ms | 1.589× |
| 32B | 13441 ms | 8833 ms | 1.522× |

The 0.6B prefill result is neutral and is not claimed as an M16 win.

W7900 gfx1100 Qwen3-0.6B Q8 tiled-decode medians, 16-token greedy, three fresh processes per side:

| Context | Legacy Q8 decode | Tiled Q8 decode | Speedup |
|---:|---:|---:|---:|
| 3691 | 27.9 tok/s | 215.8 tok/s | 7.73× |
| 7772 | 14.1 tok/s | 170.5 tok/s | 12.09× |
| 14510 | 7.8 tok/s | 123.9 tok/s | 15.88× |

All six short greedy matrices were byte-identical. Prompt MD5s: `57ab3be0ab126b0712e614ed7c91959d`, `8a7d32d9b26bbe36a8cf0090b56b5d10`, `485efd2a28b9f2f849bcdc063a2ce498`. Candidate daemon MD5: `1eb2084a28e5adcee257ced1b2263459`. Model MD5: `0d1055bf8f9492df2e2374d0e8bf787f`.

The corrected tile32 partial allocation adds 6.09 MiB at `max_seq=32768` versus the previous undersized tile128 assumption.

## Correctness

- HFQ4G128 batched embedding channel test: max abs error `0`.
- HFQ4G128 batched GEMM channel test: max abs error `7.451e-9`.
- R9700 401-token sequential/batched argmax: matched for Qwen3 0.6B, 4B, 8B, 14B, and 32B.
- Direct 16K, 16Q/8KV/128D attention parity: cosine `1.000000000`, relative L2 `2.104388e-5`, max abs `2.718e-4` versus legacy Q8 attention.
- Qwen3-8B production JSONL greedy and temperature-1 fixtures were byte-identical across sequential/batched routes on both gfx1100 and gfx1201 for the recorded fixture.
- A same-device clean-commit Qwen3.5-9B regression probe on W7900 measured baseline `106.1/105.9/106.0` tok/s and candidate `105.9/105.6/106.0` tok/s; medians `106.0 → 105.9` (−0.09%, measurement-equivalent). This is the appropriate A/B for this W7900; the repository's gfx1100 absolute floor was recorded on a faster 7900 XTX.

### Long-context quality observation

A 20-item, temperature-0, 128-token Qwen3 matrix on W7900 completed for 0.6B, 4B, 8B, 14B, and 32B without HIP faults or replacement characters. The 0.6B artifact showed six whitespace-only 128-token outputs and one repeated-sentence attractor; the four larger models did not show that pattern.

Targeted 0.6B A/B excluded the new tiled-decode route as the cause: task 02 produced the same 128 newline tokens with `HIPFIRE_ATTN_FLASH=auto` and `never`, and task 14's first 32 tokens were byte-identical across those paths, including the repeated sentence. A length sweep was non-monotonic (16K whitespace-only, 20K normal text, 24K/28K whitespace-only), which does not match a fixed cache/tile rollover boundary. The pre-M16 beta control did not complete its 28K prefill within a 30-minute timeout, so this observation is reported as a limitation rather than claimed to be fully attributed.

## Test plan

- [x] `./scripts/no-gpu-ci.sh` passes (previous full run on this branch; included daemon fixture repair, 197 Redline tests, and env/docs drift checks)
- [x] `cargo build --release --workspace --features deltanet` clean
- [x] `cargo test --lib --workspace --features deltanet` passes
- [x] Change-gate planning and execution attempted against `origin/beta@e2f7dd1a`; telemetry and incomplete routes are acknowledged below
- [x] Perf-relevant same-device clean-commit A/B is within ±2% (`106.0 → 105.9` tok/s on unaffected Qwen3.5-9B)
- [x] Runtime lib tests: 435 passed
- [x] Daemon example tests: 177 passed
- [x] `rdna-compute` lib tests passed
- [x] Kernel sources compile for gfx1010, gfx1030, gfx1100, gfx1200, and gfx1201
- [x] `git diff --check`

<details><summary>change_gate telemetry</summary>

The correct diff base is `origin/beta@e2f7dd1a` (the local `beta` branch was stale at `9ffb18da`). The plan selected eight routes and one blocked route.

Passing evidence:

- `detect.kernels-channel`: pass
- `unit.hipfire-runtime`: pass
- `unit.rdna-compute`: pass
- same-device clean-commit speed probe: baseline median `106.0`, candidate median `105.9` tok/s

Incomplete/failed routes and disposition:

- `serve.reset.qwen2`: blocked because `qwen25-0.5b-instruct.mq4`, `qwen25-0.5b-q2.mq4`, and `vibethinker-3b.mq4.hfq` are absent locally.
- `serve.battery.qwen35-4b`: the selected upstream route requests `--thinking med` (2048-token budget) with `--max-tokens 180`; `serve_harness.py` correctly rejects this as guaranteed think-only output before running the model.
- `shell.bind-thread`: reports five pre-existing VMM/pure-query methods. This PR's `dispatch.rs` diff only registers `embedding_hfq4g128_batched`; it adds no public `Gpu` method.
- `redline.capture`: after moving HOME to a writable directory, the model loaded but the harness received no `redline_capture` field and raised `KeyError`. This PR does not alter Qwen3.5 Redline capture routing.
- `serve.loop.cross-request`: 8/10 requests passed; two were rejected by the validation layer. This is recorded as incomplete and is not presented as a pass.
- `speed.arch-fast`: the absolute locked gfx1100 floor is from a 7900 XTX and fails on this W7900 (`142.5` versus `178.0` tok/s). The clean same-W7900 baseline/candidate probe above shows no regression (−0.09%).

The first workspace-lib invocation encountered one transient `ETXTBSY` in `hipfire-client::tests::load_requires_retry_reset_eligible_and_clears_stale`; the test passed immediately in isolation and the complete workspace-lib rerun passed.

First in-sandbox invocation additionally failed daemon routes because real `~/.hipfire` was read-only; reruns used `/tmp/hipfire-change-gate-home` with the model directory linked read-only.

</details>

## Architecture-trait change?

No. This PR does not change the `Architecture` trait surface.
