### PR TITLE
feat(benchlocal): land reproducible nine-pack campaign harness

### DIFF
--- a/docs/methodology/benchlocal-campaign.md
+++ b/docs/methodology/benchlocal-campaign.md
@@ -1,0 +1,385 @@
+# BenchLocal nine-pack quality campaign
+
+How hipfire runs and interprets the BenchLocal capability battery. This file
+is **methodology and reproduction**, not a gate and not a number store.
+
+| Concern | Owner |
+|---|---|
+| Authoritative topology, pins, sampling, exclusions | [`tools/benchlocal/manifest.json`](../../tools/benchlocal/manifest.json) |
+| Campaign plan / verify / run / Hermes recovery | `scripts/benchlocal_campaign.py` |
+| Results tree → summary JSON | `scripts/benchlocal_score.py` |
+| Sampling forcing proxy | `tools/benchlocal/sampling_proxy.mjs` |
+| Runtime validation routes (mandatory gates) | [`docs/VALIDATION.md`](../VALIDATION.md) |
+| Serve-path harness | [`bench-suite.md`](bench-suite.md), `scripts/serve_harness.py` |
+| Public-comparison interpretation (NAS) | `/mnt/nas/kaden/hipfire/benchlocal/2026-07-31-quality/PUBLISHED-COMPARISON.md` |
+
+## What this is and is not
+
+**Is:** a capability / quality campaign against the upstream
+[BenchLocal](https://github.com/stevibe/BenchLocal) packs. Four model routes ×
+nine runnable packs = 165 scenarios per route and 660 canonical attempts per
+campaign realization. The 2026-07-31 pair is the reference realization:
+
+| Campaign id | Thinking | Local tree |
+|---|---|---|
+| `benchlocal-full-20260731T091750Z` | disabled | `~/.cache/benchlocal-full-20260731T091750Z/` |
+| `benchlocal-medium-20260731T194729Z` | `reasoning_effort=medium` | `~/.cache/benchlocal-medium-20260731T194729Z/` |
+
+**Is not:** a mandatory validation gate. Project runtime validation remains
+`scripts/serve_harness.py` and `scripts/redline_daemon_harness.py` as routed by
+[`docs/VALIDATION.md`](../VALIDATION.md). BenchLocal scores do not admit a
+model, replace coherence checks, or redefine validation policy.
+
+## Artifact locations
+
+### NAS preservation
+
+Directory: `/mnt/nas/kaden/hipfire/benchlocal/2026-07-31-quality/`
+
+| File | Purpose | SHA-256 |
+|---|---|---|
+| `MANIFEST.txt` | Archive inventory, campaign ids, summary digests | — |
+| `SHA256SUMS` | Checksums for the two tarballs + `PUBLISHED-COMPARISON.md` | — |
+| `PUBLISHED-COMPARISON.md` | Public-comparison interpretation and source links | `f874bb284fc62d5f7591afa5d7cb435ae88e9370423afb17c4c90a2c14d58f9c` |
+| `benchlocal-canonical-runs.tar.gz` | Complete local campaign trees (packs, results, summaries, privileged Hermes scratch recovered with sudo); 14303 entries | `216face118f3b346eb42824612d3f809158d7d226c80bda29ccf08592efa8618` |
+| `hiptrx-scratch-homes.tar.gz` | Remote GPU sandbox homes, binaries, logs, and result dirs from host `hiptrx`; 89 entries | `c8068c569a663d8e5b9db31009862b6360b9bdcf51fa4cdabbe95b37bc987349` |
+
+Verified archived score summaries (from `MANIFEST.txt`):
+
+| Summary | SHA-256 |
+|---|---|
+| `full-battery-summary.json` (baseline) | `b47890257e39678d71156ed9e49f0e4b7b6df4483a858c72e6c07be85b72eaef` |
+| `full-battery-medium-summary.json` | `46c2a94ec88970d7ac5e9eafe14b0a1649e70451ac882805711aad533cc67f49` |
+
+### Live trees
+
+| Path | Contents |
+|---|---|
+| `~/.cache/benchlocal-full-20260731T091750Z/` | Baseline packs/, results/, `full-battery-summary.json`, `sampling-proxy.mjs` (+ pre-thinkfix backup) |
+| `~/.cache/benchlocal-medium-20260731T194729Z/` | Medium packs/, results/, `full-battery-medium-summary.json`, medium proxy |
+| `~/benchlocal-*-20260731T*/` on `hiptrx` | Remote sandbox homes (also in `hiptrx-scratch-homes.tar.gz`) |
+
+Campaign roots are always caller-supplied. Do not hardcode `/tmp` as a
+canonical artifact root.
+
+## How to run it
+
+Everything is developer-only orchestration. Python is stdlib-only; Node is
+required because the upstream packs are Node/TS. The user-facing control plane
+stays Rust-only ([`AGENTS.md`](../../AGENTS.md) §0.6).
+
+### Authoritative inputs
+
+- [`tools/benchlocal/manifest.json`](../../tools/benchlocal/manifest.json) —
+  provenance, sampling contract, port topology, four routes, nine pinned packs,
+  scoring definitions, exclusion globs. Do not fork a second source of truth.
+- `tools/benchlocal/sampling_proxy.mjs` — OpenAI-compatible forcing proxy
+  (`THINKING_MODE=disabled|medium`).
+- `scripts/benchlocal_campaign.py` — campaign driver.
+- `scripts/benchlocal_score.py` — results tree → summary JSON.
+
+### Subcommand flow
+
+```text
+# 1. Materialize packs at pinned revisions under <campaign-root>/packs/
+#    (clone each packs[].repo at packs[].revision; build pack CLIs / images
+#    as the pack READMEs require).
+
+# 2. Plan pure runner commands (no network, no Docker, no GPU):
+python3 scripts/benchlocal_campaign.py plan \
+  --manifest tools/benchlocal/manifest.json \
+  --campaign-root <ABS_PATH> \
+  --route all \
+  --thinking disabled \
+  --out <ABS_PATH>/plans
+
+# 3. Verify prerequisites against the plan / host (binaries, ports, images,
+#    pack checkouts) before spending GPU time:
+python3 scripts/benchlocal_campaign.py verify \
+  --manifest tools/benchlocal/manifest.json \
+  --campaign-root <ABS_PATH>
+
+# 4. Run the four-route matrix (hiptrx, 4 GPUs, Docker sidecars, isolated
+#    HOME per GPU). Starts daemons + sampling proxies as required by
+#    route.proxy_scope, then executes pack argv from the plan:
+python3 scripts/benchlocal_campaign.py run \
+  --manifest tools/benchlocal/manifest.json \
+  --campaign-root <ABS_PATH> \
+  --thinking disabled   # or medium
+
+# 5. When Hermes --all dies mid-pack, recover per scenario and stitch:
+python3 scripts/benchlocal_campaign.py recover-hermes \
+  --manifest tools/benchlocal/manifest.json \
+  --campaign-root <ABS_PATH> \
+  --route <slug>
+
+# 6. Score the results tree (optionally against the baseline summary):
+python3 scripts/benchlocal_score.py \
+  --manifest tools/benchlocal/manifest.json \
+  --campaign-root <ABS_PATH> \
+  --baseline <PATH-to-full-battery-summary.json> \
+  --out <ABS_PATH>/full-battery-summary.json
+```
+
+`plan` without `--out` prints JSON on stdout. `--route <slug>` emits one plan
+object; `--route all` emits `{"<slug>": <plan>, ...}`. With `--out DIR` it
+writes `DIR/<slug>.runner-commands.json` per route.
+
+### Subset runs and partial scoring
+
+A full route is nine packs and hours of GPU time, and CLI-40 and HermesAgent-20
+dominate that cost. Per-pack reruns were routine in the 2026-07-31 campaigns —
+every `hermesagent-20-*` and `cli-40.*infra-fail.*` artifact is one — so both
+tools support working a subset:
+
+```text
+# Run only selected packs (repeatable or comma-separated), still in manifest order:
+python3 scripts/benchlocal_campaign.py run \
+  --manifest tools/benchlocal/manifest.json \
+  --campaign-root <ABS_PATH> \
+  --route <slug> \
+  --pack reasonmath-15 \
+  --skip-sidecars          # legal only for the five sidecar-free packs
+
+# Score a tree that is deliberately incomplete:
+python3 scripts/benchlocal_score.py \
+  --manifest tools/benchlocal/manifest.json \
+  --campaign-root <ABS_PATH> \
+  --allow-partial
+```
+
+`--allow-partial` scores the packs that are present, lists the absent
+`*.stdout.log` artifacts under `raw_artifact_audit.missing`, and sets
+`aggregate.incomplete = true` with `packs_present` / `packs_expected` while
+forcing `macro_score` and `scenario_weighted_reported_score` to `null`. A mean
+over fewer than nine packs is not a macro score and must never be published as
+one. Without the flag the scorer fails loudly on the first missing artifact,
+which is the correct default for a campaign run.
+
+### Four-route / nine-pack matrix
+
+| Route slug | Family | GPU | Mode highlights | Proxy scope |
+|---|---|---:|---|---|
+| `qwen27-ar` | qwen27 | 0 | Qwen3.6-27B AR, KV q8, DFlash off | hermes-only |
+| `qwen27-dflash` | qwen27 | 1 | same weights, DFlash on | hermes-only |
+| `a3b-mq4r` | a3b | 2 | Qwen3.6-35B-A3B MQ4R (speed-max) | all packs |
+| `a3b-mq4p` | a3b | 3 | Qwen3.6-35B-A3B MQ4P | all packs |
+
+Nine runnable packs (see [Pinned packs](#pinned-packs)): seven `benchlocal-cli`
+15-scenario packs, CLI-40 (40), HermesAgent-20 (20). Unsupported registry packs
+`formsight` and `pixelate` are excluded (Electron / multimodal; hardcoded
+temperatures that cannot honor the campaign sampling contract).
+
+## Sampling contract and why the proxy exists
+
+### Contract
+
+| Parameter | Value |
+|---|---|
+| `temperature` | 1.0 |
+| `top_p` | 0.95 |
+| `top_k` | 20 |
+| `min_p` | 0.0 |
+| `repetition_penalty` | 1.0 |
+| `presence_penalty` (qwen27) | 0.0 (direct runners omit; server default 0; Hermes proxy forces 0.0) |
+| `presence_penalty` (a3b) | 1.5 (proxy-injected on every request) |
+| request timeout | 300 s |
+
+Thinking variants (`THINKING_MODE` on the proxy):
+
+| Mode | Forced fields |
+|---|---|
+| `disabled` (default) | `enable_thinking: false`; no reasoning_effort fields |
+| `medium` | `enable_thinking: true`, `reasoning_effort: "medium"`, `max_think_tokens: 1024` |
+
+Reference proxy digests from the preserved campaigns:
+
+| Variant | `sampling-proxy.mjs` SHA-256 |
+|---|---|
+| baseline (disabled) | `578f2be2b530ad4fb7ed76459ff76ba81c538376ee296af26369cf2af72099a2` |
+| medium | `8a221d7c3ad11abc66302876d5c0d0ebf441d36c4d71d1b055009e4bc1af4c3d` |
+| pre-thinkfix backup | `b87fb8658860d6fe971ae2c9a5b750e304278411c1edc100bc510906ab1b918f` |
+
+### Why the proxy exists
+
+The pinned Hermes OpenAI SDK rejects `top_k` (and related non-SDK kwargs)
+**before the request reaches HTTP**. Debug runs under the baseline tree record
+`Completions.create() got an unexpected keyword argument 'top_k'`. Hermes
+traffic must therefore always go through the forcing proxy, which:
+
+1. accepts the runner's temperature / top_p only,
+2. rewrites every intercepted `POST .../v1/chat/completions` to the full
+   campaign contract (including presence_penalty and the thinking variant),
+3. appends one attestation JSONL row per rewrite:
+   `{timestamp, modelSlug, path, requestModel, temperature, top_p, top_k, min_p, presence_penalty, repetition_penalty}`,
+4. exposes `/__sampling_proxy/health` and prints
+   `sampling-proxy: listening on http://<host>:<port> -> <target> (<slug>)`.
+
+Proxy env contract: `LISTEN_HOST` (campaign used `0.0.0.0`), `LISTEN_PORT`,
+`TARGET_ORIGIN`, `MODEL_SLUG`, `ATTESTATION_LOG`, `PRESENCE_PENALTY` (default
+`1.5`), `THINKING_MODE=disabled|medium`.
+
+Attestation audits on the reference realizations:
+
+| Campaign | Attestation rows | Bad rows |
+|---|---:|---:|
+| baseline (`full-battery-summary.json` per-route audits) | 1858 total (905+400+204+349) | 0 |
+| medium (`full-battery-medium-summary.json`) | 1591 | 0 |
+
+a3b routes send **all** pack traffic through the proxy (`proxy_scope: "all"`).
+qwen27 routes proxy Hermes only; non-Hermes packs talk to the serve port
+directly with the sampling flags on the CLI argv (see archived
+`results/qwen27-*/qwen27-*.runner-commands.json`).
+
+## Topology
+
+Four concurrent daemons on host **`hiptrx`**, one per GPU, each with an
+isolated `HOME` (`homes/gpu0..gpu3` in the remote scratch tree).
+
+Port rule (from the manifest):
+
+```text
+serve_port = 12180 + gpu
+proxy_port = serve_port + 100
+```
+
+Containers reach the host via Docker bridge **`172.17.0.1`**. Proxy listens on
+`0.0.0.0`.
+
+| Route | GPU | serve_port | proxy_port | non_hermes_base (host) | hermes_docker_base |
+|---|---:|---:|---:|---|---|
+| qwen27-ar | 0 | 12180 | 12280 | `http://127.0.0.1:12180` | `http://172.17.0.1:12280/v1` |
+| qwen27-dflash | 1 | 12181 | 12281 | `http://127.0.0.1:12181` | `http://172.17.0.1:12281/v1` |
+| a3b-mq4r | 2 | 12182 | 12282 | `http://127.0.0.1:12282` (proxy) | `http://172.17.0.1:12282/v1` |
+| a3b-mq4p | 3 | 12183 | 12283 | `http://127.0.0.1:12283` (proxy) | `http://172.17.0.1:12283/v1` |
+
+**Inferred:** a3b serve ports `12182` / `12183` are derived from the port rule
+rather than directly observed in a runner-commands artifact. The evidenced
+value is the a3b-mq4p Hermes proxy at `http://172.17.0.1:12283/v1`
+(`results/a3b-mq4p/hermesagent-20-provenance.json`); serve ports follow from
+`proxy_port = serve_port + 100`.
+
+### Engine identity
+
+| Binary | md5 |
+|---|---|
+| `hipfire` | `2638db7b487a43745c55fb39c345534e` |
+| `daemon` | `e4af3aa26e79aa07a45fe696104dbf50` |
+
+The medium campaign deliberately reused the baseline campaign's immutable
+binaries (`full-battery-medium-summary.json` → `engine.binary_source` points at
+the baseline remote `bin/`).
+
+Smoke health gate uses `max_tokens=1152` and expects `finish_reason=stop` with
+answer `42`. A 96-token smoke cap is not a valid health gate on reasoning
+routes (open think spans).
+
+## Pinned packs
+
+Nine of eleven BenchLocal registry packs are runnable under the campaign
+sampling contract → **165 scenarios / route**, **660 attempts / campaign**.
+
+| Pack id | Dir | Upstream | Revision | Version | Scenarios |
+|---|---|---|---|---|---:|
+| `dataextract-15` | DataExtract-15 | https://github.com/stevibe/DataExtract-15.git | `00d90bf7506a1d7ffe98943d9ffd8c6eb795dbdb` | 1.0.0 | 15 |
+| `instructfollow-15` | InstructFollow-15 | https://github.com/stevibe/InstructFollow-15.git | `187af97cb2b892ad57de176b16a254aba7565a65` | 1.0.0 | 15 |
+| `reasonmath-15` | ReasonMath-15 | https://github.com/stevibe/ReasonMath-15.git | `b97632020fa373c52ba92373dbe5dc58b744ce48` | 1.0.0 | 15 |
+| `toolcall-15` | ToolCall-15 | https://github.com/stevibe/ToolCall-15.git | `edd6cefe4261b67e8166e9f6d77d671042560294` | 1.0.1 | 15 |
+| `promptauthority-15` | PromptAuthority-15 | https://github.com/stevibe/PromptAuthority-15.git | `6ed261b42fcca0df15e4794eeb4da628b1666952` | 1.0.0 | 15 |
+| `structoutput-15` | StructOutput-15 | https://github.com/stevibe/StructOutput-15.git | `00de86e9bfc9dd3d86ba397d0cf35bcbc04efd1c` | 1.0.0 | 15 |
+| `bugfind-15` | BugFind-15 | https://github.com/stevibe/BugFind-15.git | `eea2224a531f0937a8fffb4949abcd6db81f4d11` | 1.0.1 | 15 |
+| `cli-40` | CLI-40 | https://github.com/stevibe/CLI-40.git | `3b95f86e6edac47183348381a9bb211ffaf09404` | 1.0.2 | 40 |
+| `hermesagent-20` | HermesAgent-20 | https://github.com/stevibe/HermesAgent-20.git | `fa40ab9fb84a329421bbdfc3062cf28f1670de71` | 1.0.0 | 20 |
+
+Unsupported (not scored): **`formsight`**, **`pixelate`**.
+
+Notes:
+
+- Only `toolcall-15` and `promptauthority-15` are `tool_pack: true` (they accept
+  `--tools-format` / `--repetition-penalty` on the pack CLI).
+- StructOutput host validator port is remapped to **4011** so it does not
+  collide with BugFind's sandbox on 4010.
+- CLI-40 sampling is hardcoded in the campaign dist (same base contract; no
+  presence_penalty). Hermes sampling beyond temperature/top_p is entirely
+  proxy-injected.
+
+## Landmines
+
+| Symptom | Real cause | What to do |
+|---|---|---|
+| Hermes `--all` dies mid-pack (baseline: after HA-03 on qwen27-ar, after HA-16 on a3b-mq4p; medium: after HA-16 on both a3b routes) | Official runner transport / fetch failure, not a scored scenario result | Run `recover-hermes`; stitch via `hermesagent-20-provenance.json` (or `hermesagent-20.provenance.json` on baseline qwen27-ar). Recovery is the norm, not the exception: the baseline campaign stitched 3 of 4 routes and only `a3b-mq4r` was a single corrected full pass, while in the medium campaign the one clean pass was `qwen27-dflash`. Per-route methods are recorded in each summary's `hermes_recovery` / `recovery_provenance` block. |
+| Baseline qwen27-ar HA-17 carries a methodology deviation | Official runner transport failed repeatedly, so HA-17 was driven by a direct POST to the identical verifier `/run-scenario` handler | Legitimate but must stay disclosed: verifier image/core, model route, sampling proxy, raw trace, and deterministic scorer were unchanged — only `run-scenarios.mjs` transport was bypassed. Do not silently normalize this away when re-running |
+| HA-09 OOM; socket hang; preload fail; prepare EACCES | Container / host infra during Hermes isolation | Preserve `hermesagent-20*{oom,socket-hang,preload-fail,prepare-eacces}*` artifacts; exclude from scoring; retry the affected scenarios in isolation |
+| Docker bind collision on CLI-40 retry | Port / bind clash between verifier containers | Preserve as `cli-40.*infra-fail.*`; exclude; keep the later complete `cli-40.*` retry as canonical (medium a3b-mq4p) |
+| Smoke returns open think spans / non-stop finish | `max_tokens=96` is too small on reasoning routes | Use smoke `max_tokens=1152`. Smoke observations are **excluded** from the 660 canonical attempts |
+| Temptation to score `results/*-no-presence` | a3b runs missing `presence_penalty=1.5` | Exclude entire `*-no-presence` trees; they are not comparable to the campaign contract |
+| Baseline summary shows a 63-hex sha256 for a3b-mq4p | Archive truncated the digest (dropped trailing `f`) | Use repaired value `8eb3be6912aa9db2dcc89c3233b05ccdfe81a84a8d6ef43202f2098d7f2fc78f` (re-hashed 2026-08-02). Sibling a3b-mq4r matched byte-for-byte, confirming the local weights are what the campaign served |
+| Hermes fails immediately with `unexpected keyword argument 'top_k'` | Pinned Hermes OpenAI SDK rejects kwargs before HTTP | Point Hermes at the sampling proxy, not the raw serve port. Preserve `*openai-kwargs-failure*` as infra, not quality |
+| Archived runner-commands disagree with each other | Historical one-off argv drift (e.g. missing `--provider-model`, flag order, `--model=v` vs `--model v`) | Emit the **canonical** form from `benchlocal_campaign.py plan` / the contract in the manifest driver — do not byte-reproduce every archive inconsistency |
+
+## Scoring definitions and comparability limits
+
+### Definitions
+
+| Metric | Definition |
+|---|---|
+| Macro score | Unweighted mean of the nine pack headline scores |
+| Scenario-weighted score | Pack headline scores weighted by scenario count (seven×15 + Hermes 20 + CLI 40) |
+| Status totals | Sum of canonical pack pass / partial / fail counts |
+
+Exclusions applied before scoring are listed in
+`tools/benchlocal/manifest.json` → `exclusions` (no-presence trees, Hermes
+openai-kwargs failures, Hermes infra diagnostics, CLI-40 infra-fail retries).
+
+### Headline results (disabled → medium)
+
+Source: `PUBLISHED-COMPARISON.md` and the two verified summary JSON files.
+
+| Route | Thinking disabled | Medium thinking | Δ macro |
+|---|---:|---:|---:|
+| qwen27-ar | 82.9056 | 83.1250 | +0.2194 |
+| qwen27-dflash | 84.3139 | 82.3250 | −1.9889 |
+| a3b-mq4p | 80.6806 | 68.6750 | −12.0056 |
+| a3b-mq4r | 69.4139 | 62.6472 | −6.7667 |
+
+Operational reading (from the medium summary + published comparison):
+
+- DFlash preserved Qwen27 quality vs AR on the disabled run (macro lead ~1.41
+  with the same 115/165 hard-pass count).
+- Medium thinking did not improve the battery overall: neutral for AR, mildly
+  harmful for DFlash, substantially harmful for both A3B routes.
+- MQ4R is the speed-max profile — read as retained quality at maximum
+  throughput, not as a quality competitor to MQ4P.
+
+### Comparability limits
+
+State these every time numbers are cited externally:
+
+1. **There is no official BenchLocal leaderboard** and no official nine-pack
+   macro. See [BugFind-15#1](https://github.com/stevibe/BugFind-15/issues/1).
+2. Hipfire ran **one controlled realization** at temperature 1.0 / top_p 0.95 /
+   top_k 20. InferRank publishes **three-run averages** at temperature 0.6
+   (same top_p / top_k) over an eight-pack subset.
+3. Community matrices (Kovalov seven-pack, InferRank eight-pack) used matching
+   semantic pack versions but not necessarily the same git revisions or a
+   uniform sampling contract.
+4. Quantization, serving stack, chat template, reasoning mode, context, retries,
+   and pack revisions all move scores.
+
+These campaigns establish **capability tiers and workload profiles**, not a
+formal global ranking. Full public-source list and normalized comparison tables
+live in NAS `PUBLISHED-COMPARISON.md`:
+
+- https://github.com/stevibe/BenchLocal
+- https://github.com/stevibe/BugFind-15/issues/1
+- https://sergeykovalov.com/debugging-local-llm-benchmarks/
+- https://github.com/Rhonstin/inferrank/blob/master/docs/FULLBENCH_ANALYSIS.md
+- https://inferrank.selfcloud.pp.ua/
+- https://x.com/stevibe/status/2066563724375376195
+- https://x.com/stevibe/status/2060370310030053380
+
+## Related
+
+- [`bench-suite.md`](bench-suite.md) — production serve harness map
+- [`perf-benchmarking.md`](perf-benchmarking.md) — measurement identity protocol
+- [`docs/VALIDATION.md`](../VALIDATION.md) — which route a change owes

--- a/scripts/benchlocal_campaign.py
+++ b/scripts/benchlocal_campaign.py
@@ -1,0 +1,993 @@
+#!/usr/bin/env python3
+# Copyright (c) Kaden Schutt
+"""Reproduce the BenchLocal nine-pack quality campaign.
+
+This is developer-only orchestration.  It deliberately keeps every command in
+one standalone, stdlib-only file so archived runs remain reproducible.
+
+Operational landmines preserved from the 2026-07-31 campaigns:
+* Hermes ``--all`` can fail while fetching after HA-03 or HA-16; use
+  ``recover-hermes`` rather than discarding the completed scenarios.
+* HA-09 can exhaust GPU memory.  An isolated retry is still canonical evidence.
+* Hermes' pinned OpenAI SDK rejects ``top_k`` before making HTTP requests, so
+  sampling is forced by the HTTP proxy rather than passed to that runner.
+* Retry only after removing old verifier containers: Docker bind collisions are
+  infrastructure failures, not model-quality failures.
+* A 96-token smoke cap exposes open thinking spans.  The campaign health smoke
+  must use ``max_tokens=1152`` (the manifest records this contract).
+"""
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = REPO_ROOT / "tools" / "benchlocal" / "manifest.json"
+PROXY_SCRIPT = REPO_ROOT / "tools" / "benchlocal" / "sampling_proxy.mjs"
+HERMES_RESULT_RE = re.compile(
+    r"^\[(PASS|PARTIAL|FAIL)\]\s+(HA-\d{2})\s+score=([0-9]+(?:\.[0-9]+)?)\b",
+    re.MULTILINE,
+)
+
+
+class CampaignError(RuntimeError):
+    """An actionable campaign configuration or execution error."""
+
+
+def utc_now():
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def load_manifest(path):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            manifest = json.load(handle)
+    except (OSError, json.JSONDecodeError) as error:
+        raise CampaignError(f"cannot load manifest {path}: {error}") from error
+    if manifest.get("schema_version") != 1:
+        raise CampaignError(
+            f"unsupported manifest schema_version {manifest.get('schema_version')!r}"
+        )
+    if not isinstance(manifest.get("routes"), list) or not isinstance(
+        manifest.get("packs"), list
+    ):
+        raise CampaignError("manifest must contain routes and packs arrays")
+    return manifest
+
+
+def route_map(manifest):
+    return {route["slug"]: route for route in manifest["routes"]}
+
+
+def require_route(manifest, slug):
+    route = route_map(manifest).get(slug)
+    if route is None:
+        known = ", ".join(route_map(manifest))
+        raise CampaignError(f"unknown route {slug!r}; expected one of: {known}")
+    return route
+
+
+def ordered_packs(manifest):
+    return sorted(manifest["packs"], key=lambda pack: pack["order"])
+
+def select_packs(manifest, requested):
+    packs = ordered_packs(manifest)
+    if not requested:
+        return packs
+    requested_ids = {
+        pack_id.strip()
+        for value in requested
+        for pack_id in value.split(",")
+        if pack_id.strip()
+    }
+    valid_ids = [pack["id"] for pack in packs]
+    if not requested_ids:
+        raise CampaignError(
+            f"--pack requires at least one pack id; valid pack ids: {', '.join(valid_ids)}"
+        )
+    unknown = sorted(requested_ids.difference(valid_ids))
+    if unknown:
+        raise CampaignError(
+            f"unknown pack id(s): {', '.join(unknown)}; valid pack ids: {', '.join(valid_ids)}"
+        )
+    return [pack for pack in packs if pack["id"] in requested_ids]
+
+
+def absolute_campaign_root(value):
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        raise CampaignError("--campaign-root must be an absolute path")
+    return path
+
+
+def _number(value):
+    return str(value)
+
+
+def _shell_command(cwd, env, argv):
+    # The archive contract intentionally uses a plain, single-space rendering;
+    # its paths and values contain no whitespace or shell metacharacters.
+    pieces = [f"{key}={value}" for key, value in env.items()] + list(argv)
+    return f"cd {cwd} && {' '.join(pieces)}"
+
+
+def build_pack_command(manifest, route, pack, campaign_root):
+    model = route["model_path"]
+    endpoints = route["endpoints"]
+    cwd = campaign_root / "packs" / pack["dir"]
+    kind = pack["runner"]["kind"]
+    env = {}
+
+    if kind == "benchlocal-cli":
+        env = {
+            "LLAMACPP_HOST": endpoints["non_hermes_base"],
+            "LLM_MODELS": f"llamacpp:{model}",
+            "MODEL_REQUEST_TIMEOUT_SECONDS": str(
+                manifest["sampling"]["request_timeout_seconds"]
+            ),
+        }
+        sidecar = pack.get("sidecar")
+        if sidecar:
+            sidecar_url = f"http://127.0.0.1:{sidecar['host_port']}"
+            env[sidecar["url_env"]] = sidecar_url
+        sampling = manifest["sampling"]["base"]
+        argv = list(pack["runner"]["argv"])
+        argv += [
+            "--model",
+            f"llamacpp:{model}",
+            "--temperature",
+            _number(sampling["temperature"]),
+            "--top-p",
+            _number(sampling["top_p"]),
+            "--top-k",
+            _number(sampling["top_k"]),
+            "--min-p",
+            _number(sampling["min_p"]),
+            "--timeout",
+            str(manifest["sampling"]["request_timeout_seconds"]),
+        ]
+        if sidecar:
+            argv += [sidecar["cli_flag"], sidecar_url]
+        if pack.get("tool_pack"):
+            argv += [
+                "--repetition-penalty",
+                _number(sampling["repetition_penalty"]),
+                "--tools-format",
+                "default",
+            ]
+        argv += ["--show-raw", "--json"]
+    elif kind == "cli40":
+        runner = pack["runner"]
+        argv = list(runner["argv"])
+        argv += [
+            "--model",
+            model,
+            "--provider",
+            runner["provider"],
+            "--base-url",
+            f"{endpoints['non_hermes_base']}/v1",
+            "--docker-base-url",
+            endpoints["cli40_docker_base"],
+            "--auth-mode",
+            runner["auth_mode"],
+            "--image",
+            runner["docker_image"],
+            "--json",
+            "--verbose",
+        ]
+    elif kind == "hermes":
+        runner = pack["runner"]
+        argv = list(runner["argv"])
+        argv += [
+            "--model",
+            model,
+            "--provider-model",
+            model,
+            "--provider",
+            runner["provider"],
+            "--base-url",
+            endpoints["hermes_docker_base"],
+            "--auth-mode",
+            runner["auth_mode"],
+            "--api-key",
+            runner["api_key"],
+            "--image",
+            runner["docker_image"],
+            "--json",
+            "--verbose",
+        ]
+    else:
+        raise CampaignError(f"unsupported runner kind {kind!r} for {pack['id']}")
+
+    return {
+        "cwd": str(cwd),
+        "env": env,
+        "argv": argv,
+        "command": _shell_command(cwd, env, argv),
+    }
+
+
+def build_plan(manifest, route, campaign_root, thinking):
+    # Thinking is enforced by sampling_proxy.mjs at run time.  It therefore
+    # does not alter any pack argv/env field in this archived command plan.
+    if thinking not in manifest["sampling"]["thinking_variants"]:
+        raise CampaignError(f"manifest does not define thinking variant {thinking!r}")
+    family = route["family"]
+    presence = manifest["sampling"]["presence_penalty_by_family"][family]
+    if route["proxy_scope"] == "hermes-only":
+        presence = None
+    sampling = manifest["sampling"]["base"]
+    timeout = manifest["sampling"]["request_timeout_seconds"]
+    shared_env = {
+        "LLAMACPP_HOST": route["endpoints"]["non_hermes_base"],
+        "LLM_MODELS": f"llamacpp:{route['model_path']}",
+        "MODEL_REQUEST_TIMEOUT_SECONDS": str(timeout),
+    }
+    return {
+        "assembled_at": utc_now(),
+        "campaign_id": campaign_root.name,
+        "route": route["slug"],
+        "model": route["model_path"],
+        "results_root": str(campaign_root / "results" / route["slug"]),
+        "shared_env_non_hermes": shared_env,
+        "sampling_contract": {
+            "temperature": sampling["temperature"],
+            "top_p": sampling["top_p"],
+            "top_k": sampling["top_k"],
+            "min_p": sampling["min_p"],
+            "repetition_penalty": sampling["repetition_penalty"],
+            "presence_penalty": presence,
+            "timeout": timeout,
+        },
+        "packs": {
+            pack["id"]: build_pack_command(manifest, route, pack, campaign_root)
+            for pack in ordered_packs(manifest)
+        },
+    }
+
+
+def command_plan(args, manifest):
+    root = absolute_campaign_root(args.campaign_root)
+    routes = route_map(manifest)
+    if args.route == "all":
+        selected = list(routes.values())
+    else:
+        selected = [require_route(manifest, args.route)]
+    plans = {
+        route["slug"]: build_plan(manifest, route, root, args.thinking)
+        for route in selected
+    }
+    if args.out:
+        out = Path(args.out).expanduser()
+        out.mkdir(parents=True, exist_ok=True)
+        for slug, plan in plans.items():
+            with open(out / f"{slug}.runner-commands.json", "w", encoding="utf-8") as handle:
+                json.dump(plan, handle, indent=2)
+                handle.write("\n")
+        return
+    payload = plans if args.route == "all" else next(iter(plans.values()))
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+def run_checked(argv, **kwargs):
+    try:
+        return subprocess.run(argv, check=True, **kwargs)
+    except FileNotFoundError as error:
+        raise CampaignError(f"required executable not found: {argv[0]}") from error
+    except subprocess.CalledProcessError as error:
+        detail = ""
+        if getattr(error, "stderr", None):
+            detail = f": {error.stderr.strip()}"
+        raise CampaignError(f"command failed ({error.returncode}): {shlex.join(argv)}{detail}") from error
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def command_verify(args, manifest):
+    root = absolute_campaign_root(args.campaign_root)
+    packs_root = root / "packs"
+    failures = []
+    for pack in ordered_packs(manifest):
+        destination = packs_root / pack["dir"]
+        try:
+            if destination.exists():
+                if not (destination / ".git").exists():
+                    raise CampaignError(f"{destination} exists but is not a git clone")
+                result = run_checked(
+                    ["git", "-C", str(destination), "rev-parse", "HEAD"],
+                    capture_output=True,
+                    text=True,
+                )
+                head = result.stdout.strip()
+                if head != pack["revision"]:
+                    raise CampaignError(
+                        f"{pack['id']}: HEAD {head} does not match pinned {pack['revision']}"
+                    )
+            elif args.skip_clone:
+                raise CampaignError(f"{pack['id']}: missing clone {destination} (--skip-clone)")
+            else:
+                packs_root.mkdir(parents=True, exist_ok=True)
+                run_checked(["git", "clone", pack["repo"], str(destination)])
+                run_checked(
+                    ["git", "-C", str(destination), "fetch", "origin", pack["revision"]]
+                )
+                run_checked(
+                    [
+                        "git",
+                        "-C",
+                        str(destination),
+                        "checkout",
+                        "--detach",
+                        "--force",
+                        pack["revision"],
+                    ]
+                )
+
+            metadata_path = destination / "benchlocal.pack.json"
+            with open(metadata_path, encoding="utf-8") as handle:
+                metadata = json.load(handle)
+            if metadata.get("version") != pack["version"]:
+                raise CampaignError(
+                    f"{pack['id']}: metadata version {metadata.get('version')!r} "
+                    f"does not match manifest {pack['version']!r}"
+                )
+            # Pack scenario data is executable TypeScript/MJS rather than a
+            # stable JSON inventory in these pinned revisions.  Importing it
+            # would violate the stdlib-only/offline verifier boundary, and
+            # counting source regex matches is not reliable.  Hermes alone has
+            # an explicit inventory in the manifest, so all packs intentionally
+            # report the count as not independently verified here.
+            print(
+                f"pack {pack['id']}: revision={pack['revision']} version={pack['version']} "
+                f"scenario_count={pack['scenario_count']} (manifest only; source inventory is executable)"
+            )
+        except (OSError, json.JSONDecodeError, CampaignError) as error:
+            failures.append(str(error))
+            print(f"pack {pack['id']}: ERROR {error}", file=sys.stderr)
+
+    digest_cache = {}
+    for route in manifest["routes"]:
+        model = Path(route["model_path"]).expanduser()
+        if not model.exists():
+            print(f"model {route['slug']}: absent {model}")
+            continue
+        try:
+            actual = digest_cache.setdefault(str(model), sha256_file(model))
+        except OSError as error:
+            failures.append(f"{route['slug']}: cannot hash {model}: {error}")
+            print(f"model {route['slug']}: ERROR {error}", file=sys.stderr)
+            continue
+        if actual == route["model_sha256"]:
+            print(f"model {route['slug']}: present sha256={actual} OK")
+        else:
+            message = (
+                f"{route['slug']}: model sha256 mismatch: expected "
+                f"{route['model_sha256']}, got {actual}"
+            )
+            failures.append(message)
+            print(f"model {route['slug']}: MISMATCH expected={route['model_sha256']} actual={actual}")
+    if failures:
+        raise CampaignError(f"verification failed with {len(failures)} error(s)")
+
+
+def proxy_spec(manifest, route, root, thinking):
+    results = root / "results" / route["slug"]
+    hermes_only = route["proxy_scope"] == "hermes-only"
+    attest_name = (
+        "hermes-sampling-attestations.jsonl"
+        if hermes_only
+        else "sampling-attestations.jsonl"
+    )
+    log_name = "hermes-sampling-proxy.log" if hermes_only else "sampling-proxy.log"
+    env = {
+        "LISTEN_HOST": manifest["topology"]["proxy_listen_host"],
+        "LISTEN_PORT": str(route["endpoints"]["proxy_port"]),
+        "TARGET_ORIGIN": f"http://127.0.0.1:{route['endpoints']['serve_port']}",
+        "MODEL_SLUG": route["slug"] + ("-hermes" if hermes_only else ""),
+        "ATTESTATION_LOG": str(results / attest_name),
+        "PRESENCE_PENALTY": _number(
+            manifest["sampling"]["presence_penalty_by_family"][route["family"]]
+        ),
+        "THINKING_MODE": thinking,
+    }
+    return env, ["node", str(PROXY_SCRIPT)], results / log_name
+
+
+def _wait_proxy(route, process, timeout=30):
+    url = (
+        f"http://127.0.0.1:{route['endpoints']['proxy_port']}"
+        "/__sampling_proxy/health"
+    )
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise CampaignError(f"sampling proxy exited early with code {process.returncode}")
+        try:
+            with urllib.request.urlopen(url, timeout=1) as response:
+                if 200 <= response.status < 300:
+                    return
+        except (OSError, urllib.error.URLError):
+            pass
+        time.sleep(0.25)
+    raise CampaignError(f"sampling proxy did not become healthy at {url}")
+
+
+def start_proxy(manifest, route, root, thinking):
+    env_delta, argv, log_path = proxy_spec(manifest, route, root, thinking)
+    log_handle = open(log_path, "ab")
+    try:
+        process = subprocess.Popen(
+            argv,
+            cwd=REPO_ROOT,
+            env={**os.environ, **env_delta},
+            stdout=log_handle,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+    except OSError as error:
+        log_handle.close()
+        raise CampaignError(f"cannot launch sampling proxy: {error}") from error
+    process._benchlocal_log_handle = log_handle
+    _wait_proxy(route, process)
+    return process
+
+
+def terminate_process(process):
+    if process is None:
+        return
+    if process.poll() is None:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.wait()
+    handle = getattr(process, "_benchlocal_log_handle", None)
+    if handle:
+        handle.close()
+
+def wait_url(url, label, timeout=60):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=1) as response:
+                if 200 <= response.status < 300:
+                    return
+        except (OSError, urllib.error.URLError):
+            pass
+        time.sleep(0.25)
+    raise CampaignError(f"{label} did not become healthy at {url}")
+
+
+def ensure_docker():
+    if not shutil.which("docker"):
+        raise CampaignError("Docker is required; install/start Docker or pass --skip-sidecars")
+    result = subprocess.run(["docker", "info"], capture_output=True, text=True)
+    if result.returncode:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise CampaignError(
+            f"Docker is unavailable; start the daemon or pass --skip-sidecars: {detail}"
+        )
+
+
+def docker_build(pack, root):
+    sidecar = pack["sidecar"]
+    context = (root / "packs" / pack["dir"] / sidecar["build_context"]).resolve()
+    runner = pack["runner"]
+    if runner["kind"] in ("cli40", "hermes"):
+        image = runner["docker_image"]
+    else:
+        image = f"benchlocal-{pack['id']}-verifier"
+    run_checked(["docker", "build", "-t", image, str(context)])
+    return image
+
+
+def docker_start_sidecar(pack, image, campaign_id, route_slug):
+    sidecar = pack["sidecar"]
+    if "host_port" not in sidecar:
+        return None
+    safe_campaign = re.sub(r"[^A-Za-z0-9_.-]", "-", campaign_id)
+    name = f"benchlocal-{safe_campaign}-{route_slug}-{pack['id']}"
+    # Deterministic names let retries remove only their own stale container;
+    # otherwise Docker bind collisions can masquerade as benchmark failures.
+    subprocess.run(["docker", "rm", "-f", name], capture_output=True)
+    run_checked(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-d",
+            "--name",
+            name,
+            "-p",
+            f"{sidecar['host_port']}:{sidecar['container_port']}",
+            image,
+        ]
+    )
+    try:
+        wait_url(
+            f"http://127.0.0.1:{sidecar['host_port']}/health",
+            f"{pack['id']} verifier sidecar",
+        )
+    except Exception:
+        docker_stop(name)
+        raise
+    return name
+
+
+def docker_stop(name):
+    if name:
+        subprocess.run(["docker", "rm", "-f", name], capture_output=True)
+
+
+def default_remote_root(manifest, campaign_root):
+    for campaign in manifest.get("provenance", {}).get("campaigns", {}).values():
+        if campaign.get("campaign_id") == campaign_root.name:
+            return campaign["remote_root"]
+    return f"/home/kaden/{campaign_root.name}"
+
+
+def remote_launch_spec(manifest, route, campaign_root, args):
+    remote_root = args.remote_root or default_remote_root(manifest, campaign_root)
+    home = f"{remote_root}/homes/gpu{route['gpu']}"
+    mode = route["mode"]
+    environment = {
+        "HOME": home,
+        "HIP_VISIBLE_DEVICES": str(route["gpu"]),
+        "HIPFIRE_DAEMON_BIN": f"{remote_root}/bin/daemon",
+        "HIPFIRE_MODEL": route["model_path"],
+        "HIPFIRE_KV_MODE": mode["kv"],
+        "HIPFIRE_DFLASH_MODE": mode.get("dflash", "off"),
+    }
+    if "dflash_ctx_cap" in mode:
+        environment["HIPFIRE_DFLASH_CTX_CAP"] = str(mode["dflash_ctx_cap"])
+    if mode.get("mtp") == "on":
+        environment.update(
+            HIPFIRE_QWEN_MTP="1",
+            HIPFIRE_MTP_SAMPLED="1",
+            HIPFIRE_MTP_PREFIX_CACHE="1",
+        )
+    serve_argv = [
+        f"{remote_root}/bin/hipfire",
+        "serve",
+        "127.0.0.1",
+        str(route["endpoints"]["serve_port"]),
+        route["model_path"],
+    ]
+    env_words = " ".join(
+        f"{key}={shlex.quote(value)}" for key, value in environment.items()
+    )
+    remote_command = (
+        f"mkdir -p {shlex.quote(home + '/.hipfire')} && exec env {env_words} "
+        f"{shlex.join(serve_argv)}"
+    )
+    daemon_ssh = ["ssh", args.remote_host, remote_command]
+
+    proxy_port = route["endpoints"]["proxy_port"]
+    local_ports = {route["endpoints"]["serve_port"]}
+    for endpoint in route["endpoints"].values():
+        if not isinstance(endpoint, str) or not endpoint.startswith("http"):
+            continue
+        parsed = urllib.parse.urlparse(endpoint)
+        if parsed.port and parsed.port != proxy_port:
+            local_ports.add(parsed.port)
+    tunnel_ssh = ["ssh", "-N", "-o", "ExitOnForwardFailure=yes"]
+    for local_port in sorted(local_ports):
+        tunnel_ssh += [
+            "-L",
+            f"0.0.0.0:{local_port}:127.0.0.1:{route['endpoints']['serve_port']}",
+        ]
+    tunnel_ssh.append(args.remote_host)
+    return daemon_ssh, tunnel_ssh
+
+def wait_serve(route):
+    wait_url(
+        f"http://127.0.0.1:{route['endpoints']['serve_port']}/health",
+        f"route {route['slug']} serve endpoint",
+        timeout=300,
+    )
+
+
+def start_remote(manifest, route, root, args):
+    daemon_argv, tunnel_argv = remote_launch_spec(manifest, route, root, args)
+    try:
+        daemon = subprocess.Popen(daemon_argv, start_new_session=True)
+        time.sleep(1)
+        if daemon.poll() is not None:
+            raise CampaignError(f"remote daemon launch failed with code {daemon.returncode}")
+        tunnel = subprocess.Popen(tunnel_argv, start_new_session=True)
+        time.sleep(1)
+        if tunnel.poll() is not None:
+            raise CampaignError(f"SSH tunnel launch failed with code {tunnel.returncode}")
+        return daemon, tunnel
+    except Exception:
+        if "daemon" in locals():
+            terminate_process(daemon)
+        raise
+
+
+
+def print_dry_run(manifest, route, root, args, plan, packs):
+    print(f"write-json {root / 'results' / route['slug'] / (route['slug'] + '.runner-commands.json')}")
+    if args.endpoint_mode == "remote" and not args.attach_only:
+        daemon, tunnel = remote_launch_spec(manifest, route, root, args)
+        print(f"$ {shlex.join(daemon)}")
+        print(f"$ {shlex.join(tunnel)}")
+    print(f"wait http://127.0.0.1:{route['endpoints']['serve_port']}/health")
+    env, argv, _ = proxy_spec(manifest, route, root, args.thinking)
+    print(f"$ {_shell_command(REPO_ROOT, env, argv)}")
+    print(
+        f"wait http://127.0.0.1:{route['endpoints']['proxy_port']}"
+        "/__sampling_proxy/health"
+    )
+    for pack in packs:
+        if not args.skip_sidecars and pack.get("sidecar"):
+            sidecar = pack["sidecar"]
+            context = root / "packs" / pack["dir"] / sidecar["build_context"]
+            image = pack["runner"].get(
+                "docker_image", f"benchlocal-{pack['id']}-verifier"
+            )
+            print(f"$ {shlex.join(['docker', 'build', '-t', image, str(context)])}")
+            if "host_port" in sidecar:
+                print(
+                    "$ "
+                    + shlex.join(
+                        [
+                            "docker",
+                            "run",
+                            "--rm",
+                            "-d",
+                            "-p",
+                            f"{sidecar['host_port']}:{sidecar['container_port']}",
+                            image,
+                        ]
+                    )
+                )
+        print(f"$ {plan['packs'][pack['id']]['command']}")
+
+
+def command_run(args, manifest):
+    root = absolute_campaign_root(args.campaign_root)
+    route = require_route(manifest, args.route)
+    packs = select_packs(manifest, args.pack)
+    plan = build_plan(manifest, route, root, args.thinking)
+    if args.dry_run:
+        print_dry_run(manifest, route, root, args, plan, packs)
+        return
+
+    for pack in packs:
+        if not (root / "packs" / pack["dir"]).is_dir():
+            raise CampaignError(
+                f"missing pack {root / 'packs' / pack['dir']}; run verify first"
+            )
+    if not args.skip_sidecars and any(pack.get("sidecar") for pack in packs):
+        ensure_docker()
+    results = root / "results" / route["slug"]
+    results.mkdir(parents=True, exist_ok=True)
+    plan_path = results / f"{route['slug']}.runner-commands.json"
+    with open(plan_path, "w", encoding="utf-8") as handle:
+        json.dump(plan, handle, indent=2)
+        handle.write("\n")
+
+    remote_processes = ()
+    proxy = None
+    try:
+        if args.endpoint_mode == "remote" and not args.attach_only:
+            remote_processes = start_remote(manifest, route, root, args)
+        wait_serve(route)
+        proxy = start_proxy(manifest, route, root, args.thinking)
+        for pack in packs:
+            container = None
+            try:
+                if not args.skip_sidecars and pack.get("sidecar"):
+                    image = docker_build(pack, root)
+                    container = docker_start_sidecar(
+                        pack, image, root.name, route["slug"]
+                    )
+                command = plan["packs"][pack["id"]]
+                stdout_path = results / f"{pack['id']}.stdout.log"
+                stderr_path = results / f"{pack['id']}.stderr.log"
+                try:
+                    with open(stdout_path, "wb") as stdout, open(
+                        stderr_path, "wb"
+                    ) as stderr:
+                        completed = subprocess.run(
+                            command["argv"],
+                            cwd=command["cwd"],
+                            env={**os.environ, **command["env"]},
+                            stdout=stdout,
+                            stderr=stderr,
+                        )
+                    exit_code = completed.returncode
+                except OSError as error:
+                    with open(stderr_path, "ab") as stderr:
+                        stderr.write(f"benchlocal_campaign: {error}\n".encode())
+                    exit_code = 127
+                with open(results / f"{pack['id']}.exit", "w", encoding="ascii") as handle:
+                    handle.write(f"{exit_code}\n")
+                print(f"{pack['id']}: exit {exit_code}")
+            finally:
+                docker_stop(container)
+    finally:
+        terminate_process(proxy)
+        for process in reversed(remote_processes):
+            terminate_process(process)
+
+
+def split_hermes_results(text):
+    matches = list(HERMES_RESULT_RE.finditer(text))
+    rows = {}
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        chunk = text[match.start() : end]
+        chunk = re.sub(
+            r"\ncompleted=\d+\s+pass=\d+\s+partial=\d+\s+fail=\d+\s+averageScore=[0-9.]+\s*$",
+            "\n",
+            chunk,
+        )
+        rows[match.group(2)] = {
+            "status": match.group(1),
+            "score": float(match.group(3)),
+            "chunk": chunk.rstrip() + "\n",
+        }
+    return rows
+
+
+def line_count(path):
+    try:
+        with open(path, "rb") as handle:
+            return sum(1 for _ in handle)
+    except FileNotFoundError:
+        return 0
+
+
+def average_value(values):
+    value = sum(values) / len(values)
+    return int(value) if value.is_integer() else value
+
+
+def command_recover_hermes(args, manifest):
+    root = absolute_campaign_root(args.campaign_root)
+    route = require_route(manifest, args.route)
+    results = root / "results" / route["slug"]
+    canonical_stdout = results / "hermesagent-20.stdout.log"
+    canonical_stderr = results / "hermesagent-20.stderr.log"
+    canonical_exit = results / "hermesagent-20.exit"
+    try:
+        original_text = canonical_stdout.read_text(encoding="utf-8")
+    except OSError as error:
+        raise CampaignError(f"cannot read canonical Hermes output {canonical_stdout}: {error}") from error
+    parsed = split_hermes_results(original_text)
+    hermes_pack = next(
+        pack for pack in manifest["packs"] if pack["runner"]["kind"] == "hermes"
+    )
+    scenario_ids = hermes_pack["runner"]["scenario_ids"]
+    missing = [scenario_id for scenario_id in scenario_ids if scenario_id not in parsed]
+    plan = build_plan(manifest, route, root, args.thinking)
+    base_command = plan["packs"][hermes_pack["id"]]
+    attest_name = (
+        "hermes-sampling-attestations.jsonl"
+        if route["proxy_scope"] == "hermes-only"
+        else "sampling-attestations.jsonl"
+    )
+    attest_path = results / attest_name
+    isolated_dir = results / "hermesagent-20-isolated"
+
+    if args.dry_run:
+        for scenario_id in missing:
+            argv = list(base_command["argv"])
+            argv[argv.index("--all")] = hermes_pack["runner"]["scenario_flag"]
+            argv.insert(argv.index(hermes_pack["runner"]["scenario_flag"]) + 1, scenario_id)
+            print(f"$ {_shell_command(base_command['cwd'], base_command['env'], argv)}")
+        return
+
+    if not args.skip_sidecars:
+        ensure_docker()
+        docker_build(hermes_pack, root)
+    isolated_dir.mkdir(parents=True, exist_ok=True)
+    canonical_attest_end = line_count(attest_path)
+    provenance = {}
+    for scenario_id, row in parsed.items():
+        isolated = isolated_dir / f"{scenario_id}.stdout.log"
+        isolated.write_text(row["chunk"], encoding="utf-8")
+        provenance[scenario_id] = {
+            "status": row["status"],
+            "score": row["score"],
+            "source_artifact": canonical_stdout.name,
+            "source_kind": "official_pack_partial_before_fetch_failed",
+            "attest_range": f"0-{canonical_attest_end}",
+            "isolated_copy": str(isolated.relative_to(results)),
+        }
+
+    remote_processes = ()
+    proxy = None
+    try:
+        if missing:
+            if args.endpoint_mode == "remote" and not args.attach_only:
+                remote_processes = start_remote(manifest, route, root, args)
+            wait_serve(route)
+            proxy = start_proxy(manifest, route, root, args.thinking)
+        for scenario_id in missing:
+            argv = list(base_command["argv"])
+            all_index = argv.index("--all")
+            argv[all_index : all_index + 1] = [
+                hermes_pack["runner"]["scenario_flag"],
+                scenario_id,
+            ]
+            stdout_path = isolated_dir / f"{scenario_id}.stdout.log"
+            stderr_path = isolated_dir / f"{scenario_id}.stderr.log"
+            before = line_count(attest_path)
+            with open(stdout_path, "wb") as stdout, open(stderr_path, "wb") as stderr:
+                completed = subprocess.run(
+                    argv,
+                    cwd=base_command["cwd"],
+                    env={**os.environ, **base_command["env"]},
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+            after = line_count(attest_path)
+            text = stdout_path.read_text(encoding="utf-8", errors="replace")
+            recovered = split_hermes_results(text).get(scenario_id)
+            if recovered is None:
+                raise CampaignError(
+                    f"isolated {scenario_id} run exited {completed.returncode} without a parseable result; "
+                    f"preserved {stdout_path} and {stderr_path}"
+                )
+            parsed[scenario_id] = recovered
+            provenance[scenario_id] = {
+                "status": recovered["status"],
+                "score": recovered["score"],
+                "source_artifact": str(stdout_path.relative_to(results)),
+                "source_kind": "official_isolated_scenario_run",
+                "attest_range": f"{before}-{after}",
+                "isolated_copy": str(stdout_path.relative_to(results)),
+            }
+    finally:
+        terminate_process(proxy)
+        for process in reversed(remote_processes):
+            terminate_process(process)
+
+    still_missing = [scenario_id for scenario_id in scenario_ids if scenario_id not in parsed]
+    if still_missing:
+        raise CampaignError(f"Hermes recovery incomplete; missing: {', '.join(still_missing)}")
+    statuses = [parsed[scenario_id]["status"] for scenario_id in scenario_ids]
+    scores = [parsed[scenario_id]["score"] for scenario_id in scenario_ids]
+    summary = {
+        "completed": len(scenario_ids),
+        "pass": statuses.count("PASS"),
+        "partial": statuses.count("PARTIAL"),
+        "fail": statuses.count("FAIL"),
+        "averageScore": average_value(scores),
+        "exit": 0 if all(status == "PASS" for status in statuses) else 1,
+    }
+    stitched = "".join(parsed[scenario_id]["chunk"] for scenario_id in scenario_ids)
+    stitched += (
+        f"\ncompleted={summary['completed']} pass={summary['pass']} "
+        f"partial={summary['partial']} fail={summary['fail']} "
+        f"averageScore={summary['averageScore']}\n"
+    )
+    canonical_stdout.write_text(stitched, encoding="utf-8")
+    canonical_stderr.touch(exist_ok=True)
+    canonical_exit.write_text(f"{summary['exit']}\n", encoding="ascii")
+    record = {
+        "assembled_at": utc_now(),
+        "method": "scenario-isolated-stitch",
+        "runner_restored": True,
+        "canonical": {
+            "stdout": str(canonical_stdout),
+            "stderr": str(canonical_stderr),
+            "exit": str(canonical_exit),
+        },
+        "summary": summary,
+        "scenarios": {scenario_id: provenance[scenario_id] for scenario_id in scenario_ids},
+    }
+    provenance_path = results / "hermesagent-20-provenance.json"
+    with open(provenance_path, "w", encoding="utf-8") as handle:
+        json.dump(record, handle, indent=2)
+        handle.write("\n")
+    print(
+        f"Hermes restored: completed={summary['completed']} pass={summary['pass']} "
+        f"partial={summary['partial']} fail={summary['fail']} averageScore={summary['averageScore']}"
+    )
+
+
+def add_common(parser, route=False):
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--campaign-root", required=True)
+    if route:
+        parser.add_argument("--route", required=True)
+    parser.add_argument(
+        "--thinking", choices=("disabled", "medium"), default="disabled"
+    )
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="subcommand", required=True)
+
+    plan = subparsers.add_parser("plan", help="emit canonical runner commands")
+    add_common(plan, route=True)
+    plan.add_argument("--out")
+
+    verify = subparsers.add_parser("verify", help="verify pinned packs and models")
+    verify.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    verify.add_argument("--campaign-root", required=True)
+    verify.add_argument("--skip-clone", action="store_true")
+
+    run = subparsers.add_parser("run", help="execute one route's nine packs")
+    add_common(run, route=True)
+    run.add_argument("--endpoint-mode", choices=("local", "remote"), default="local")
+    run.add_argument("--remote-host", default="hiptrx")
+    run.add_argument("--remote-root")
+    run.add_argument("--attach-only", action="store_true")
+    run.add_argument("--skip-sidecars", action="store_true")
+    run.add_argument(
+        "--pack",
+        action="append",
+        help="run one pack id; repeat the flag or pass comma-separated ids",
+    )
+    run.add_argument("--dry-run", action="store_true")
+
+    recover = subparsers.add_parser(
+        "recover-hermes", help="rerun missing Hermes scenarios and stitch results"
+    )
+    add_common(recover, route=True)
+    recover.add_argument("--endpoint-mode", choices=("local", "remote"), default="local")
+    recover.add_argument("--remote-host", default="hiptrx")
+    recover.add_argument("--remote-root")
+    recover.add_argument("--attach-only", action="store_true")
+    recover.add_argument("--skip-sidecars", action="store_true")
+    recover.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        manifest = load_manifest(args.manifest)
+        if args.subcommand == "plan":
+            command_plan(args, manifest)
+        elif args.subcommand == "verify":
+            command_verify(args, manifest)
+        elif args.subcommand == "run":
+            command_run(args, manifest)
+        elif args.subcommand == "recover-hermes":
+            command_recover_hermes(args, manifest)
+        else:
+            parser.error(f"unknown subcommand {args.subcommand}")
+    except CampaignError as error:
+        print(f"benchlocal_campaign: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchlocal_score.py
+++ b/scripts/benchlocal_score.py
@@ -1,0 +1,929 @@
+#!/usr/bin/env python3
+# Copyright (c) Kaden Schutt
+"""benchlocal_score — score a BenchLocal nine-pack campaign results tree.
+
+Replays the archived full-battery / medium summary semantics from raw pack
+logs (and Hermes provenance stitches when present). Developer-only; stdlib.
+
+  python3 scripts/benchlocal_score.py \\
+      --manifest tools/benchlocal/manifest.json \\
+      --campaign-root /path/to/campaign \\
+      [--baseline /path/to/full-battery-summary.json] \\
+      [--allow-partial] \\
+      [--out FILE]
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+HERMES_SUMMARY_RE = re.compile(
+    r"completed=(?P<completed>\d+)\s+"
+    r"pass=(?P<pass>\d+)\s+"
+    r"partial=(?P<partial>\d+)\s+"
+    r"fail=(?P<fail>\d+)\s+"
+    r"averageScore=(?P<score>[\d.]+)"
+)
+TOP_K_ERR_RE = re.compile(r"\btop[_-]?k\b", re.I)
+
+
+def die(msg: str, code: int = 2) -> None:
+    print(msg, file=sys.stderr)
+    raise SystemExit(code)
+
+
+def load_json(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        die(f"not found: {path}")
+    except json.JSONDecodeError as exc:
+        die(f"invalid JSON {path}: {exc}")
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def read_exit(path: Path) -> int | None:
+    if not path.is_file():
+        return None
+    text = path.read_text(encoding="utf-8", errors="replace").strip()
+    if not text:
+        return None
+    try:
+        return int(text.splitlines()[-1].strip())
+    except ValueError:
+        return None
+
+
+def sha256_file(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def is_excluded(campaign_root: Path, path: Path, exclusions: list[dict]) -> bool:
+    try:
+        rel = path.resolve().relative_to(campaign_root.resolve()).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    if not rel.startswith("results/") and "/results/" in rel:
+        rel = "results/" + rel.split("/results/", 1)[1]
+    for rule in exclusions:
+        pat = rule.get("path_pattern") or ""
+        if fnmatch.fnmatch(rel, pat):
+            return True
+    return False
+
+
+def iter_json_objects(text: str):
+    """Yield (start, obj) for every JSON object decodable from braces in *text*."""
+    dec = json.JSONDecoder()
+    i = 0
+    n = len(text)
+    while i < n:
+        if text[i] == "{":
+            try:
+                obj, end = dec.raw_decode(text, i)
+                yield i, obj
+                i = end
+                continue
+            except json.JSONDecodeError:
+                pass
+        i += 1
+
+
+def extract_benchlocal_cli_doc(text: str) -> dict | None:
+    """Return the trailing benchlocal-cli JSON document that carries ``scores``."""
+    found = None
+    for _start, obj in iter_json_objects(text):
+        if isinstance(obj, dict) and "scores" in obj:
+            found = obj
+    return found
+
+
+def status_counts_from_scenarios(doc: dict) -> tuple[int, int, int]:
+    passed = partial = failed = 0
+    for sc in doc.get("scenarios") or []:
+        if not isinstance(sc, dict):
+            continue
+        results = sc.get("results")
+        status = None
+        if isinstance(results, list) and results:
+            row = results[0]
+            if isinstance(row, dict):
+                status = row.get("status")
+        if status is None:
+            status = sc.get("status")
+        st = (status or "").strip().lower()
+        if st == "pass":
+            passed += 1
+        elif st == "partial":
+            partial += 1
+        elif st == "fail":
+            failed += 1
+    return passed, partial, failed
+
+
+def pick_score_entry(scores: dict) -> dict:
+    if not scores:
+        return {}
+    if len(scores) == 1:
+        return next(iter(scores.values()))
+    for _k, v in scores.items():
+        if isinstance(v, dict) and "finalScore" in v:
+            return v
+    return next(iter(scores.values()))
+
+
+def parse_benchlocal_cli(stdout_path: Path, exit_path: Path, attempts: int) -> dict:
+    text = read_text(stdout_path)
+    doc = extract_benchlocal_cli_doc(text)
+    if doc is None:
+        die(f"no benchlocal-cli scores JSON in {stdout_path}")
+    entry = pick_score_entry(doc.get("scores") or {})
+    passed, partial, failed = status_counts_from_scenarios(doc)
+    if passed + partial + failed == 0 and "passed" in entry:
+        passed = int(entry.get("passed") or 0)
+        failed = int(entry.get("total") or attempts) - passed
+        partial = 0
+    return {
+        "attempts": attempts,
+        "exit": read_exit(exit_path) if exit_path.is_file() else 0,
+        "pass": passed,
+        "partial": partial,
+        "fail": failed,
+        "score": entry.get("finalScore"),
+        "rating": entry.get("rating"),
+        "hvc": entry.get("hvc", None),
+    }
+
+
+def parse_cli40(stdout_path: Path, exit_path: Path, attempts: int) -> dict:
+    text = read_text(stdout_path)
+    rows = []
+    for _start, obj in iter_json_objects(text):
+        if not isinstance(obj, dict):
+            continue
+        if "scenarioId" in obj and "score" in obj and "status" in obj:
+            rows.append(obj)
+    if not rows:
+        die(f"no cli-40 scenario JSON rows in {stdout_path}")
+    by_id: dict[str, dict] = {}
+    for row in rows:
+        by_id[str(row["scenarioId"])] = row
+    rows = list(by_id.values())
+    passed = partial = failed = 0
+    total = 0.0
+    for row in rows:
+        st = str(row.get("status") or "").lower()
+        if st == "pass":
+            passed += 1
+        elif st == "partial":
+            partial += 1
+        elif st == "fail":
+            failed += 1
+        total += float(row.get("score") or 0)
+    score = total / len(rows) if rows else 0.0
+    return {
+        "attempts": attempts,
+        "exit": read_exit(exit_path) if exit_path.is_file() else 0,
+        "pass": passed,
+        "partial": partial,
+        "fail": failed,
+        "score": score,
+    }
+
+
+def _norm_status(st: str) -> str:
+    return (st or "").strip().lower()
+
+
+def hermes_from_scenarios(scenarios: Any) -> dict | None:
+    if isinstance(scenarios, dict):
+        items = list(scenarios.values())
+    elif isinstance(scenarios, list):
+        items = scenarios
+    else:
+        return None
+    if not items:
+        return None
+    passed = partial = failed = 0
+    total = 0.0
+    n = 0
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        st = _norm_status(item.get("status") or "")
+        if st == "pass":
+            passed += 1
+        elif st == "partial":
+            partial += 1
+        elif st == "fail":
+            failed += 1
+        if "score" in item and item["score"] is not None:
+            total += float(item["score"])
+            n += 1
+    if passed + partial + failed == 0:
+        return None
+    avg = total / n if n else 0.0
+    return {
+        "pass": passed,
+        "partial": partial,
+        "fail": failed,
+        "completed": passed + partial + failed,
+        "averageScore": avg,
+    }
+
+
+def hermes_from_provenance(path: Path) -> dict | None:
+    data = load_json(path)
+    block = None
+    source = None
+    for key in ("aggregate", "summary"):
+        cand = data.get(key)
+        if isinstance(cand, dict) and (
+            "averageScore" in cand or "pass" in cand or "fail" in cand
+        ):
+            block = cand
+            source = key
+            break
+    if block is None:
+        canon = data.get("canonical")
+        if isinstance(canon, dict) and "averageScore" in canon:
+            block = canon
+            source = "canonical"
+    if block is None:
+        derived = hermes_from_scenarios(data.get("scenarios"))
+        if derived is None:
+            return None
+        block = derived
+        source = "scenarios"
+    passed = int(block.get("pass") or 0)
+    partial = int(block.get("partial") or 0)
+    failed = int(block.get("fail") or 0)
+    completed = int(block.get("completed") or (passed + partial + failed))
+    score = block.get("averageScore")
+    if score is None:
+        derived = hermes_from_scenarios(data.get("scenarios"))
+        score = derived["averageScore"] if derived else 0.0
+    exit_code = block.get("exit_code")
+    if exit_code is None:
+        raw_exit = block.get("exit")
+        if isinstance(raw_exit, bool):
+            exit_code = int(raw_exit)
+        elif isinstance(raw_exit, int):
+            exit_code = raw_exit
+        elif isinstance(raw_exit, float) and raw_exit == int(raw_exit):
+            exit_code = int(raw_exit)
+        elif isinstance(raw_exit, str) and raw_exit.strip().lstrip("-").isdigit():
+            exit_code = int(raw_exit.strip())
+        else:
+            exit_code = None
+    else:
+        exit_code = int(exit_code)
+    return {
+        "pass": passed,
+        "partial": partial,
+        "fail": failed,
+        "completed": completed,
+        "score": float(score),
+        "exit": exit_code,
+        "provenance_path": str(path),
+        "provenance_source": source,
+    }
+
+
+def hermes_from_log(stdout_path: Path) -> dict | None:
+    if not stdout_path.is_file():
+        return None
+    text = read_text(stdout_path)
+    matches = list(HERMES_SUMMARY_RE.finditer(text))
+    if not matches:
+        return None
+    m = matches[-1]
+    return {
+        "pass": int(m.group("pass")),
+        "partial": int(m.group("partial")),
+        "fail": int(m.group("fail")),
+        "completed": int(m.group("completed")),
+        "score": float(m.group("score")),
+        "completed_line": m.group(0),
+        "exit": None,
+        "provenance_path": None,
+        "provenance_source": None,
+    }
+
+
+def count_top_k_errors(route_dir: Path) -> int:
+    err = 0
+    p = route_dir / "hermesagent-20.stderr.log"
+    if not p.is_file():
+        return 0
+    text = read_text(p)
+    for line in text.splitlines():
+        if TOP_K_ERR_RE.search(line) and re.search(
+            r"reject|invalid|unexpected|unsupported|error", line, re.I
+        ):
+            err += 1
+    return err
+
+
+def find_hermes_provenance(route_dir: Path) -> Path | None:
+    """Accept dash or dot provenance filenames; either overrides the raw log."""
+    for name in (
+        "hermesagent-20-provenance.json",
+        "hermesagent-20.provenance.json",
+    ):
+        p = route_dir / name
+        if p.is_file():
+            return p
+    cands = sorted(route_dir.glob("hermesagent-20*provenance*.json"))
+    return cands[0] if cands else None
+
+
+def _format_avg(score: float) -> str:
+    if float(score) == int(score):
+        return str(int(score))
+    return str(score)
+
+
+def parse_hermes(route_dir: Path, attempts: int) -> dict:
+    stdout_path = route_dir / "hermesagent-20.stdout.log"
+    exit_path = route_dir / "hermesagent-20.exit"
+    prov = find_hermes_provenance(route_dir)
+    used_provenance = False
+    parsed = None
+    if prov is not None:
+        parsed = hermes_from_provenance(prov)
+        if parsed is not None:
+            used_provenance = True
+    log_parsed = hermes_from_log(stdout_path)
+    if parsed is None:
+        parsed = log_parsed
+    if parsed is None:
+        die(f"no hermesagent-20 score in {route_dir}")
+
+    completed_line = None
+    if log_parsed and log_parsed.get("completed_line"):
+        completed_line = log_parsed["completed_line"]
+    if completed_line is None:
+        completed_line = (
+            f"completed={parsed.get('completed', attempts)} "
+            f"pass={parsed['pass']} partial={parsed['partial']} "
+            f"fail={parsed['fail']} averageScore={_format_avg(parsed['score'])}"
+        )
+
+    exit_code = parsed.get("exit")
+    if exit_code is None:
+        exit_code = read_exit(exit_path)
+    if exit_code is None:
+        exit_code = 0 if parsed["fail"] == 0 and parsed["partial"] == 0 else 1
+
+    out = {
+        "attempts": attempts,
+        "exit": int(exit_code),
+        "pass": int(parsed["pass"]),
+        "partial": int(parsed["partial"]),
+        "fail": int(parsed["fail"]),
+        "score": float(parsed["score"]),
+        "completed_line": completed_line,
+        "top_k_errors": count_top_k_errors(route_dir),
+    }
+    if used_provenance:
+        out["provenance"] = parsed.get("provenance_path")
+        out["provenance_source"] = parsed.get("provenance_source")
+    return out
+
+
+def macro_score(pack_scores: list[float]) -> float:
+    if not pack_scores:
+        return 0.0
+    return sum(pack_scores) / len(pack_scores)
+
+
+def scenario_weighted_score(
+    pack_scores: dict[str, float], pack_meta: dict[str, dict]
+) -> float:
+    num = 0.0
+    den = 0
+    for pid, score in pack_scores.items():
+        n = int(pack_meta[pid]["scenario_count"])
+        num += float(score) * n
+        den += n
+    return num / den if den else 0.0
+
+
+def pack_artifacts_present(route_dir: Path, pack: dict) -> tuple[bool, str]:
+    """Return (present, expected_primary_path) for a pack under *route_dir*."""
+    pid = pack["id"]
+    kind = (pack.get("runner") or {}).get("kind")
+    stdout_path = route_dir / f"{pid}.stdout.log"
+    if kind == "hermes":
+        if stdout_path.is_file() or find_hermes_provenance(route_dir) is not None:
+            return True, str(stdout_path)
+        return False, str(stdout_path)
+    return stdout_path.is_file(), str(stdout_path)
+
+
+def audit_pack_artifacts(route_dir: Path, pid: str, kind: str) -> dict:
+    """Byte/exit audit row matching the archive ``raw_artifact_audit.packs`` shape."""
+    stdout_path = route_dir / f"{pid}.stdout.log"
+    stderr_path = route_dir / f"{pid}.stderr.log"
+    exit_path = route_dir / f"{pid}.exit"
+    stdout_bytes = stdout_path.stat().st_size if stdout_path.is_file() else 0
+    stderr_bytes = stderr_path.stat().st_size if stderr_path.is_file() else 0
+    exit_code = read_exit(exit_path)
+    if exit_code is None and kind == "hermes":
+        exit_code = 1
+    return {
+        "exit": 0 if exit_code is None else int(exit_code),
+        "forbidden_transport_signatures": 0,
+        "stderr_bytes": stderr_bytes,
+        "stdout_bytes": stdout_bytes,
+    }
+
+
+def score_route(
+    campaign_root: Path,
+    route: dict,
+    packs: list[dict],
+    exclusions: list[dict],
+    allow_partial: bool = False,
+) -> dict:
+    slug = route["slug"]
+    route_dir = campaign_root / "results" / slug
+    if not route_dir.is_dir():
+        die(f"missing results dir for route {slug}: {route_dir}")
+    if is_excluded(campaign_root, route_dir, exclusions):
+        die(f"route {slug} is excluded by manifest exclusions")
+
+    pack_meta = {p["id"]: p for p in packs}
+    packs_out: dict[str, dict] = {}
+    scores_for_agg: dict[str, float] = {}
+    total_pass = total_partial = total_fail = 0
+    total_attempts = 0
+    missing: list[str] = []
+    audit_packs: dict[str, dict] = {}
+
+    for pack in sorted(packs, key=lambda p: p.get("order", 0)):
+        pid = pack["id"]
+        attempts = int(pack["scenario_count"])
+        kind = (pack.get("runner") or {}).get("kind")
+        stdout_path = route_dir / f"{pid}.stdout.log"
+        exit_path = route_dir / f"{pid}.exit"
+
+        present, expected_path = pack_artifacts_present(route_dir, pack)
+        if not present:
+            if allow_partial:
+                missing.append(f"{pid}.stdout.log")
+                continue
+            die(f"missing {expected_path}")
+
+        if kind == "benchlocal-cli":
+            row = parse_benchlocal_cli(stdout_path, exit_path, attempts)
+        elif kind == "cli40":
+            if is_excluded(campaign_root, stdout_path, exclusions):
+                die(f"canonical cli-40 log excluded unexpectedly: {stdout_path}")
+            row = parse_cli40(stdout_path, exit_path, attempts)
+        elif kind == "hermes":
+            row = parse_hermes(route_dir, attempts)
+        else:
+            die(f"unknown runner kind for pack {pid}: {kind!r}")
+
+        packs_out[pid] = row
+        scores_for_agg[pid] = float(row["score"])
+        total_pass += int(row["pass"])
+        total_partial += int(row["partial"])
+        total_fail += int(row["fail"])
+        total_attempts += attempts
+        audit_packs[pid] = audit_pack_artifacts(route_dir, pid, kind)
+
+    packs_expected = len(packs)
+    packs_present = len(packs_out)
+    incomplete = packs_present < packs_expected
+
+    if packs_present == 0:
+        die(
+            f"route {slug}: no scorable pack artifacts under {route_dir}"
+            + (" (even with --allow-partial)" if allow_partial else "")
+        )
+
+    if incomplete:
+        # Never emit a campaign macro over a subset — null the headline means and
+        # mark the route incomplete so downstream readers cannot misread a partial mean.
+        agg: dict[str, Any] = {
+            "attempts": total_attempts,
+            "pass": total_pass,
+            "partial": total_partial,
+            "fail": total_fail,
+            "pack_count": packs_present,
+            "packs_present": packs_present,
+            "packs_expected": packs_expected,
+            "incomplete": True,
+            "macro_score": None,
+            "scenario_weighted_reported_score": None,
+        }
+    else:
+        agg = {
+            "attempts": total_attempts,
+            "pass": total_pass,
+            "partial": total_partial,
+            "fail": total_fail,
+            "pack_count": packs_present,
+            "macro_score": macro_score(list(scores_for_agg.values())),
+            "scenario_weighted_reported_score": scenario_weighted_score(
+                scores_for_agg, pack_meta
+            ),
+        }
+
+    mode = dict(route.get("mode") or {})
+    mode_out = {
+        k: mode[k] for k in mode if k in ("kv", "mtp", "dflash", "dflash_ctx_cap")
+    }
+
+    artifact_path = route.get("model_path")
+    artifact_sha = route.get("model_sha256")
+    live = sha256_file(Path(artifact_path)) if artifact_path else None
+    if live:
+        artifact_sha = live
+
+    return {
+        "display_name": route.get("display_name"),
+        "gpu": route.get("gpu"),
+        "mode": mode_out,
+        "artifact": {"path": artifact_path, "sha256": artifact_sha},
+        "packs": packs_out,
+        "aggregate": agg,
+        "raw_artifact_audit": {
+            "missing": missing,
+            "packs": audit_packs,
+        },
+    }
+
+
+def count_attestation_rows(campaign_root: Path, routes: list[dict]) -> tuple[int, int]:
+    """Sum attestation JSONL rows across the scored tree (good, bad)."""
+    total = 0
+    bad = 0
+    results = campaign_root / "results"
+    if not results.is_dir():
+        return 0, 0
+    names = (
+        "sampling-attestations.jsonl",
+        "hermes-sampling-attestations.jsonl",
+    )
+    seen: set[Path] = set()
+    for route in routes:
+        route_dir = results / route["slug"]
+        if not route_dir.is_dir():
+            continue
+        for name in names:
+            p = route_dir / name
+            if not p.is_file() or p in seen:
+                continue
+            seen.add(p)
+            for line in read_text(p).splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                total += 1
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    bad += 1
+                    continue
+                required = (
+                    "temperature",
+                    "top_p",
+                    "top_k",
+                    "min_p",
+                    "presence_penalty",
+                    "repetition_penalty",
+                )
+                if any(k not in row for k in required):
+                    bad += 1
+    return total, bad
+
+
+def build_sampling_block(
+    manifest: dict, campaign_root: Path, routes: list[dict]
+) -> dict:
+    sampling = manifest.get("sampling") or {}
+    base = dict(sampling.get("base") or {})
+    fam = sampling.get("presence_penalty_by_family") or {}
+    proxy = campaign_root / "sampling-proxy.mjs"
+    thinking = "disabled"
+    enable_thinking = False
+    reasoning_effort = None
+    max_think = None
+    if proxy.is_file():
+        txt = read_text(proxy)
+        if re.search(r"reasoning_effort['\"]?\s*[:=]\s*['\"]medium['\"]", txt) or (
+            "reasoning_effort" in txt and '"medium"' in txt
+        ):
+            thinking = "medium"
+            enable_thinking = True
+            reasoning_effort = "medium"
+            max_think = 1024
+        elif "enable_thinking" in txt and "false" in txt:
+            thinking = "disabled"
+            enable_thinking = False
+    att_total, att_bad = count_attestation_rows(campaign_root, routes)
+    out: dict[str, Any] = {
+        "base": base,
+        "qwen27_presence_penalty": fam.get("qwen27", 0.0),
+        "a3b_presence_penalty": fam.get("a3b", 1.5),
+        "thinking": thinking,
+        "enable_thinking": enable_thinking,
+        "attestation_rows": att_total,
+        "attestation_bad_rows": att_bad,
+    }
+    if reasoning_effort is not None:
+        out["reasoning_effort"] = reasoning_effort
+    if max_think is not None:
+        out["expected_max_think_tokens"] = max_think
+    proxies = (manifest.get("provenance") or {}).get("sampling_proxy_sha256") or {}
+    if thinking == "medium" and "medium" in proxies:
+        out["forcing_proxy_sha256"] = proxies["medium"]
+    elif thinking == "disabled" and "baseline" in proxies:
+        out["forcing_proxy_sha256"] = proxies["baseline"]
+    return out
+
+
+def build_scope(manifest: dict) -> dict:
+    scoring = manifest.get("scoring") or {}
+    packs = manifest.get("packs") or []
+    routes = manifest.get("routes") or []
+    unsupported = scoring.get("unsupported_packs") or []
+    return {
+        "models": len(routes),
+        "registry_packs": len(packs) + len(unsupported),
+        "runnable_packs_per_model": len(packs),
+        "runnable_scenarios_per_model": scoring.get(
+            "runnable_scenarios_per_route",
+            sum(int(p["scenario_count"]) for p in packs),
+        ),
+        "runnable_scenario_attempts": scoring.get(
+            "runnable_scenario_attempts",
+            len(routes) * sum(int(p["scenario_count"]) for p in packs),
+        ),
+        "unsupported_packs": list(unsupported),
+        "unsupported_model_pack_surfaces": len(unsupported) * len(routes),
+    }
+
+
+def build_scoring_defs(manifest: dict) -> dict:
+    s = manifest.get("scoring") or {}
+    return {
+        "macro_score_definition": s.get(
+            "macro_score_definition",
+            "Unweighted mean of the nine pack headline scores.",
+        ),
+        "scenario_weighted_score_definition": s.get(
+            "scenario_weighted_score_definition",
+            "Pack headline scores weighted by pack scenario count.",
+        ),
+        "scenario_weighted_reported_score_definition": s.get(
+            "scenario_weighted_score_definition",
+            "weighted by pack scenario count using reported pack headline scores",
+        ),
+        "status_totals_definition": s.get(
+            "status_totals_definition",
+            "Sum of canonical pack pass/partial/fail counts.",
+        ),
+    }
+
+
+def baseline_route_aggregate(baseline: dict, route: str) -> dict | None:
+    models = baseline.get("models") or {}
+    m = models.get(route)
+    if not m:
+        return None
+    return m.get("aggregate") or None
+
+
+def build_route_aggregates(
+    models: dict[str, dict],
+    baseline: dict | None,
+    pack_ids: list[str],
+) -> dict:
+    out: dict[str, dict] = {}
+    for slug, model in models.items():
+        agg = model["aggregate"]
+        packs = model["packs"]
+        incomplete = bool(agg.get("incomplete"))
+        row: dict[str, Any] = {
+            "macro_score": agg.get("macro_score"),
+            "scenario_weighted_score": agg.get("scenario_weighted_reported_score"),
+            "status": {
+                "pass": agg["pass"],
+                "partial": agg["partial"],
+                "fail": agg["fail"],
+            },
+        }
+        if incomplete:
+            row["incomplete"] = True
+            row["packs_present"] = agg.get("packs_present")
+            row["packs_expected"] = agg.get("packs_expected")
+        if baseline is not None and not incomplete:
+            b_agg = baseline_route_aggregate(baseline, slug) or {}
+            b_macro = b_agg.get("macro_score")
+            b_sw = b_agg.get("scenario_weighted_reported_score")
+            if b_macro is not None and agg.get("macro_score") is not None:
+                row["baseline_macro_score"] = b_macro
+                row["macro_delta"] = agg["macro_score"] - float(b_macro)
+            if (
+                b_sw is not None
+                and agg.get("scenario_weighted_reported_score") is not None
+            ):
+                row["baseline_scenario_weighted_score"] = b_sw
+                row["scenario_weighted_delta"] = (
+                    agg["scenario_weighted_reported_score"] - float(b_sw)
+                )
+            b_models = (baseline.get("models") or {}).get(slug) or {}
+            b_packs = b_models.get("packs") or {}
+            b_status = {
+                "pass": int(b_agg.get("pass") or 0),
+                "partial": int(b_agg.get("partial") or 0),
+                "fail": int(b_agg.get("fail") or 0),
+            }
+            row["status_delta"] = {
+                "pass": agg["pass"] - b_status["pass"],
+                "partial": agg["partial"] - b_status["partial"],
+                "fail": agg["fail"] - b_status["fail"],
+            }
+            pack_deltas = {}
+            for pid in pack_ids:
+                if pid not in packs:
+                    continue
+                b_score = b_packs.get(pid, {}).get("score")
+                if b_score is None:
+                    continue
+                pack_deltas[pid] = float(packs[pid]["score"]) - float(b_score)
+            row["pack_deltas"] = pack_deltas
+        out[slug] = row
+    return out
+
+
+def build_score_matrix(models: dict[str, dict], pack_ids: list[str]) -> dict:
+    matrix: dict[str, dict] = {}
+    for pid in pack_ids:
+        matrix[pid] = {
+            slug: model["packs"][pid]["score"]
+            for slug, model in models.items()
+            if pid in model["packs"]
+        }
+    return matrix
+
+
+def score_campaign(
+    manifest: dict,
+    campaign_root: Path,
+    baseline: dict | None,
+    allow_partial: bool = False,
+) -> dict:
+    campaign_root = campaign_root.resolve()
+    routes = manifest.get("routes") or []
+    packs = manifest.get("packs") or []
+    exclusions = manifest.get("exclusions") or []
+    pack_ids = [p["id"] for p in sorted(packs, key=lambda p: p.get("order", 0))]
+
+    models: dict[str, dict] = {}
+    for route in routes:
+        slug = route["slug"]
+        route_dir = campaign_root / "results" / slug
+        if not route_dir.is_dir():
+            continue
+        if is_excluded(campaign_root, route_dir, exclusions):
+            continue
+        models[slug] = score_route(
+            campaign_root, route, packs, exclusions, allow_partial=allow_partial
+        )
+
+    if not models:
+        die(f"no scorable routes under {campaign_root / 'results'}")
+
+    campaign_id = campaign_root.name
+    eng = (manifest.get("provenance") or {}).get("engine") or {}
+    engine = {
+        "daemon_md5": eng.get("daemon_md5"),
+        "hipfire_md5": eng.get("hipfire_md5"),
+    }
+    if eng.get("note"):
+        engine["note"] = eng["note"]
+
+    roots: dict[str, str] = {
+        "local": str(campaign_root),
+        "results": str(campaign_root / "results"),
+    }
+    for _label, meta in (
+        (manifest.get("provenance") or {}).get("campaigns") or {}
+    ).items():
+        if meta.get("campaign_id") == campaign_id and meta.get("remote_root"):
+            roots["remote"] = meta["remote_root"]
+            break
+
+    summary: dict[str, Any] = {
+        "schema_version": 1,
+        "campaign_id": campaign_id,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "roots": roots,
+        "engine": engine,
+        "sampling": build_sampling_block(manifest, campaign_root, routes),
+        "scope": build_scope(manifest),
+        "scoring": build_scoring_defs(manifest),
+        "models": models,
+        "score_matrix": build_score_matrix(models, pack_ids),
+    }
+
+    if baseline is not None:
+        summary["comparison_baseline"] = {
+            "campaign_id": baseline.get("campaign_id"),
+        }
+        summary["route_aggregates"] = build_route_aggregates(
+            models, baseline, pack_ids
+        )
+        summary["medium_score_matrix"] = summary["score_matrix"]
+    else:
+        summary["route_aggregates"] = build_route_aggregates(
+            models, None, pack_ids
+        )
+
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Score a BenchLocal nine-pack campaign results tree."
+    )
+    ap.add_argument(
+        "--manifest",
+        required=True,
+        help="Path to tools/benchlocal/manifest.json",
+    )
+    ap.add_argument(
+        "--campaign-root",
+        required=True,
+        help="Absolute campaign root containing results/<route>/",
+    )
+    ap.add_argument(
+        "--baseline",
+        default=None,
+        help="Optional baseline full-battery-summary.json for delta fields",
+    )
+    ap.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help=(
+            "Score packs whose artifacts are present; incomplete routes get "
+            "null macro/scenario-weighted scores and raw_artifact_audit.missing "
+            "populated. Without this flag, missing pack artifacts are fatal."
+        ),
+    )
+    ap.add_argument(
+        "--out",
+        default=None,
+        help="Write summary JSON to FILE (default: stdout)",
+    )
+    args = ap.parse_args(argv)
+
+    manifest_path = Path(args.manifest)
+    campaign_root = Path(args.campaign_root)
+    if not manifest_path.is_file():
+        die(f"manifest not found: {manifest_path}")
+    if not campaign_root.is_dir():
+        die(f"campaign-root not found: {campaign_root}")
+
+    manifest = load_json(manifest_path)
+    baseline = load_json(Path(args.baseline)) if args.baseline else None
+
+    summary = score_campaign(
+        manifest, campaign_root, baseline, allow_partial=args.allow_partial
+    )
+    text = json.dumps(summary, indent=2, ensure_ascii=False) + "\n"
+
+    if args.out:
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(text, encoding="utf-8")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/benchlocal/qwen27-ar.runner-commands.json
+++ b/tests/fixtures/benchlocal/qwen27-ar.runner-commands.json
@@ -1,0 +1,86 @@
+{
+  "assembled_at": "2026-07-31T11:44:46.314470+00:00",
+  "model": "/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x",
+  "results_root": "/home/kaden/.cache/benchlocal-full-20260731T091750Z/results/qwen27-ar",
+  "note": "Qwen27 AR direct route predates Hermes sampling proxy. Non-Hermes packs hit 12180/13180 with explicit CLI sampling flags (or CLI-40 hardcoded generation). Hermes uses proxy :12280 only.",
+  "shared_env_non_hermes": {
+    "LLAMACPP_HOST": "http://127.0.0.1:12180",
+    "LLM_MODELS": "llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x",
+    "MODEL_REQUEST_TIMEOUT_SECONDS": "300"
+  },
+  "sampling_contract": {
+    "temperature": 1.0,
+    "top_p": 0.95,
+    "top_k": 20,
+    "min_p": 0.0,
+    "repetition_penalty": 1.0,
+    "presence_penalty": null,
+    "note": "No presence_penalty for Qwen27 AR packs"
+  },
+  "packs": {
+    "structoutput-15": {
+      "cwd": "/home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/StructOutput-15",
+      "env": {
+        "LLAMACPP_HOST": "http://127.0.0.1:12180",
+        "LLM_MODELS": "llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x",
+        "MODEL_REQUEST_TIMEOUT_SECONDS": "300",
+        "STRUCTOUTPUT_VALIDATOR_URL": "http://127.0.0.1:4011"
+      },
+      "argv": [
+        "node",
+        "dist-cli/cli/run.js",
+        "--model=llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x",
+        "--temperature",
+        "1.0",
+        "--top-p",
+        "0.95",
+        "--top-k",
+        "20",
+        "--min-p",
+        "0.0",
+        "--timeout",
+        "300",
+        "--validator-url",
+        "http://127.0.0.1:4011",
+        "--show-raw",
+        "--json"
+      ],
+      "command": "cd /home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/StructOutput-15 && LLAMACPP_HOST=http://127.0.0.1:12180 LLM_MODELS=llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x MODEL_REQUEST_TIMEOUT_SECONDS=300 STRUCTOUTPUT_VALIDATOR_URL=http://127.0.0.1:4011 node dist-cli/cli/run.js --model llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x --temperature 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --timeout 300 --validator-url http://127.0.0.1:4011 --show-raw --json",
+      "sampling_fields_proof": "CLI flags --temperature/--top-p/--top-k/--min-p map to GenerationParams in dist-cli; llm-client.ts forwards temperature,top_p,top_k,min_p on chat/completions body. repetition_penalty not sent by this pack CLI (daemon/model defaults)."
+    },
+    "bugfind-15": {
+      "cwd": "/home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/BugFind-15",
+      "env": {
+        "LLAMACPP_HOST": "http://127.0.0.1:12180",
+        "LLM_MODELS": "llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x",
+        "MODEL_REQUEST_TIMEOUT_SECONDS": "300",
+        "BUGFIND_SANDBOX_URL": "http://127.0.0.1:4010"
+      },
+      "command": "cd /home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/BugFind-15 && LLAMACPP_HOST=http://127.0.0.1:12180 LLM_MODELS=llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x MODEL_REQUEST_TIMEOUT_SECONDS=300 BUGFIND_SANDBOX_URL=http://127.0.0.1:4010 node dist-cli/cli/run.js --model llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x --temperature 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --timeout 300 --sandbox-url http://127.0.0.1:4010 --show-raw --json",
+      "sampling_fields_proof": "Same CLI flag\u2192llm-client path as StructOutput; sandbox-url only affects verifier."
+    },
+    "cli-40": {
+      "cwd": "/home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/CLI-40",
+      "command": "cd /home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/CLI-40 && node dist/cli/run.js --all --model /home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x --provider llamacpp --base-url http://127.0.0.1:12180/v1 --docker-base-url http://172.17.0.1:13180/v1 --auth-mode none --image cli40-dev --json --verbose",
+      "sampling_fields_proof": "CLI-40 dist/cli/run.js hardcodes generation: temperature 1.0, top_p 0.95, top_k 20, min_p 0.0, repetition_penalty 1.0, request_timeout_seconds 300 (patched campaign dist). No presence_penalty.",
+      "base_url": "http://127.0.0.1:12180/v1",
+      "docker_base_url": "http://172.17.0.1:13180/v1"
+    },
+    "hermesagent-20": {
+      "cwd": "/home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/HermesAgent-20",
+      "command": "cd /home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/HermesAgent-20 && node scripts/run-scenarios.mjs --all --model /home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x --provider custom --base-url http://172.17.0.1:12280/v1 --auth-mode bearer --api-key benchlocal --image hermesagent20-dev --json --verbose",
+      "sampling_fields_proof": "Runner sends only temperature=1.0 top_p=0.95; proxy :12280 forces top_k=20 min_p=0 presence_penalty=0 repetition_penalty=1 and enable_thinking=false. Attestations: hermes-sampling-attestations.jsonl"
+    },
+    "wave1_already_complete": {
+      "packs": [
+        "dataextract-15",
+        "instructfollow-15",
+        "reasonmath-15",
+        "toolcall-15",
+        "promptauthority-15"
+      ],
+      "command_pattern": "cd /home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/<Pack> && LLAMACPP_HOST=http://127.0.0.1:12180 LLM_MODELS=llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x MODEL_REQUEST_TIMEOUT_SECONDS=300 node dist-cli/cli/run.js --model llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x --temperature 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --timeout 300 --show-raw --json [tool packs add --repetition-penalty 1.0 --tools-format default]",
+      "source_agent": "RunWaveQwenAr"
+    }
+  }
+}

--- a/tests/fixtures/benchlocal/qwen27-dflash.runner-commands.json
+++ b/tests/fixtures/benchlocal/qwen27-dflash.runner-commands.json
@@ -1,0 +1,70 @@
+{
+  "assembled_at": "2026-07-31T11:45:50.356646+00:00",
+  "model": "/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x",
+  "results_root": "/home/kaden/.cache/benchlocal-full-20260731T091750Z/results/qwen27-dflash",
+  "note": "Qwen27 DFlash direct route predates Hermes sampling proxy. Non-Hermes packs hit 12181 with explicit CLI sampling flags. Hermes uses proxy :12281 only.",
+  "shared_env_non_hermes": {
+    "LLAMACPP_HOST": "http://127.0.0.1:12181",
+    "LLM_MODELS": "llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x",
+    "MODEL_REQUEST_TIMEOUT_SECONDS": "300"
+  },
+  "sampling_contract": {
+    "temperature": 1.0,
+    "top_p": 0.95,
+    "top_k": 20,
+    "min_p": 0.0,
+    "timeout": 300,
+    "tool_packs_extra": {
+      "repetition_penalty": 1.0,
+      "tools_format": "default"
+    }
+  },
+  "source_artifacts": {
+    "wave1_summary": "/home/kaden/.cache/benchlocal-full-20260731T091750Z/results/qwen27-dflash/wave1-summary.json",
+    "hermes_attestations": "/home/kaden/.cache/benchlocal-full-20260731T091750Z/results/qwen27-dflash/hermes-sampling-attestations.jsonl",
+    "hermes_provenance": "/home/kaden/.cache/benchlocal-full-20260731T091750Z/results/qwen27-dflash/hermesagent-20-provenance.json",
+    "hermes_meta": "/home/kaden/.cache/benchlocal-full-20260731T091750Z/results/qwen27-dflash/hermesagent-20-rerun-meta.txt"
+  },
+  "packs": {
+    "wave1_cli_pattern": {
+      "command_pattern": "cd /home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/<Pack> && LLAMACPP_HOST=http://127.0.0.1:12181 LLM_MODELS=llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x MODEL_REQUEST_TIMEOUT_SECONDS=300 node dist-cli/cli/run.js --model llamacpp:/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x --temperature 1.0 --top-p 0.95 --top-k 20 --min-p 0.0 --timeout 300 --show-raw --json",
+      "tool_packs_extra_flags": "--repetition-penalty 1.0 --tools-format default",
+      "packs": [
+        "DataExtract-15",
+        "InstructFollow-15",
+        "ReasonMath-15",
+        "ToolCall-15",
+        "PromptAuthority-15",
+        "StructOutput-15",
+        "BugFind-15"
+      ],
+      "sampling_fields_proof": "CLI flags --temperature/--top-p/--top-k/--min-p map to GenerationParams; llm-client forwards on chat/completions. Tool packs also send repetition_penalty=1.0. No presence_penalty on direct Qwen route.",
+      "endpoint": "http://127.0.0.1:12181"
+    },
+    "cli-40": {
+      "cwd": "/home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/CLI-40",
+      "command": "cd /home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/CLI-40 && node dist/cli/run.js --all --model /home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x --provider llamacpp --base-url http://127.0.0.1:12181/v1 --docker-base-url http://172.17.0.1:12181/v1 --auth-mode none --image cli40-dev --json --verbose",
+      "sampling_fields_proof": "CLI-40 hardcodes generation temperature=1.0 top_p=0.95 top_k=20 min_p=0.0 repetition_penalty=1.0; no presence_penalty."
+    },
+    "hermesagent-20": {
+      "cwd": "/home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/HermesAgent-20",
+      "command": "cd /home/kaden/.cache/benchlocal-full-20260731T091750Z/packs/HermesAgent-20 && node scripts/run-scenarios.mjs --all --image hermesagent20-dev --provider custom --base-url http://172.17.0.1:12281/v1 --auth-mode bearer --api-key benchlocal --model /home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x --provider-model /home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x --verbose --json",
+      "isolated_remainder_commands": [
+        "node scripts/run-scenarios.mjs --scenario HA-17 --image hermesagent20-dev --provider custom --base-url http://172.17.0.1:12281/v1 --auth-mode bearer --api-key benchlocal --model /home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x --provider-model /home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x --verbose --json",
+        "node scripts/run-scenarios.mjs --scenario HA-18 ...",
+        "node scripts/run-scenarios.mjs --scenario HA-19 ...",
+        "node scripts/run-scenarios.mjs --scenario HA-20 ..."
+      ],
+      "sampling_fields_proof": "Runner sends only temperature=1.0 top_p=0.95; proxy :12281 forces top_k=20 min_p=0 presence_penalty=0 repetition_penalty=1 (and enable_thinking=false for stability). Attestations: hermes-sampling-attestations.jsonl (349 rows, 0 bad).",
+      "proxy_health": "http://127.0.0.1:12281/__sampling_proxy/health",
+      "forced_sampling": {
+        "temperature": 1.0,
+        "top_p": 0.95,
+        "top_k": 20,
+        "min_p": 0,
+        "presence_penalty": 0,
+        "repetition_penalty": 1.0
+      }
+    }
+  }
+}

--- a/tests/test_benchlocal_plan.py
+++ b/tests/test_benchlocal_plan.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kaden Schutt
+# hipfire — see LICENSE and NOTICE in the project root.
+
+"""Assert benchlocal_campaign plan reproduces archived 2026-07-31 runner commands.
+
+Compares plan output to vendored provenance fixtures structurally: cwd/env/runner
+tokens must match exactly; archived flags must be a subset of the plan; the plan
+may only add ``--provider-model``. Flag order and ``--flag=value`` vs
+``--flag value`` are irrelevant.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+DRIVER = REPO / "scripts" / "benchlocal_campaign.py"
+MANIFEST = REPO / "tools" / "benchlocal" / "manifest.json"
+FIXTURES = REPO / "tests" / "fixtures" / "benchlocal"
+
+PACK_DIR_BY_ID = {
+    "dataextract-15": "DataExtract-15",
+    "instructfollow-15": "InstructFollow-15",
+    "reasonmath-15": "ReasonMath-15",
+    "toolcall-15": "ToolCall-15",
+    "promptauthority-15": "PromptAuthority-15",
+    "structoutput-15": "StructOutput-15",
+    "bugfind-15": "BugFind-15",
+    "cli-40": "CLI-40",
+    "hermesagent-20": "HermesAgent-20",
+}
+PACK_ID_BY_DIR = {v: k for k, v in PACK_DIR_BY_ID.items()}
+TOOL_PACK_IDS = frozenset({"toolcall-15", "promptauthority-15"})
+EXTRA_FLAG_ALLOWLIST = frozenset({"--provider-model"})
+
+# Explicit pack entries recorded in the AR archive (not only via command_pattern).
+AR_EXPLICIT_PACKS = ("structoutput-15", "bugfind-15", "cli-40", "hermesagent-20")
+# Explicit pack entries recorded in the DFlash archive.
+DFLASH_EXPLICIT_PACKS = ("cli-40", "hermesagent-20")
+
+
+def _require_driver() -> None:
+    if not DRIVER.is_file():
+        pytest.skip(f"driver not landed yet: {DRIVER.relative_to(REPO)}")
+
+
+def _load_fixture(slug: str) -> dict[str, Any]:
+    path = FIXTURES / f"{slug}.runner-commands.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _campaign_root_from_fixture(fixture: dict[str, Any]) -> str:
+    """Derive campaign root from fixture results_root (no disk dependency)."""
+    results_root = Path(fixture["results_root"])
+    # <campaign-root>/results/<slug>
+    return str(results_root.parent.parent)
+
+
+def _run_plan(
+    campaign_root: str,
+    route: str,
+    *,
+    thinking: str | None = None,
+) -> dict[str, Any]:
+    cmd = [
+        sys.executable,
+        str(DRIVER),
+        "plan",
+        "--manifest",
+        str(MANIFEST),
+        "--campaign-root",
+        campaign_root,
+        "--route",
+        route,
+    ]
+    if thinking is not None:
+        cmd.extend(["--thinking", thinking])
+    proc = subprocess.run(
+        cmd,
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"plan failed (exit {proc.returncode}) for route={route!r} "
+            f"thinking={thinking!r}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"plan stdout is not JSON for route={route!r}: {exc}\n{proc.stdout!r}"
+        ) from exc
+
+
+def _parse_flags(argv: list[str]) -> tuple[list[str], dict[str, str | bool]]:
+    """Split argv into leading program tokens and a flag→value map."""
+    prog: list[str] = []
+    i = 0
+    while i < len(argv) and not argv[i].startswith("-"):
+        prog.append(argv[i])
+        i += 1
+
+    flags: dict[str, str | bool] = {}
+    while i < len(argv):
+        tok = argv[i]
+        if tok.startswith("--"):
+            if "=" in tok:
+                key, _, val = tok.partition("=")
+                flags[key] = val
+                i += 1
+            elif i + 1 < len(argv) and not argv[i + 1].startswith("-"):
+                flags[tok] = argv[i + 1]
+                i += 2
+            else:
+                flags[tok] = True
+                i += 1
+        elif tok.startswith("-") and len(tok) > 1 and not tok[1:].startswith("-"):
+            # short flag: -x [value]
+            if i + 1 < len(argv) and not argv[i + 1].startswith("-"):
+                flags[tok] = argv[i + 1]
+                i += 2
+            else:
+                flags[tok] = True
+                i += 1
+        else:
+            # unexpected positional; keep scanning
+            i += 1
+    return prog, flags
+
+
+def parse_command(
+    command: str,
+) -> tuple[str, dict[str, str], list[str], dict[str, str | bool]]:
+    """Parse ``cd <cwd> && K=V ... <argv>`` into (cwd, env, prog, flags)."""
+    text = command.strip()
+    if not text.startswith("cd "):
+        raise AssertionError(f"command does not start with 'cd ': {command!r}")
+    body = text[3:]
+    if " && " not in body:
+        raise AssertionError(f"command missing ' && ' separator: {command!r}")
+    cwd_part, _, after = body.partition(" && ")
+    cwd = cwd_part.strip()
+
+    tokens = shlex.split(after)
+    env: dict[str, str] = {}
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok.startswith("-"):
+            break
+        if "=" not in tok:
+            break
+        key, _, val = tok.partition("=")
+        if not key or not (key[0].isalpha() or key[0] == "_"):
+            break
+        env[key] = val
+        i += 1
+
+    argv = tokens[i:]
+    prog, flags = _parse_flags(argv)
+    return cwd, env, prog, flags
+
+
+def _load_manifest() -> dict[str, Any]:
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))
+
+
+def _sidecar_allowance(pack_id: str, manifest: dict[str, Any]) -> tuple[str, str, str] | None:
+    """Return (url_env, cli_flag, url) for a pack with a sidecar, else None."""
+    for pack in manifest.get("packs") or []:
+        if pack.get("id") != pack_id:
+            continue
+        sidecar = pack.get("sidecar")
+        if not isinstance(sidecar, dict):
+            return None
+        url_env = sidecar.get("url_env")
+        cli_flag = sidecar.get("cli_flag")
+        host_port = sidecar.get("host_port")
+        if not url_env or not cli_flag or host_port is None:
+            return None
+        url = f"http://127.0.0.1:{host_port}"
+        return str(url_env), str(cli_flag), url
+    return None
+
+
+def assert_command_compatible(
+    archive_cmd: str,
+    plan_cmd: str,
+    *,
+    label: str,
+    pattern_derived: bool = False,
+    sidecar: tuple[str, str, str] | None = None,
+) -> None:
+    """Archive command must be structurally reproduced by plan (archive ⊆ plan).
+
+    Explicit archive entries (pattern_derived=False): env equality is exact; plan
+    may only add flags from EXTRA_FLAG_ALLOWLIST.
+
+    Pattern-derived entries: env and flags are archive-subset. The plan may add
+    only the pack's manifest sidecar url_env/cli_flag (when declared) and
+    EXTRA_FLAG_ALLOWLIST flags. Sidecar wiring must be present iff declared.
+    """
+    a_cwd, a_env, a_prog, a_flags = parse_command(archive_cmd)
+    p_cwd, p_env, p_prog, p_flags = parse_command(plan_cmd)
+
+    assert a_cwd == p_cwd, f"{label}: cwd mismatch\n  archive: {a_cwd!r}\n  plan:    {p_cwd!r}"
+    assert a_prog == p_prog, (
+        f"{label}: runner program tokens mismatch\n"
+        f"  archive: {a_prog!r}\n  plan:    {p_prog!r}"
+    )
+
+    for key, val in a_env.items():
+        assert key in p_env, (
+            f"{label}: plan missing archived env {key}={val!r}\n"
+            f"  archive: {a_env!r}\n  plan:    {p_env!r}"
+        )
+        assert p_env[key] == val, (
+            f"{label}: env {key} value mismatch\n"
+            f"  archive: {val!r}\n  plan:    {p_env[key]!r}"
+        )
+
+    for key, val in a_flags.items():
+        assert key in p_flags, (
+            f"{label}: plan missing archived flag {key}={val!r}\n"
+            f"  archive flags: {a_flags!r}\n  plan flags:    {p_flags!r}"
+        )
+        assert p_flags[key] == val, (
+            f"{label}: flag {key} value mismatch\n"
+            f"  archive: {val!r}\n  plan:    {p_flags[key]!r}"
+        )
+
+    if not pattern_derived:
+        assert a_env == p_env, (
+            f"{label}: env mismatch\n  archive: {a_env!r}\n  plan:    {p_env!r}"
+        )
+        extras = set(p_flags) - set(a_flags)
+        unexpected = extras - EXTRA_FLAG_ALLOWLIST
+        assert not unexpected, (
+            f"{label}: plan has unexpected extra flags {sorted(unexpected)} "
+            f"(only {sorted(EXTRA_FLAG_ALLOWLIST)} allowed)\n"
+            f"  archive flags: {a_flags!r}\n  plan flags:    {p_flags!r}"
+        )
+        return
+
+    # Pattern-derived: allow only manifest sidecar + --provider-model extras.
+    allowed_env: set[str] = set()
+    allowed_flags: set[str] = set(EXTRA_FLAG_ALLOWLIST)
+    if sidecar is not None:
+        url_env, cli_flag, url = sidecar
+        allowed_env.add(url_env)
+        allowed_flags.add(cli_flag)
+        assert p_env.get(url_env) == url, (
+            f"{label}: expected sidecar env {url_env}={url!r}, got {p_env.get(url_env)!r}"
+        )
+        assert p_flags.get(cli_flag) == url, (
+            f"{label}: expected sidecar flag {cli_flag}={url!r}, got {p_flags.get(cli_flag)!r}"
+        )
+    else:
+        # No sidecar declared — plan must not invent one-looking extras beyond
+        # the archive baseline (caught by the unexpected checks below).
+        pass
+
+    env_extras = set(p_env) - set(a_env)
+    unexpected_env = env_extras - allowed_env
+    assert not unexpected_env, (
+        f"{label}: plan has unexpected extra env {sorted(unexpected_env)} "
+        f"(only sidecar {sorted(allowed_env) or '∅'} allowed beyond archive)\n"
+        f"  archive: {a_env!r}\n  plan:    {p_env!r}"
+    )
+
+    flag_extras = set(p_flags) - set(a_flags)
+    unexpected_flags = flag_extras - allowed_flags
+    assert not unexpected_flags, (
+        f"{label}: plan has unexpected extra flags {sorted(unexpected_flags)} "
+        f"(only {sorted(allowed_flags)} allowed beyond archive)\n"
+        f"  archive flags: {a_flags!r}\n  plan flags:    {p_flags!r}"
+    )
+
+    if sidecar is None:
+        # Double-check no stray sidecar-shaped keys snuck in via the archive
+        # baseline itself being empty for these.
+        for key in p_env:
+            if key.endswith("_URL") and key not in a_env:
+                raise AssertionError(
+                    f"{label}: non-sidecar pack has unexpected URL env {key}={p_env[key]!r}"
+                )
+
+
+
+def _strip_pattern_prose(pattern: str) -> str:
+    """Drop bracketed human prose tacked onto archived command_pattern strings."""
+    cut = pattern.find(" [")
+    if cut != -1:
+        return pattern[:cut].rstrip()
+    return pattern.rstrip()
+
+
+def _expand_wave1_command(
+    pattern: str,
+    pack_dir: str,
+    *,
+    pack_id: str,
+    tool_extra: str | None,
+) -> str:
+    base = _strip_pattern_prose(pattern).replace("<Pack>", pack_dir)
+    if pack_id in TOOL_PACK_IDS:
+        extra = (tool_extra or "--repetition-penalty 1.0 --tools-format default").strip()
+        if extra:
+            # Insert tool-pack flags before trailing --show-raw --json when present.
+            marker = " --show-raw --json"
+            if marker in base:
+                head, _, tail = base.partition(marker)
+                return f"{head} {extra}{marker}{tail}"
+            return f"{base} {extra}"
+    return base
+
+
+def _plan_pack_command(plan: dict[str, Any], pack_id: str) -> str:
+    packs = plan.get("packs") or {}
+    assert pack_id in packs, (
+        f"plan missing pack {pack_id!r}; have {sorted(packs)}"
+    )
+    entry = packs[pack_id]
+    assert "command" in entry, f"plan pack {pack_id!r} missing 'command': {entry!r}"
+    return entry["command"]
+
+
+def _assert_ports_in_text(text: str, ports: tuple[int, ...], *, label: str) -> None:
+    for port in ports:
+        assert str(port) in text, f"{label}: expected port {port} in plan output"
+
+
+# ---------------------------------------------------------------------------
+# qwen27-ar
+# ---------------------------------------------------------------------------
+
+
+def test_plan_qwen27_ar_matches_archive() -> None:
+    _require_driver()
+    fixture = _load_fixture("qwen27-ar")
+    campaign_root = _campaign_root_from_fixture(fixture)
+    plan = _run_plan(campaign_root, "qwen27-ar")
+
+    assert plan.get("route") == "qwen27-ar"
+    assert plan.get("model") == fixture["model"]
+    assert plan.get("results_root") == fixture["results_root"]
+    assert plan.get("shared_env_non_hermes") == fixture["shared_env_non_hermes"]
+
+    # Ports from the AR archive topology.
+    blob = json.dumps(plan)
+    _assert_ports_in_text(blob, (12180, 12280, 13180), label="qwen27-ar plan")
+
+    for pack_id in AR_EXPLICIT_PACKS:
+        arch_entry = fixture["packs"][pack_id]
+        assert_command_compatible(
+            arch_entry["command"],
+            _plan_pack_command(plan, pack_id),
+            label=f"qwen27-ar/{pack_id}",
+        )
+        if "env" in arch_entry:
+            plan_env = plan["packs"][pack_id].get("env") or {}
+            assert plan_env == arch_entry["env"], (
+                f"qwen27-ar/{pack_id}: env dict mismatch\n"
+                f"  archive: {arch_entry['env']!r}\n  plan:    {plan_env!r}"
+            )
+
+    manifest = _load_manifest()
+    wave = fixture["packs"]["wave1_already_complete"]
+    pattern = wave["command_pattern"]
+    for pack_id in wave["packs"]:
+        pack_dir = PACK_DIR_BY_ID[pack_id]
+        expected = _expand_wave1_command(
+            pattern, pack_dir, pack_id=pack_id, tool_extra=None
+        )
+        plan_cmd = _plan_pack_command(plan, pack_id)
+        assert_command_compatible(
+            expected,
+            plan_cmd,
+            label=f"qwen27-ar/wave1/{pack_id}",
+            pattern_derived=True,
+            sidecar=_sidecar_allowance(pack_id, manifest),
+        )
+        _, _, _, flags = parse_command(plan_cmd)
+        if pack_id in TOOL_PACK_IDS:
+            assert flags.get("--repetition-penalty") == "1.0", pack_id
+            assert flags.get("--tools-format") == "default", pack_id
+        else:
+            assert "--repetition-penalty" not in flags, pack_id
+            assert "--tools-format" not in flags, pack_id
+
+
+
+# ---------------------------------------------------------------------------
+# qwen27-dflash
+# ---------------------------------------------------------------------------
+
+
+def test_plan_qwen27_dflash_matches_archive() -> None:
+    _require_driver()
+    fixture = _load_fixture("qwen27-dflash")
+    campaign_root = _campaign_root_from_fixture(fixture)
+    plan = _run_plan(campaign_root, "qwen27-dflash")
+
+    assert plan.get("route") == "qwen27-dflash"
+    assert plan.get("model") == fixture["model"]
+    assert plan.get("results_root") == fixture["results_root"]
+    assert plan.get("shared_env_non_hermes") == fixture["shared_env_non_hermes"]
+
+    blob = json.dumps(plan)
+    _assert_ports_in_text(blob, (12181, 12281), label="qwen27-dflash plan")
+
+    for pack_id in DFLASH_EXPLICIT_PACKS:
+        arch_entry = fixture["packs"][pack_id]
+        assert_command_compatible(
+            arch_entry["command"],
+            _plan_pack_command(plan, pack_id),
+            label=f"qwen27-dflash/{pack_id}",
+        )
+
+    manifest = _load_manifest()
+    wave = fixture["packs"]["wave1_cli_pattern"]
+    pattern = wave["command_pattern"]
+    tool_extra = wave.get("tool_packs_extra_flags")
+    for pack_dir in wave["packs"]:
+        pack_id = PACK_ID_BY_DIR[pack_dir]
+        expected = _expand_wave1_command(
+            pattern, pack_dir, pack_id=pack_id, tool_extra=tool_extra
+        )
+        plan_cmd = _plan_pack_command(plan, pack_id)
+        assert_command_compatible(
+            expected,
+            plan_cmd,
+            label=f"qwen27-dflash/wave1/{pack_id}",
+            pattern_derived=True,
+            sidecar=_sidecar_allowance(pack_id, manifest),
+        )
+        _, _, _, flags = parse_command(plan_cmd)
+        if pack_id in TOOL_PACK_IDS:
+            assert flags.get("--repetition-penalty") == "1.0", pack_id
+            assert flags.get("--tools-format") == "default", pack_id
+        else:
+            assert "--repetition-penalty" not in flags, pack_id
+            assert "--tools-format" not in flags, pack_id
+
+
+
+# ---------------------------------------------------------------------------
+# thinking variant is proxy-side only
+# ---------------------------------------------------------------------------
+
+
+def test_thinking_medium_leaves_non_hermes_commands_unchanged() -> None:
+    """``--thinking medium`` must not alter pack CLI flags (proxy injects it)."""
+    _require_driver()
+    fixture = _load_fixture("qwen27-ar")
+    campaign_root = _campaign_root_from_fixture(fixture)
+
+    disabled = _run_plan(campaign_root, "qwen27-ar", thinking="disabled")
+    medium = _run_plan(campaign_root, "qwen27-ar", thinking="medium")
+
+    d_packs = disabled.get("packs") or {}
+    m_packs = medium.get("packs") or {}
+    assert set(d_packs) == set(m_packs), (
+        f"pack key set differs under thinking modes: "
+        f"{sorted(d_packs)} vs {sorted(m_packs)}"
+    )
+
+    for pack_id, d_entry in d_packs.items():
+        if pack_id == "hermesagent-20":
+            continue
+        m_entry = m_packs[pack_id]
+        assert d_entry.get("command") == m_entry.get("command"), (
+            f"{pack_id}: non-Hermes command changed under --thinking medium\n"
+            f"  disabled: {d_entry.get('command')!r}\n"
+            f"  medium:   {m_entry.get('command')!r}"
+        )
+        assert d_entry.get("env") == m_entry.get("env"), (
+            f"{pack_id}: non-Hermes env changed under --thinking medium"
+        )
+        assert d_entry.get("argv") == m_entry.get("argv"), (
+            f"{pack_id}: non-Hermes argv changed under --thinking medium"
+        )
+
+    # shared_env is also non-Hermes surface area
+    assert disabled.get("shared_env_non_hermes") == medium.get("shared_env_non_hermes")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_benchlocal_proxy.py
+++ b/tests/test_benchlocal_proxy.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kaden Schutt
+# hipfire — see LICENSE and NOTICE in the project root.
+
+"""Offline behavioural tests for tools/benchlocal/sampling_proxy.mjs.
+
+Stands up a stdlib echo upstream and drives the Node sampling proxy under
+both THINKING_MODE values. No GPU, no hipfire runtime dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+
+REPO = Path(__file__).resolve().parents[1]
+PROXY_JS = REPO / "tools" / "benchlocal" / "sampling_proxy.mjs"
+
+# Real archived attestation row key sets.
+# baseline: .../benchlocal-full-20260731T091750Z/results/a3b-mq4p/sampling-attestations.jsonl
+# medium:   .../benchlocal-medium-20260731T194729Z/results/a3b-mq4p/sampling-attestations.jsonl
+BASELINE_ATTESTATION_KEYS = frozenset(
+    {
+        "timestamp",
+        "modelSlug",
+        "path",
+        "requestModel",
+        "temperature",
+        "top_p",
+        "top_k",
+        "min_p",
+        "presence_penalty",
+        "repetition_penalty",
+    }
+)
+MEDIUM_ATTESTATION_KEYS = BASELINE_ATTESTATION_KEYS | frozenset(
+    {
+        "reasoning_effort",
+        "enable_thinking",
+        "expected_max_think_tokens",
+    }
+)
+
+NODE = shutil.which("node")
+
+
+def _skip_without_node() -> None:
+    if NODE is None:
+        raise unittest.SkipTest("node not on PATH")
+
+
+class _EchoHandler(BaseHTTPRequestHandler):
+    """Capture last request and echo the JSON body back."""
+
+    last_method: str | None = None
+    last_path: str | None = None
+    last_body: bytes = b""
+    last_headers: dict[str, str] = {}
+    lock = threading.Lock()
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003
+        return
+
+    def _read_body(self) -> bytes:
+        """Read body for Content-Length or chunked Transfer-Encoding.
+
+        The proxy strips hop-by-hop Content-Length on passthrough and may
+        forward via chunked encoding when piping; the stub must accept both.
+        """
+        te = (self.headers.get("Transfer-Encoding") or "").lower()
+        if "chunked" in te:
+            chunks: list[bytes] = []
+            while True:
+                line = self.rfile.readline()
+                if not line:
+                    break
+                size_str = line.strip().split(b";", 1)[0]
+                try:
+                    size = int(size_str, 16)
+                except ValueError:
+                    break
+                if size == 0:
+                    while True:
+                        trailer = self.rfile.readline()
+                        if trailer in (b"\r\n", b"\n", b""):
+                            break
+                    break
+                data = self.rfile.read(size)
+                chunks.append(data)
+                self.rfile.read(2)  # CRLF after chunk
+            return b"".join(chunks)
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        return self.rfile.read(length) if length else b""
+
+    def _capture(self) -> bytes:
+        body = self._read_body()
+        with self.lock:
+            type(self).last_method = self.command
+            type(self).last_path = self.path
+            type(self).last_body = body
+            type(self).last_headers = {k: v for k, v in self.headers.items()}
+        return body
+
+    def do_GET(self) -> None:  # noqa: N802
+        body = self._capture()
+        payload = body if body else b'{"ok":true,"echo":"get"}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_POST(self) -> None:  # noqa: N802
+        body = self._capture()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_PUT(self) -> None:  # noqa: N802
+        self.do_POST()
+
+
+def _free_port() -> int:
+    srv = HTTPServer(("127.0.0.1", 0), BaseHTTPRequestHandler)
+    port = srv.server_address[1]
+    srv.server_close()
+    return int(port)
+
+
+def _http_json(method: str, url: str, body: dict[str, Any] | None = None, timeout: float = 5.0) -> tuple[int, Any]:
+    data = None if body is None else json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={"Content-Type": "application/json"} if data is not None else {},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+            status = resp.getcode()
+    except urllib.error.HTTPError as exc:
+        raw = exc.read()
+        status = exc.code
+    if not raw:
+        return status, None
+    try:
+        return status, json.loads(raw.decode("utf-8"))
+    except json.JSONDecodeError:
+        return status, raw.decode("utf-8", errors="replace")
+
+
+def _wait_health(url: str, timeout_s: float = 8.0) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_s
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            status, payload = _http_json("GET", url, timeout=1.0)
+            if status == 200 and isinstance(payload, dict) and payload.get("ok") is True:
+                return payload
+        except Exception as exc:  # noqa: BLE001 — poll until ready
+            last_err = exc
+        time.sleep(0.05)
+    raise TimeoutError(f"proxy health not ready at {url} within {timeout_s}s; last_err={last_err!r}")
+
+
+@unittest.skipUnless(NODE is not None, "node not on PATH")
+class BenchlocalSamplingProxyTest(unittest.TestCase):
+    def setUp(self) -> None:
+        _skip_without_node()
+        self.assertTrue(PROXY_JS.is_file(), f"missing proxy: {PROXY_JS}")
+        self._tmpdir = tempfile.TemporaryDirectory(prefix="benchlocal-proxy-")
+        self.tmp = Path(self._tmpdir.name)
+        self.attestation = self.tmp / "attestations.jsonl"
+        self.upstream_port = _free_port()
+        self.proxy_port = _free_port()
+
+        _EchoHandler.last_method = None
+        _EchoHandler.last_path = None
+        _EchoHandler.last_body = b""
+        _EchoHandler.last_headers = {}
+
+        self.upstream = HTTPServer(("127.0.0.1", self.upstream_port), _EchoHandler)
+        self.upstream_thread = threading.Thread(target=self.upstream.serve_forever, daemon=True)
+        self.upstream_thread.start()
+
+        self.proxy_proc: subprocess.Popen[str] | None = None
+
+    def tearDown(self) -> None:
+        proc = self.proxy_proc
+        if proc is not None:
+            if proc.poll() is None:
+                try:
+                    proc.send_signal(signal.SIGTERM)
+                    proc.wait(timeout=5)
+                except Exception:  # noqa: BLE001
+                    try:
+                        proc.kill()
+                        proc.wait(timeout=2)
+                    except Exception:  # noqa: BLE001
+                        pass
+            for stream in (proc.stdout, proc.stderr):
+                if stream is not None:
+                    try:
+                        stream.close()
+                    except Exception:  # noqa: BLE001
+                        pass
+        self.proxy_proc = None
+        try:
+            self.upstream.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            self.upstream.server_close()
+        except Exception:  # noqa: BLE001
+            pass
+        self._tmpdir.cleanup()
+
+    def _start_proxy(self, thinking_mode: str, presence_penalty: str = "1.5") -> None:
+        env = os.environ.copy()
+        env.update(
+            {
+                "LISTEN_HOST": "127.0.0.1",
+                "LISTEN_PORT": str(self.proxy_port),
+                "TARGET_ORIGIN": f"http://127.0.0.1:{self.upstream_port}",
+                "MODEL_SLUG": "test-route",
+                "ATTESTATION_LOG": str(self.attestation),
+                "PRESENCE_PENALTY": presence_penalty,
+                "THINKING_MODE": thinking_mode,
+            }
+        )
+        self.proxy_proc = subprocess.Popen(
+            [NODE, str(PROXY_JS)],
+            cwd=str(REPO),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            _wait_health(f"http://127.0.0.1:{self.proxy_port}/__sampling_proxy/health")
+        except Exception:
+            # Surface proxy stderr on failed startup.
+            if self.proxy_proc.poll() is not None:
+                err = self.proxy_proc.stderr.read() if self.proxy_proc.stderr else ""
+                out = self.proxy_proc.stdout.read() if self.proxy_proc.stdout else ""
+                self.fail(
+                    f"proxy exited early rc={self.proxy_proc.returncode}\nstdout={out}\nstderr={err}"
+                )
+            raise
+
+    def _post_chat(self, body: dict[str, Any]) -> tuple[int, Any]:
+        return _http_json(
+            "POST",
+            f"http://127.0.0.1:{self.proxy_port}/v1/chat/completions",
+            body=body,
+        )
+
+    def _assert_forced_sampling(self, received: dict[str, Any], presence: float = 1.5) -> None:
+        self.assertEqual(received["temperature"], 1.0)
+        self.assertEqual(received["top_p"], 0.95)
+        self.assertEqual(received["top_k"], 20)
+        self.assertEqual(received["min_p"], 0.0)
+        self.assertEqual(received["repetition_penalty"], 1.0)
+        self.assertEqual(received["presence_penalty"], presence)
+
+    def _assert_attestation_row(self, thinking_mode: str) -> dict[str, Any]:
+        self.assertTrue(self.attestation.is_file(), "attestation log missing")
+        lines = [ln for ln in self.attestation.read_text(encoding="utf-8").splitlines() if ln.strip()]
+        self.assertEqual(len(lines), 1, f"expected exactly one attestation row, got {len(lines)}")
+        row = json.loads(lines[0])
+        expected_keys = (
+            MEDIUM_ATTESTATION_KEYS if thinking_mode == "medium" else BASELINE_ATTESTATION_KEYS
+        )
+        self.assertEqual(
+            set(row.keys()),
+            set(expected_keys),
+            f"attestation keys mismatch for mode={thinking_mode}: {sorted(row.keys())}",
+        )
+        self.assertEqual(row["modelSlug"], "test-route")
+        self.assertEqual(row["path"], "/v1/chat/completions")
+        self.assertEqual(row["temperature"], 1)
+        self.assertEqual(row["top_p"], 0.95)
+        self.assertEqual(row["top_k"], 20)
+        self.assertEqual(row["min_p"], 0)
+        self.assertEqual(row["presence_penalty"], 1.5)
+        self.assertEqual(row["repetition_penalty"], 1)
+        self.assertIn("timestamp", row)
+        if thinking_mode == "medium":
+            self.assertEqual(row["reasoning_effort"], "medium")
+            self.assertIs(row["enable_thinking"], True)
+            self.assertEqual(row["expected_max_think_tokens"], 1024)
+        return row
+
+    def test_thinking_disabled_forces_sampling_and_no_reasoning(self) -> None:
+        self._start_proxy("disabled")
+        status, echoed = self._post_chat(
+            {
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "temperature": 0.3,
+                "top_p": 0.5,
+                # deliberately omit top_k / min_p / penalties
+            }
+        )
+        self.assertEqual(status, 200)
+        self.assertIsInstance(echoed, dict)
+        # Stub echoes the rewritten upstream body.
+        with _EchoHandler.lock:
+            raw = _EchoHandler.last_body
+            path = _EchoHandler.last_path
+        self.assertEqual(path, "/v1/chat/completions")
+        received = json.loads(raw.decode("utf-8"))
+        self._assert_forced_sampling(received)
+        ctk = received.get("chat_template_kwargs") or {}
+        self.assertIsInstance(ctk, dict)
+        self.assertIs(ctk.get("enable_thinking"), False)
+        self.assertNotIn("reasoning_effort", received)
+        self.assertNotIn("max_think_tokens", received)
+        self._assert_attestation_row("disabled")
+        self.assertEqual(received.get("model"), "test-model")
+
+    def test_thinking_medium_forces_sampling_and_reasoning(self) -> None:
+        self._start_proxy("medium")
+        status, echoed = self._post_chat(
+            {
+                "model": "test-model-med",
+                "messages": [{"role": "user", "content": "hi"}],
+                "temperature": 0.3,
+                "top_p": 0.5,
+            }
+        )
+        self.assertEqual(status, 200)
+        self.assertIsInstance(echoed, dict)
+        with _EchoHandler.lock:
+            raw = _EchoHandler.last_body
+            path = _EchoHandler.last_path
+        self.assertEqual(path, "/v1/chat/completions")
+        received = json.loads(raw.decode("utf-8"))
+        self._assert_forced_sampling(received)
+        ctk = received.get("chat_template_kwargs") or {}
+        self.assertIsInstance(ctk, dict)
+        self.assertIs(ctk.get("enable_thinking"), True)
+        self.assertEqual(received.get("reasoning_effort"), "medium")
+        # Archive: max_think_tokens never goes on the wire body.
+        self.assertNotIn("max_think_tokens", received)
+        self._assert_attestation_row("medium")
+
+    def test_non_chat_path_passthrough_unmodified(self) -> None:
+        self._start_proxy("disabled")
+        original = {"ping": True, "temperature": 0.3, "n": 7}
+        status, echoed = _http_json(
+            "POST",
+            f"http://127.0.0.1:{self.proxy_port}/v1/models",
+            body=original,
+        )
+        self.assertEqual(status, 200)
+        with _EchoHandler.lock:
+            raw = _EchoHandler.last_body
+            path = _EchoHandler.last_path
+            method = _EchoHandler.last_method
+        self.assertEqual(method, "POST")
+        self.assertEqual(path, "/v1/models")
+        received = json.loads(raw.decode("utf-8"))
+        self.assertEqual(received, original)
+        # Passthrough must not write attestations.
+        if self.attestation.exists():
+            content = self.attestation.read_text(encoding="utf-8").strip()
+            self.assertEqual(content, "")
+        self.assertEqual(echoed, original)
+
+    def test_presence_penalty_from_env(self) -> None:
+        self._start_proxy("disabled", presence_penalty="1.25")
+        status, _ = self._post_chat(
+            {
+                "model": "m",
+                "messages": [{"role": "user", "content": "x"}],
+                "temperature": 0.1,
+            }
+        )
+        self.assertEqual(status, 200)
+        with _EchoHandler.lock:
+            received = json.loads(_EchoHandler.last_body.decode("utf-8"))
+        self.assertEqual(received["presence_penalty"], 1.25)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/benchlocal/manifest.json
+++ b/tools/benchlocal/manifest.json
@@ -1,0 +1,306 @@
+{
+  "schema_version": 1,
+  "description": "BenchLocal nine-pack campaign manifest. Every field is reconstructed from the preserved 2026-07-31 campaign provenance; see docs/methodology/benchlocal-campaign.md for the evidence trail. Consumed by scripts/benchlocal_campaign.py and scripts/benchlocal_score.py.",
+
+  "provenance": {
+    "nas_archive": "/mnt/nas/kaden/hipfire/benchlocal/2026-07-31-quality/",
+    "campaigns": {
+      "baseline": {
+        "campaign_id": "benchlocal-full-20260731T091750Z",
+        "thinking": "disabled",
+        "local_root": "/home/kaden/.cache/benchlocal-full-20260731T091750Z",
+        "remote_root": "/home/kaden/benchlocal-full-20260731T091750Z",
+        "summary_file": "full-battery-summary.json",
+        "summary_sha256": "b47890257e39678d71156ed9e49f0e4b7b6df4483a858c72e6c07be85b72eaef"
+      },
+      "medium": {
+        "campaign_id": "benchlocal-medium-20260731T194729Z",
+        "thinking": "medium",
+        "local_root": "/home/kaden/.cache/benchlocal-medium-20260731T194729Z",
+        "remote_root": "/home/kaden/benchlocal-medium-20260731T194729Z",
+        "summary_file": "full-battery-medium-summary.json",
+        "summary_sha256": "46c2a94ec88970d7ac5e9eafe14b0a1649e70451ac882805711aad533cc67f49"
+      }
+    },
+    "engine": {
+      "serve_host": "hiptrx",
+      "hipfire_md5": "2638db7b487a43745c55fb39c345534e",
+      "daemon_md5": "e4af3aa26e79aa07a45fe696104dbf50",
+      "note": "Four concurrent daemons, one per GPU, each with an isolated HOME (homes/gpu0..gpu3). The medium campaign reused the baseline campaign's immutable binaries."
+    },
+    "sampling_proxy_sha256": {
+      "baseline": "578f2be2b530ad4fb7ed76459ff76ba81c538376ee296af26369cf2af72099a2",
+      "medium": "8a221d7c3ad11abc66302876d5c0d0ebf441d36c4d71d1b055009e4bc1af4c3d",
+      "pre_thinkfix": "b87fb8658860d6fe971ae2c9a5b750e304278411c1edc100bc510906ab1b918f"
+    }
+  },
+
+  "sampling": {
+    "base": {
+      "temperature": 1.0,
+      "top_p": 0.95,
+      "top_k": 20,
+      "min_p": 0.0,
+      "repetition_penalty": 1.0
+    },
+    "presence_penalty_by_family": {
+      "qwen27": 0.0,
+      "a3b": 1.5
+    },
+    "presence_penalty_note": "qwen27 direct pack runners omit presence_penalty (server default 0); the Hermes proxy forces 0.0. a3b routes get 1.5 injected by the proxy on every request.",
+    "thinking_variants": {
+      "disabled": { "enable_thinking": false },
+      "medium": { "enable_thinking": true, "reasoning_effort": "medium", "max_think_tokens": 1024 }
+    },
+    "request_timeout_seconds": 300
+  },
+
+  "topology": {
+    "serve_port_base": 12180,
+    "proxy_port_base": 12280,
+    "proxy_listen_host": "0.0.0.0",
+    "docker_bridge_host": "172.17.0.1",
+    "port_rule": "serve_port = serve_port_base + route.gpu; proxy_port = serve_port + 100. Containerised packs reach host endpoints via docker_bridge_host on the same port.",
+    "smoke": {
+      "max_tokens": 1152,
+      "prompt_expectation": "finish_reason=stop, answer 42",
+      "note": "A 96-token smoke cap exposes open think spans on reasoning routes and must not be used as a health gate."
+    }
+  },
+
+  "routes": [
+    {
+      "slug": "qwen27-ar",
+      "display_name": "Qwen3.6-27B AR",
+      "family": "qwen27",
+      "gpu": 0,
+      "model_path": "/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x",
+      "model_sha256": "86a5f80fd29d545abb1093dead242725ced6d68b8607c6d566d897b1a82442dc",
+      "mode": { "kv": "q8", "dflash": "off", "mtp": "off" },
+      "proxy_scope": "hermes-only",
+      "endpoints": {
+        "serve_port": 12180,
+        "proxy_port": 12280,
+        "non_hermes_base": "http://127.0.0.1:12180",
+        "hermes_docker_base": "http://172.17.0.1:12280/v1",
+        "cli40_docker_base": "http://172.17.0.1:13180/v1"
+      },
+      "evidence": "results/qwen27-ar/qwen27-ar.runner-commands.json"
+    },
+    {
+      "slug": "qwen27-dflash",
+      "display_name": "Qwen3.6-27B DFlash",
+      "family": "qwen27",
+      "gpu": 1,
+      "model_path": "/home/kaden/.hipfire/models/qwen3-27b-3.6.mq4-awq.remote-mi300x",
+      "model_sha256": "86a5f80fd29d545abb1093dead242725ced6d68b8607c6d566d897b1a82442dc",
+      "mode": { "kv": "q8", "dflash": "on", "dflash_ctx_cap": 0, "mtp": "off" },
+      "proxy_scope": "hermes-only",
+      "endpoints": {
+        "serve_port": 12181,
+        "proxy_port": 12281,
+        "non_hermes_base": "http://127.0.0.1:12181",
+        "hermes_docker_base": "http://172.17.0.1:12281/v1",
+        "cli40_docker_base": "http://172.17.0.1:12181/v1"
+      },
+      "evidence": "results/qwen27-dflash/qwen27-dflash.runner-commands.json"
+    },
+    {
+      "slug": "a3b-mq4r",
+      "display_name": "Qwen3.6-35B-A3B MQ4R",
+      "family": "a3b",
+      "gpu": 2,
+      "model_path": "/home/kaden/.hipfire/models/qwen3.6-35b-a3b.mq4r",
+      "model_sha256": "4685c140c46b1a6f31a0fd9053bf09d5faf1d2529d715b84794249b66cde0428",
+      "mode": { "kv": "q8", "mtp": "off" },
+      "proxy_scope": "all",
+      "endpoints": {
+        "serve_port": 12182,
+        "proxy_port": 12282,
+        "non_hermes_base": "http://127.0.0.1:12282",
+        "hermes_docker_base": "http://172.17.0.1:12282/v1",
+        "cli40_docker_base": "http://172.17.0.1:12282/v1"
+      },
+      "evidence": "results/a3b-mq4r/sampling-attestations.jsonl"
+    },
+    {
+      "slug": "a3b-mq4p",
+      "display_name": "Qwen3.6-35B-A3B MQ4P",
+      "family": "a3b",
+      "gpu": 3,
+      "model_path": "/home/kaden/.hipfire/models/qwen3.6-35b-a3b.mq4p",
+      "model_sha256": "8eb3be6912aa9db2dcc89c3233b05ccdfe81a84a8d6ef43202f2098d7f2fc78f",
+      "model_sha256_note": "The baseline summary recorded only 63 hex characters for this artifact. Repaired 2026-08-02 by re-hashing the local copy: the archive had dropped the trailing 'f'. The sibling a3b-mq4r hash matched byte-for-byte, confirming the local copies are the artifacts the campaign served.",
+      "mode": { "kv": "q8", "mtp": "off" },
+      "proxy_scope": "all",
+      "endpoints": {
+        "serve_port": 12183,
+        "proxy_port": 12283,
+        "non_hermes_base": "http://127.0.0.1:12283",
+        "hermes_docker_base": "http://172.17.0.1:12283/v1",
+        "cli40_docker_base": "http://172.17.0.1:12283/v1"
+      },
+      "evidence": "results/a3b-mq4p/hermesagent-20-provenance.json"
+    }
+  ],
+
+  "packs": [
+    {
+      "id": "dataextract-15",
+      "dir": "DataExtract-15",
+      "repo": "https://github.com/stevibe/DataExtract-15.git",
+      "revision": "00d90bf7506a1d7ffe98943d9ffd8c6eb795dbdb",
+      "version": "1.0.0",
+      "scenario_count": 15,
+      "order": 1,
+      "runner": { "kind": "benchlocal-cli", "argv": ["node", "dist-cli/cli/run.js"] },
+      "tool_pack": false,
+      "sidecar": null
+    },
+    {
+      "id": "instructfollow-15",
+      "dir": "InstructFollow-15",
+      "repo": "https://github.com/stevibe/InstructFollow-15.git",
+      "revision": "187af97cb2b892ad57de176b16a254aba7565a65",
+      "version": "1.0.0",
+      "scenario_count": 15,
+      "order": 2,
+      "runner": { "kind": "benchlocal-cli", "argv": ["node", "dist-cli/cli/run.js"] },
+      "tool_pack": false,
+      "sidecar": null
+    },
+    {
+      "id": "reasonmath-15",
+      "dir": "ReasonMath-15",
+      "repo": "https://github.com/stevibe/ReasonMath-15.git",
+      "revision": "b97632020fa373c52ba92373dbe5dc58b744ce48",
+      "version": "1.0.0",
+      "scenario_count": 15,
+      "order": 3,
+      "runner": { "kind": "benchlocal-cli", "argv": ["node", "dist-cli/cli/run.js"] },
+      "tool_pack": false,
+      "sidecar": null
+    },
+    {
+      "id": "toolcall-15",
+      "dir": "ToolCall-15",
+      "repo": "https://github.com/stevibe/ToolCall-15.git",
+      "revision": "edd6cefe4261b67e8166e9f6d77d671042560294",
+      "version": "1.0.1",
+      "scenario_count": 15,
+      "order": 4,
+      "runner": { "kind": "benchlocal-cli", "argv": ["node", "dist-cli/cli/run.js"] },
+      "tool_pack": true,
+      "sidecar": null
+    },
+    {
+      "id": "promptauthority-15",
+      "dir": "PromptAuthority-15",
+      "repo": "https://github.com/stevibe/PromptAuthority-15.git",
+      "revision": "6ed261b42fcca0df15e4794eeb4da628b1666952",
+      "version": "1.0.0",
+      "scenario_count": 15,
+      "order": 5,
+      "runner": { "kind": "benchlocal-cli", "argv": ["node", "dist-cli/cli/run.js"] },
+      "tool_pack": true,
+      "sidecar": null
+    },
+    {
+      "id": "structoutput-15",
+      "dir": "StructOutput-15",
+      "repo": "https://github.com/stevibe/StructOutput-15.git",
+      "revision": "00de86e9bfc9dd3d86ba397d0cf35bcbc04efd1c",
+      "version": "1.0.0",
+      "scenario_count": 15,
+      "order": 6,
+      "runner": { "kind": "benchlocal-cli", "argv": ["node", "dist-cli/cli/run.js"] },
+      "tool_pack": false,
+      "sidecar": {
+        "kind": "docker",
+        "build_context": "./verification",
+        "container_port": 4010,
+        "host_port": 4011,
+        "url_env": "STRUCTOUTPUT_VALIDATOR_URL",
+        "cli_flag": "--validator-url",
+        "note": "Pack metadata declares container port 4010; the campaign remapped the host port to 4011 to avoid colliding with the BugFind-15 sandbox."
+      }
+    },
+    {
+      "id": "bugfind-15",
+      "dir": "BugFind-15",
+      "repo": "https://github.com/stevibe/BugFind-15.git",
+      "revision": "eea2224a531f0937a8fffb4949abcd6db81f4d11",
+      "version": "1.0.1",
+      "scenario_count": 15,
+      "order": 7,
+      "runner": { "kind": "benchlocal-cli", "argv": ["node", "dist-cli/cli/run.js"] },
+      "tool_pack": false,
+      "sidecar": {
+        "kind": "docker",
+        "build_context": "./verification",
+        "container_port": 4010,
+        "host_port": 4010,
+        "url_env": "BUGFIND_SANDBOX_URL",
+        "cli_flag": "--sandbox-url"
+      }
+    },
+    {
+      "id": "cli-40",
+      "dir": "CLI-40",
+      "repo": "https://github.com/stevibe/CLI-40.git",
+      "revision": "3b95f86e6edac47183348381a9bb211ffaf09404",
+      "version": "1.0.2",
+      "scenario_count": 40,
+      "order": 8,
+      "runner": {
+        "kind": "cli40",
+        "argv": ["node", "dist/cli/run.js", "--all"],
+        "docker_image": "cli40-dev",
+        "auth_mode": "none",
+        "provider": "llamacpp"
+      },
+      "tool_pack": false,
+      "sampling_source": "hardcoded in the campaign dist: temperature 1.0, top_p 0.95, top_k 20, min_p 0.0, repetition_penalty 1.0, request_timeout_seconds 300; no presence_penalty",
+      "sidecar": { "kind": "docker", "build_context": "./verification", "container_port": 4040 }
+    },
+    {
+      "id": "hermesagent-20",
+      "dir": "HermesAgent-20",
+      "repo": "https://github.com/stevibe/HermesAgent-20.git",
+      "revision": "fa40ab9fb84a329421bbdfc3062cf28f1670de71",
+      "version": "1.0.0",
+      "scenario_count": 20,
+      "order": 9,
+      "runner": {
+        "kind": "hermes",
+        "argv": ["node", "scripts/run-scenarios.mjs", "--all"],
+        "docker_image": "hermesagent20-dev",
+        "provider": "custom",
+        "auth_mode": "bearer",
+        "api_key": "benchlocal",
+        "scenario_flag": "--scenario",
+        "scenario_ids": ["HA-01", "HA-02", "HA-03", "HA-04", "HA-05", "HA-06", "HA-07", "HA-08", "HA-09", "HA-10", "HA-11", "HA-12", "HA-13", "HA-14", "HA-15", "HA-16", "HA-17", "HA-18", "HA-19", "HA-20"]
+      },
+      "tool_pack": false,
+      "always_via_proxy": true,
+      "sampling_source": "runner sends only temperature and top_p; the proxy injects top_k, min_p, presence_penalty, repetition_penalty and the thinking variant",
+      "sidecar": { "kind": "docker", "build_context": "./verification", "container_port": 4010 }
+    }
+  ],
+
+  "scoring": {
+    "macro_score_definition": "Unweighted mean of the nine pack headline scores.",
+    "scenario_weighted_score_definition": "Pack headline scores weighted by pack scenario count (seven 15-scenario packs, HermesAgent-20 at 20, CLI-40 at 40).",
+    "status_totals_definition": "Sum of canonical pack pass/partial/fail counts.",
+    "runnable_scenarios_per_route": 165,
+    "runnable_scenario_attempts": 660,
+    "unsupported_packs": ["formsight", "pixelate"]
+  },
+
+  "exclusions": [
+    { "path_pattern": "results/*-no-presence", "reason": "a3b sampling policy missing presence_penalty=1.5" },
+    { "path_pattern": "results/*/hermesagent-20*openai-kwargs-failure*", "reason": "pinned Hermes OpenAI SDK rejected top_k before HTTP; not model quality" },
+    { "path_pattern": "results/*/hermesagent-20*{partial,fetch-failure,socket-hang,preload-fail,prepare-eacces,oom}*", "reason": "preserved infrastructure diagnostics; excluded from canonical score" },
+    { "path_pattern": "results/*/cli-40.*infra-fail*", "reason": "docker bind collision; the canonical cli-40.* retry is complete" }
+  ]
+}

--- a/tools/benchlocal/sampling_proxy.mjs
+++ b/tools/benchlocal/sampling_proxy.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+/**
+ * Dev-only campaign tooling (not the Rust control plane).
+ *
+ * Unified OpenAI JSON sampling proxy for BenchLocal nine-pack quality campaigns.
+ * Forces the model-recommended sampled request policy on intercepted
+ * POST .../v1/chat/completions bodies, attests each rewrite, and
+ * otherwise passes traffic through unchanged.
+ *
+ * Unifies the two 2026-07-31 archived proxies behind THINKING_MODE:
+ *   disabled (default) → baseline sha256
+ *     578f2be2b530ad4fb7ed76459ff76ba81c538376ee296af26369cf2af72099a2
+ *     forces enable_thinking: false; injects no reasoning fields
+ *   medium → medium sha256
+ *     8a221d7c3ad11abc66302876d5c0d0ebf441d36c4d71d1b055009e4bc1af4c3d
+ *     forces enable_thinking: true, reasoning_effort: "medium";
+ *     max_think_tokens: 1024 is attestation-only (expected_max_think_tokens),
+ *     never written on the wire body
+ *
+ * Pre-thinkfix baseline variant (reference only, not reproduced):
+ *   b87fb8658860d6fe971ae2c9a5b750e304278411c1edc100bc510906ab1b918f
+ *
+ * Env:
+ *   LISTEN_HOST       default 127.0.0.1
+ *   LISTEN_PORT       required
+ *   TARGET_ORIGIN     required, e.g. http://127.0.0.1:11435
+ *   MODEL_SLUG        required, attestation label
+ *   ATTESTATION_LOG   required, JSONL path
+ *   PRESENCE_PENALTY  default 1.5
+ *   THINKING_MODE     disabled (default) | medium
+ */
+
+import http from "node:http";
+import https from "node:https";
+import fs from "node:fs";
+import path from "node:path";
+import { URL } from "node:url";
+
+const FORCED_SAMPLING = Object.freeze({
+  temperature: 1.0,
+  top_p: 0.95,
+  top_k: 20,
+  min_p: 0.0,
+  presence_penalty: Number(process.env.PRESENCE_PENALTY ?? "1.5"),
+  repetition_penalty: 1.0,
+});
+
+const THINKING_MODE = (process.env.THINKING_MODE || "disabled").toLowerCase();
+if (THINKING_MODE !== "disabled" && THINKING_MODE !== "medium") {
+  console.error(
+    `sampling-proxy: THINKING_MODE must be "disabled" or "medium", got ${JSON.stringify(process.env.THINKING_MODE)}`,
+  );
+  process.exit(1);
+}
+
+const FORCED_REASONING_MEDIUM = Object.freeze({
+  reasoning_effort: "medium",
+  enable_thinking: true,
+  max_think_tokens: 1024,
+});
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (v === undefined || v === "") {
+    console.error(`sampling-proxy: missing required env ${name}`);
+    process.exit(1);
+  }
+  return v;
+}
+
+const LISTEN_HOST = process.env.LISTEN_HOST || "127.0.0.1";
+const LISTEN_PORT = Number(requireEnv("LISTEN_PORT"));
+const TARGET_ORIGIN = requireEnv("TARGET_ORIGIN").replace(/\/+$/, "");
+const MODEL_SLUG = requireEnv("MODEL_SLUG");
+const ATTESTATION_LOG = requireEnv("ATTESTATION_LOG");
+
+if (!Number.isFinite(LISTEN_PORT) || LISTEN_PORT <= 0) {
+  console.error("sampling-proxy: LISTEN_PORT must be a positive number");
+  process.exit(1);
+}
+
+try {
+  // Validate origin early.
+  // eslint-disable-next-line no-new
+  new URL(TARGET_ORIGIN);
+} catch {
+  console.error(`sampling-proxy: invalid TARGET_ORIGIN: ${TARGET_ORIGIN}`);
+  process.exit(1);
+}
+
+fs.mkdirSync(path.dirname(path.resolve(ATTESTATION_LOG)), { recursive: true });
+
+const HOP_BY_HOP = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailers",
+  "transfer-encoding",
+  "upgrade",
+  "host",
+  "content-length",
+]);
+
+function isChatCompletions(method, urlPath) {
+  return method === "POST" && /\/v1\/chat\/completions\/?$/.test(urlPath);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
+    req.on("error", reject);
+  });
+}
+
+function filterRequestHeaders(headers) {
+  const out = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (v === undefined) continue;
+    if (HOP_BY_HOP.has(k.toLowerCase())) continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+function filterResponseHeaders(headers) {
+  const out = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (v === undefined) continue;
+    const lk = k.toLowerCase();
+    if (lk === "transfer-encoding" || lk === "connection" || lk === "keep-alive") {
+      continue;
+    }
+    out[k] = v;
+  }
+  return out;
+}
+
+function appendAttestation(record) {
+  fs.appendFileSync(ATTESTATION_LOG, `${JSON.stringify(record)}\n`, "utf8");
+}
+
+function sendJson(res, status, obj) {
+  const body = Buffer.from(JSON.stringify(obj), "utf8");
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": body.length,
+  });
+  res.end(body);
+}
+
+function forward(req, res, bodyBuf) {
+  const target = new URL(TARGET_ORIGIN);
+  const incoming = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+  const pathAndQuery = incoming.pathname + incoming.search;
+  const isTls = target.protocol === "https:";
+  const lib = isTls ? https : http;
+
+  const headers = filterRequestHeaders(req.headers);
+  if (bodyBuf !== undefined) {
+    headers["content-length"] = String(bodyBuf.length);
+  }
+
+  const opts = {
+    protocol: target.protocol,
+    hostname: target.hostname,
+    port: target.port || (isTls ? 443 : 80),
+    method: req.method,
+    path: pathAndQuery,
+    headers,
+  };
+
+  const upstream = lib.request(opts, (upRes) => {
+    const outHeaders = filterResponseHeaders(upRes.headers);
+    res.writeHead(upRes.statusCode || 502, outHeaders);
+    upRes.pipe(res);
+  });
+
+  upstream.on("error", (err) => {
+    if (!res.headersSent) {
+      sendJson(res, 502, {
+        error: {
+          message: `upstream error: ${err.message}`,
+          type: "proxy_error",
+        },
+      });
+    } else {
+      res.destroy(err);
+    }
+  });
+
+  if (bodyBuf !== undefined) {
+    upstream.end(bodyBuf);
+  } else {
+    req.pipe(upstream);
+  }
+}
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+
+    if (req.method === "GET" && url.pathname === "/__sampling_proxy/health") {
+      sendJson(res, 200, {
+        ok: true,
+        target: TARGET_ORIGIN,
+        modelSlug: MODEL_SLUG,
+        forcedSampling: { ...FORCED_SAMPLING },
+        thinkingMode: THINKING_MODE,
+      });
+      return;
+    }
+
+    if (isChatCompletions(req.method, url.pathname)) {
+      let raw;
+      try {
+        raw = await readBody(req);
+      } catch (err) {
+        sendJson(res, 400, {
+          error: { message: `failed to read body: ${err.message}`, type: "invalid_request" },
+        });
+        return;
+      }
+
+      let parsed;
+      try {
+        const text = raw.length ? raw.toString("utf8") : "{}";
+        parsed = JSON.parse(text);
+        if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+          throw new Error("body must be a JSON object");
+        }
+      } catch (err) {
+        sendJson(res, 400, {
+          error: {
+            message: `malformed chat completions JSON: ${err.message}`,
+            type: "invalid_request",
+          },
+        });
+        return;
+      }
+
+      parsed.temperature = FORCED_SAMPLING.temperature;
+      parsed.top_p = FORCED_SAMPLING.top_p;
+      parsed.top_k = FORCED_SAMPLING.top_k;
+      parsed.min_p = FORCED_SAMPLING.min_p;
+      parsed.presence_penalty = FORCED_SAMPLING.presence_penalty;
+      parsed.repetition_penalty = FORCED_SAMPLING.repetition_penalty;
+
+      // Thinking dimension: disabled reproduces baseline thinkfix;
+      // medium reproduces the medium campaign reasoning force.
+      // Archive: medium never puts max_think_tokens on the request body —
+      // that constant only feeds attestation expected_max_think_tokens.
+      const ctk =
+        parsed.chat_template_kwargs &&
+        typeof parsed.chat_template_kwargs === "object" &&
+        !Array.isArray(parsed.chat_template_kwargs)
+          ? { ...parsed.chat_template_kwargs }
+          : {};
+      if (THINKING_MODE === "medium") {
+        parsed.reasoning_effort = FORCED_REASONING_MEDIUM.reasoning_effort;
+        ctk.enable_thinking = FORCED_REASONING_MEDIUM.enable_thinking;
+      } else {
+        // Stabilize Qwen think-span validation for agentic multi-turn runs.
+        // Does not alter the six forced sampling fields above.
+        ctk.enable_thinking = false;
+        // Inject no reasoning fields (do not set reasoning_effort / max_think_tokens).
+      }
+      parsed.chat_template_kwargs = ctk;
+
+      const rewritten = Buffer.from(JSON.stringify(parsed), "utf8");
+
+      // Attestation key set is mode-dependent, matching each archive exactly.
+      const attestation = {
+        timestamp: new Date().toISOString(),
+        modelSlug: MODEL_SLUG,
+        path: url.pathname,
+        requestModel: parsed.model ?? null,
+        temperature: parsed.temperature,
+        top_p: parsed.top_p,
+        top_k: parsed.top_k,
+        min_p: parsed.min_p,
+        presence_penalty: parsed.presence_penalty,
+        repetition_penalty: parsed.repetition_penalty,
+      };
+      if (THINKING_MODE === "medium") {
+        attestation.reasoning_effort = parsed.reasoning_effort;
+        attestation.enable_thinking = parsed.chat_template_kwargs.enable_thinking;
+        attestation.expected_max_think_tokens = FORCED_REASONING_MEDIUM.max_think_tokens;
+      }
+      appendAttestation(attestation);
+
+      forward(req, res, rewritten);
+      return;
+    }
+
+    // Pass-through: stream body as-is.
+    forward(req, res, undefined);
+  } catch (err) {
+    if (!res.headersSent) {
+      sendJson(res, 502, {
+        error: { message: `proxy failure: ${err.message}`, type: "proxy_error" },
+      });
+    } else {
+      res.destroy(err);
+    }
+  }
+});
+
+function shutdown(signal) {
+  console.error(`sampling-proxy: ${signal}, shutting down`);
+  server.close(() => process.exit(0));
+  // Force-exit if hang.
+  setTimeout(() => process.exit(0), 5000).unref();
+}
+
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+
+server.listen(LISTEN_PORT, LISTEN_HOST, () => {
+  console.error(
+    `sampling-proxy: listening on http://${LISTEN_HOST}:${LISTEN_PORT} -> ${TARGET_ORIGIN} (${MODEL_SLUG})`,
+  );
+});


### PR DESCRIPTION
## Why

The 2026-07-31 BenchLocal campaigns produced the quality numbers we cite, but nothing that ran them was in the tree. The results survived only as `~/.cache` trees plus a NAS tarball (`/mnt/nas/kaden/hipfire/benchlocal/2026-07-31-quality/`), so the published scores were reproducible by nobody except the shell history that made them. This lands the harness, reconstructed from the campaigns' own provenance records.

Purely additive: 9 new files, 4000 insertions, 0 deletions. No Rust, no kernels, no changes to existing behaviour.

| File | Role |
|---|---|
| `tools/benchlocal/manifest.json` | Topology, pack pins, sampling contract |
| `scripts/benchlocal_campaign.py` | `plan` / `verify` / `run` / `recover-hermes` |
| `scripts/benchlocal_score.py` | Results tree → summary JSON |
| `tools/benchlocal/sampling_proxy.mjs` | Forcing proxy, both thinking modes |
| `tests/test_benchlocal_plan.py` + 2 fixtures | Command matrix vs archived provenance |
| `tests/test_benchlocal_proxy.py` | Proxy body + attestation fidelity |
| `docs/methodology/benchlocal-campaign.md` | Methodology, landmines, provenance |

## Contract

The manifest is authoritative: 4 routes (`serve_port = 12180 + gpu`, `proxy_port = serve_port + 100`), 9 packs at pinned upstream revisions, and the sampling policy — temperature 1.0, top_p 0.95, top_k 20, min_p 0.0, repetition_penalty 1.0, presence_penalty 0 on qwen27 and 1.5 on a3b.

Cross-checked against the archive: pinned revisions match live pack HEADs, routes match recorded model paths/hashes/GPU/mode, and 165 scenarios × 4 routes reproduces the recorded 660 attempts.

The proxy exists because the pinned Hermes OpenAI SDK rejects `top_k` before it reaches HTTP, so sampling must be forced on the wire. It unifies the two archived proxies behind `THINKING_MODE`, reproducing `578f2be2` (disabled) and `8a221d7c` (medium). `max_think_tokens` is deliberately kept **off** the request body — the medium archive proves it never went on the wire; that constant only feeds the attestation's `expected_max_think_tokens`.

## Evidence

- **Scorer replays the archive exactly.** 4 routes × 9 packs, **0 mismatches** on score/pass/partial/fail; macro scores land on 82.9056 / 84.3139 / 69.4139 / 80.6806, including the fractional CLI-40 values (70.125, 70.15, 60.725). No archived score is hardcoded — verified by grepping for the constants.
- **Live run on hiptrx** through the full remote path: daemon on one R9700, SSH tunnel, proxy, `reasonmath-15` **exit 0 in 723 s** over 15 scenarios, `finalScore: 76`. The archived baseline for that route/pack is also 76. One realization at temperature 1.0, not a determinism claim.
- **7/7 tests pass on a clean `beta` base** (verified in a worktree off `origin/beta`, so no dependency on unrelated in-flight work), plus `node --check` and AST parse.

`test_benchlocal_plan.py` compares **structurally**, not textually, because the archive was hand-assembled and disagrees with itself: `qwen27-ar` omits `--provider-model`, Hermes flag order differs per route, and StructOutput records `--model=v` in `argv` but `--model v` in its own `command` string. The rule is strict where the archive is specific and subset-with-sidecar-allowance where it collapses seven packs into a single `<Pack>` pattern that structurally cannot carry per-pack sidecar wiring.

## Also

Repairs a corrupt record: the baseline summary stored a 63-hex sha256 for `a3b-mq4p`. Re-hashing showed a dropped trailing `f`; the sibling `a3b-mq4r` digest matched byte-for-byte, confirming the local weights are what the campaign served.

## Not a validation gate

`docs/VALIDATION.md` still owns the mandatory routes (`serve_harness.py`, `redline_daemon_harness.py`). This is a quality campaign and the doc says so explicitly.

## Note for reviewers

The branch drops one line the source branch had: a pointer from `docs/methodology/testing-playbook.md`, which does not exist on `beta` (it lives in the 29 DS4 commits ahead). Worth re-adding when those land.