### PR TITLE
feat(kv): compose CASK eviction with VMM and adaptive KV

### DIFF
--- a/crates/hipfire-arch-qwen35/src/carrier.rs
+++ b/crates/hipfire-arch-qwen35/src/carrier.rs
@@ -211,6 +211,7 @@ fn plan_qwen35_gpu_stages(config: &Qwen35Config, ctx: &LoadCtx) -> Result<Qwen35
     } else {
         // Static path: final K mode + optional Lloyd-V known before allocation.
         let static_v = v_mode_override.unwrap_or(llama::VMode::Q8);
+        validate_cask_static_layout(ctx.cask.sidecar.is_some(), mode, static_v)?;
         if !matches!(static_v, llama::VMode::Q8) {
             let is_fwht = matches!(
                 mode,
@@ -233,6 +234,37 @@ fn plan_qwen35_gpu_stages(config: &Qwen35Config, ctx: &LoadCtx) -> Result<Qwen35
             kv_v_env,
         })
     }
+}
+
+/// CASK's score kernels currently decode Q8/Givens-asym K and its compaction
+/// path copies Q8 V rows. VMM does not change those bytes, but enabling an
+/// unsupported FWHT/Lloyd layout would defer a deterministic format mismatch
+/// until the first eviction. Reject it in the CPU plan instead.
+fn validate_cask_static_layout(
+    cask_enabled: bool,
+    mode: hipfire_runtime::kv_mode::KvMode,
+    v_mode: llama::VMode,
+) -> Result<(), String> {
+    if !cask_enabled {
+        return Ok(());
+    }
+    if !matches!(v_mode, llama::VMode::Q8) {
+        return Err(format!(
+            "CASK currently requires V=q8 (resolved V mode is {v_mode:?})"
+        ));
+    }
+    if !matches!(
+        mode,
+        hipfire_runtime::kv_mode::KvMode::Q8
+            | hipfire_runtime::kv_mode::KvMode::Asym2
+            | hipfire_runtime::kv_mode::KvMode::Asym3
+            | hipfire_runtime::kv_mode::KvMode::Asym4
+    ) {
+        return Err(format!(
+            "CASK currently supports Q8/asym2/asym3/asym4 K only (resolved mode is {mode:?})"
+        ));
+    }
+    Ok(())
 }
 
 fn construct_kv_cache(
@@ -607,5 +639,27 @@ mod tests {
         let s = append_cleanup_context("kv failed".into(), Err("pending VMM teardown".into()));
         assert!(s.starts_with("kv failed; cleanup also failed:"), "{s}");
         assert!(s.contains("pending VMM"), "{s}");
+    }
+
+    #[test]
+    fn cask_static_layout_accepts_only_current_compaction_formats() {
+        use hipfire_runtime::kv_mode::KvMode;
+
+        for mode in [KvMode::Q8, KvMode::Asym2, KvMode::Asym3, KvMode::Asym4] {
+            validate_cask_static_layout(true, mode, VMode::Q8).unwrap();
+        }
+        for mode in [KvMode::Fwht2, KvMode::Fwht3, KvMode::Fwht4] {
+            let err = validate_cask_static_layout(true, mode, VMode::Q8).unwrap_err();
+            assert!(err.contains("Q8/asym2/asym3/asym4"), "{err}");
+        }
+        let err = validate_cask_static_layout(true, KvMode::Fwht3, VMode::Lloyd3).unwrap_err();
+        assert!(err.contains("V=q8"), "{err}");
+    }
+
+    #[test]
+    fn cask_layout_guard_is_inert_when_cask_is_disabled() {
+        use hipfire_runtime::kv_mode::KvMode;
+
+        validate_cask_static_layout(false, KvMode::Fwht3, VMode::Lloyd3).unwrap();
     }
 }

--- a/crates/hipfire-arch-qwen35/src/carrier.rs
+++ b/crates/hipfire-arch-qwen35/src/carrier.rs
@@ -136,6 +136,14 @@ fn plan_qwen35_gpu_stages(config: &Qwen35Config, ctx: &LoadCtx) -> Result<Qwen35
         .map(|s| s.to_string())
         .unwrap_or_else(|| hipfire_runtime::config::get().kv_adaptive.clone());
     let adaptive_req = parse_kv_adaptive(&kv_adaptive_spec)?;
+    validate_adaptive_cask_handoff(
+        adaptive_req.is_some(),
+        ctx.cask.sidecar.is_some(),
+        ctx.cask.handoff_tokens,
+        ctx.kv_backend,
+        ctx.cask.cask_m_folding,
+        ctx.max_seq,
+    )?;
 
     // Adaptive DFlash is out of scope: refuse explicit adaptive + DFlash draft.
     if adaptive_req.is_some() {
@@ -150,12 +158,6 @@ fn plan_qwen35_gpu_stages(config: &Qwen35Config, ctx: &LoadCtx) -> Result<Qwen35
         }
         if ctx.pp > 1 {
             return Err("kv_adaptive requires single-GPU (pp=1)".into());
-        }
-        if ctx.cask.sidecar.is_some() {
-            return Err(
-                "kv_adaptive is a no-eviction capacity strategy and cannot combine with CASK"
-                    .into(),
-            );
         }
         if let Some(vm) = v_mode_override {
             return Err(format!(
@@ -182,7 +184,7 @@ fn plan_qwen35_gpu_stages(config: &Qwen35Config, ctx: &LoadCtx) -> Result<Qwen35
 
     if let Some((preset, k_floor, v_floor)) = adaptive_req {
         // Build controller first — floors and thresholds are authoritative.
-        let ad = match preset {
+        let mut ad = match preset {
             Some(p) => KvAdaptive::from_preset(p, ctx.max_seq, config.n_kv_heads, config.head_dim),
             None => KvAdaptive::new(
                 ctx.max_seq,
@@ -199,6 +201,9 @@ fn plan_qwen35_gpu_stages(config: &Qwen35Config, ctx: &LoadCtx) -> Result<Qwen35
                 ad.current_cap(),
                 hipfire_runtime::llama::PREFILL_MAX_BATCH,
             ));
+        }
+        if ctx.cask.sidecar.is_some() {
+            ad.configure_eviction_handoff(ctx.cask.handoff_tokens);
         }
         Ok(Qwen35KvPlan {
             mode,
@@ -236,10 +241,57 @@ fn plan_qwen35_gpu_stages(config: &Qwen35Config, ctx: &LoadCtx) -> Result<Qwen35
     }
 }
 
-/// CASK's score kernels currently decode Q8/Givens-asym K and its compaction
-/// path copies Q8 V rows. VMM does not change those bytes, but enabling an
-/// unsupported FWHT/Lloyd layout would defer a deterministic format mismatch
-/// until the first eviction. Reject it in the CPU plan instead.
+fn validate_adaptive_cask_handoff(
+    adaptive: bool,
+    sidecar: bool,
+    handoff_tokens: usize,
+    backend: KvBackend,
+    cask_m_folding: bool,
+    max_seq: usize,
+) -> Result<(), String> {
+    if !adaptive {
+        return if handoff_tokens == 0 {
+            Ok(())
+        } else {
+            Err("memory.cask.handoff_tokens requires memory.kv_adaptive != off".into())
+        };
+    }
+    if !sidecar {
+        return if handoff_tokens == 0 {
+            Ok(())
+        } else {
+            Err(
+                "memory.cask.handoff_tokens requires memory.cask.sidecar (or auto-attached sidecar)"
+                    .into(),
+            )
+        };
+    }
+    if handoff_tokens == 0 {
+        return Err(
+            "kv_adaptive and CASK require memory.cask.handoff_tokens > 0 for an explicit one-way handoff"
+                .into(),
+        );
+    }
+    if backend != KvBackend::Vmm {
+        return Err("kv_adaptive -> CASK handoff currently requires memory.kv_backend=vmm".into());
+    }
+    if cask_m_folding {
+        return Err(
+            "kv_adaptive -> CASK handoff supports plain TriAttention eviction only; CASK m-folding needs FWHT/Lloyd fold kernels"
+                .into(),
+        );
+    }
+    if handoff_tokens > max_seq {
+        return Err(format!(
+            "memory.cask.handoff_tokens={handoff_tokens} exceeds max_seq={max_seq} and can never activate"
+        ));
+    }
+    Ok(())
+}
+
+/// The static CASK path remains limited to Q8 V and Givens-asym K. Adaptive
+/// FWHT/Lloyd layouts use the separately validated plain-TriAttention handoff;
+/// m-folding still lacks the corresponding fold/requant kernels.
 fn validate_cask_static_layout(
     cask_enabled: bool,
     mode: hipfire_runtime::kv_mode::KvMode,
@@ -629,6 +681,35 @@ mod tests {
         assert!(
             err.contains("incomplete") || err.contains("malformed"),
             "{err}"
+        );
+    }
+
+    #[test]
+    fn adaptive_cask_handoff_compatibility_matrix_is_fail_closed() {
+        let check = |adaptive, sidecar, handoff, backend, folding| {
+            validate_adaptive_cask_handoff(adaptive, sidecar, handoff, backend, folding, 2048)
+        };
+
+        assert!(check(true, true, 128, KvBackend::Vmm, false).is_ok());
+        assert!(check(true, true, 0, KvBackend::Vmm, false)
+            .unwrap_err()
+            .contains("handoff_tokens > 0"));
+        assert!(check(true, true, 128, KvBackend::Contiguous, false)
+            .unwrap_err()
+            .contains("requires memory.kv_backend=vmm"));
+        assert!(check(true, true, 128, KvBackend::Vmm, true)
+            .unwrap_err()
+            .contains("m-folding"));
+        assert!(check(true, false, 128, KvBackend::Vmm, false)
+            .unwrap_err()
+            .contains("requires memory.cask.sidecar"));
+        assert!(check(false, false, 128, KvBackend::Vmm, false)
+            .unwrap_err()
+            .contains("requires memory.kv_adaptive"));
+        assert!(
+            validate_adaptive_cask_handoff(true, true, 2049, KvBackend::Vmm, false, 2048)
+                .unwrap_err()
+                .contains("exceeds max_seq")
         );
     }
 

--- a/crates/hipfire-arch-qwen35/src/carrier.rs
+++ b/crates/hipfire-arch-qwen35/src/carrier.rs
@@ -171,12 +171,13 @@ fn plan_qwen35_gpu_stages(config: &Qwen35Config, ctx: &LoadCtx) -> Result<Qwen35
         }
     }
 
+    let physical_cap = ctx.cask.physical_cap(ctx.max_seq)?;
     let dims = KvDims {
         layers: KvLayers::Mask(is_kv_layer.clone()),
         n_kv_heads: config.n_kv_heads,
         head_dim: config.head_dim,
         max_seq: ctx.max_seq,
-        physical_cap: Some(ctx.max_seq),
+        physical_cap: Some(physical_cap),
     };
 
     if let Some((preset, k_floor, v_floor)) = adaptive_req {
@@ -293,6 +294,10 @@ fn construct_kv_cache(
     } else {
         let static_v = plan.static_v;
         let mode = plan.mode;
+        let physical_cap = plan
+            .dims
+            .physical_cap
+            .expect("Qwen3.5 KV plan always resolves physical_cap");
         let kv = match (ctx.kv_backend, static_v) {
             (KvBackend::Vmm, vm) => {
                 // Unified VMM constructor: reserve == current; never post-alloc realloc.
@@ -302,7 +307,7 @@ fn construct_kv_cache(
                     config.n_kv_heads,
                     config.head_dim,
                     ctx.max_seq,
-                    ctx.max_seq,
+                    physical_cap,
                     mode,
                     vm,
                 )

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -6845,6 +6845,16 @@ fn ar_graph_trace_enabled() -> bool {
     })
 }
 
+#[inline]
+fn ar_graph_eligible_for_kv(requested: bool, compact_offset: usize) -> bool {
+    // The captured single-token route is built while compact_offset is zero.
+    // After eviction, Q/K RoPE must use physical_pos + compact_offset, and the
+    // offset changes again at every later eviction. Neither hipGraph nor the
+    // retained replay route currently has a dynamic offset input, so replaying
+    // the old route silently rotates at the physical slot and corrupts decode.
+    requested && compact_offset == 0
+}
+
 /// Zero-alloc forward pass using pre-allocated scratch buffers.
 /// Logits stay on GPU in scratch.logits. Returns nothing — caller uses scratch.logits.
 pub fn forward_scratch(
@@ -6971,7 +6981,9 @@ pub fn forward_scratch(
     // right before their `forward_scratch` call so the plain-AR graph can never
     // capture or replay in a non-sequential context. An ineligible call also
     // INVALIDATES any captured graph (forces re-capture on the next plain call).
-    let graph_eligible = std::mem::replace(&mut gpu.graphs.ar_graph_eligible, true);
+    let requested_graph_eligible = std::mem::replace(&mut gpu.graphs.ar_graph_eligible, true);
+    let graph_eligible =
+        ar_graph_eligible_for_kv(requested_graph_eligible, kv_cache.compact_offset);
     // Redline's plain-AR capture/replay has the same eligibility contract as
     // the AR HipGraph. MTP/spec re-seed and verify calls must not contaminate
     // or consume the immutable single-token replay sequence.
@@ -24355,5 +24367,13 @@ mod tests {
         assert!(ep_tick_inputs_prepared(usize::MAX));
         // Saturating representative: any non-zero later band is prepared.
         assert!(ep_tick_inputs_prepared(usize::MAX.saturating_sub(1)));
+    }
+
+    #[test]
+    fn ar_graph_is_ineligible_after_kv_compaction() {
+        assert!(ar_graph_eligible_for_kv(true, 0));
+        assert!(!ar_graph_eligible_for_kv(true, 1));
+        assert!(!ar_graph_eligible_for_kv(true, 128));
+        assert!(!ar_graph_eligible_for_kv(false, 0));
     }
 }

--- a/crates/hipfire-cli/src/main.rs
+++ b/crates/hipfire-cli/src/main.rs
@@ -6176,6 +6176,7 @@ fn load_params(
         "cask": config_bool(resolved, "memory.cask.enabled")?,
         "cask_budget": config_u64(resolved, "memory.cask.budget")?,
         "cask_beta": config_u64(resolved, "memory.cask.beta")?,
+        "cask_handoff_tokens": config_u64(resolved, "memory.cask.handoff_tokens")?,
         "cask_core_frac": config_f64(resolved, "memory.cask.core_fraction")?,
         "cask_fold_m": config_u64(resolved, "memory.cask.fold")?,
         "prefill_compression": config_string(resolved, "speculation.prefill.mode")?,
@@ -8911,6 +8912,7 @@ mod tests {
         let defaults = resolve(Vec::<NamedLayer>::new()).unwrap();
         let params = load_params(&defaults, Some(entry), &model_path, 64, None, None).unwrap();
         assert_eq!(params["cask"], false);
+        assert_eq!(params["cask_handoff_tokens"], 0);
         assert_eq!(params["cask_sidecar"], "");
         assert_eq!(params["prefill_compression"], "off");
 

--- a/crates/hipfire-config/src/lib.rs
+++ b/crates/hipfire-config/src/lib.rs
@@ -1091,6 +1091,18 @@ pub static FIELDS: &[ConfigField] = &[
         "Eviction hysteresis."
     ),
     field!(
+        "memory.cask.handoff_tokens",
+        "cask_handoff_tokens",
+        Memory,
+        ModelLoad,
+        DefaultValue::Integer(0),
+        ValueRule::Integer { min: 0, max: 1048576 },
+        true,
+        false,
+        None,
+        "One-way kv_adaptive to plain TriAttention handoff position; zero disables it."
+    ),
+    field!(
         "memory.cask.core_fraction",
         "cask_core_frac",
         Memory,

--- a/crates/hipfire-loader/src/carriers.rs
+++ b/crates/hipfire-loader/src/carriers.rs
@@ -338,12 +338,6 @@ impl Carrier for Qwen35Carrier {
                     .into(),
             );
         }
-        if ctx.kv_backend == KvBackend::Vmm && ctx.cask.sidecar.is_some() {
-            return Err(
-                "qwen35: KV backend 'vmm' does not yet support CASK/TriAttention eviction; disable the sidecar or use 'contiguous'"
-                    .into(),
-            );
-        }
         // Dir + pp>1: early return before any diagnostics/meta resolution,
         // preserving the original error string and preventing tokenizer work.
         if ctx.pp > 1 {
@@ -363,17 +357,7 @@ impl Carrier for Qwen35Carrier {
                 }
 
                 // ── pp=1 path (single-GPU) ────────────────────
-                let physical_cap = if ctx.cask.sidecar.is_some() {
-                    let env_override = hipfire_config::developer_var("HIPFIRE_KV_PHYSICAL_CAP")
-                        .ok()
-                        .and_then(|s| s.parse::<usize>().ok());
-                    let safety = 256usize;
-                    let floor = ctx.cask.budget + ctx.cask.beta + 4;
-                    let derived = ctx.cask.budget + ctx.cask.beta + safety;
-                    env_override.unwrap_or(derived).clamp(floor, ctx.max_seq)
-                } else {
-                    ctx.max_seq
-                };
+                let physical_cap = ctx.cask.physical_cap(ctx.max_seq)?;
 
                 // VL detection — loads weights from hfq_file in-place
                 let (vision_config, vision_weights) = {

--- a/crates/hipfire-loader/src/lib.rs
+++ b/crates/hipfire-loader/src/lib.rs
@@ -780,6 +780,7 @@ fn rollback_unfinished_qwen35(
 fn build_qwen35_eviction(
     config: &hipfire_arch_qwen35::qwen35::Qwen35Config,
     physical_cap: usize,
+    activation_gate: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
     ctx: &mut LoadCtx,
 ) -> Result<Option<Eviction>, String> {
     use hipfire_arch_qwen35::qwen35::LayerType;
@@ -819,7 +820,7 @@ fn build_qwen35_eviction(
         return Ok(None);
     }
     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
-    let base = EvictionCtx::new(
+    let mut base = EvictionCtx::new(
         ctx.gpu,
         &centers,
         fa_layer_ids,
@@ -833,6 +834,9 @@ fn build_qwen35_eviction(
         physical_cap,
     )
     .map_err(|e| format!("build EvictionCtx: {e}"))?;
+    if let Some(gate) = activation_gate {
+        base.set_activation_gate(gate);
+    }
     if ctx.cask.cask_m_folding {
         eprintln!(
             "  eviction: CASK α={:.2} m={} budget={} β={} physical_cap={}",
@@ -869,7 +873,11 @@ fn finish_qwen35_load(
 ) -> Result<LoadedModel, String> {
     // ── Eviction (only hard-error stage before publish) ────────────
     // Built before long-lived borrows so rollback can move `bundle`.
-    let eviction = match build_qwen35_eviction(&bundle.config, physical_cap, ctx) {
+    let activation_gate = bundle
+        .kv_adaptive
+        .as_ref()
+        .and_then(|adaptive| adaptive.eviction_gate());
+    let eviction = match build_qwen35_eviction(&bundle.config, physical_cap, activation_gate, ctx) {
         Ok(e) => e,
         Err(e) => {
             return Err(rollback_unfinished_qwen35(

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -12102,6 +12102,23 @@ fn vl_no_eviction_kv_cap(physical_cap: usize, max_seq: usize, adaptive_engaged: 
     }
 }
 
+/// Bound an eviction-enabled Qwen prefill write while an adaptive cache still
+/// owns the layout.  Before the one-way handoff, the eviction window is not a
+/// capacity limit (its gate is closed); writes must instead stop at every
+/// adaptive transition boundary.  After handoff, the normal budget window
+/// again determines how much can be appended before compaction.
+fn qwen_ar_eviction_prefill_chunk_limit(
+    seq_pos: usize,
+    eviction_window: usize,
+    adaptive_staging: bool,
+) -> usize {
+    if adaptive_staging {
+        qwen35::PREFILL_MAX_BATCH
+    } else {
+        eviction_window.saturating_sub(seq_pos).max(1)
+    }
+}
+
 /// Cold-reset VL trunk after a GPU/VMM/adaptive failure so the next request
 /// cannot inherit partial DN/KV/seq or mismatched conversation history.
 ///
@@ -12376,6 +12393,33 @@ mod mtp_host_timing_contract {
         assert_eq!(arr[0]["wall_us"], 1);
         assert_eq!(arr[1]["wall_us"], 2);
         assert_eq!(arr[2]["wall_us"], 3);
+    }
+}
+
+#[cfg(test)]
+mod adaptive_eviction_prefill_contract {
+    use super::qwen_ar_eviction_prefill_chunk_limit;
+    use hipfire_arch_qwen35::qwen35::PREFILL_MAX_BATCH;
+
+    #[test]
+    fn staging_uses_adaptive_boundaries_until_handoff() {
+        let window = 2048 + 128;
+        assert_eq!(
+            qwen_ar_eviction_prefill_chunk_limit(0, window, true),
+            PREFILL_MAX_BATCH
+        );
+        assert_eq!(
+            qwen_ar_eviction_prefill_chunk_limit(8192 - PREFILL_MAX_BATCH, window, true),
+            PREFILL_MAX_BATCH
+        );
+        assert_eq!(
+            qwen_ar_eviction_prefill_chunk_limit(2048, window, false),
+            128
+        );
+        assert_eq!(
+            qwen_ar_eviction_prefill_chunk_limit(window, window, false),
+            1
+        );
     }
 }
 
@@ -25218,8 +25262,13 @@ fn generate(
                     prefill_aborted = true;
                     break;
                 }
-                let space = window.saturating_sub(m.seq_pos).max(1);
-                let chunk_len = remaining.len().min(space);
+                let adaptive_staging = m
+                    .kv_adaptive
+                    .as_ref()
+                    .is_some_and(|ad| !ad.handoff_complete());
+                let chunk_limit =
+                    qwen_ar_eviction_prefill_chunk_limit(m.seq_pos, window, adaptive_staging);
+                let chunk_len = remaining.len().min(chunk_limit);
                 let (chunk, rest) = remaining.split_at(chunk_len);
                 if let Err(e) = qwen35::forward_prefill_batch(
                     gpu, weights, config, chunk, m.seq_pos, kv, dn, scratch, None, None, None, None,
@@ -25238,6 +25287,42 @@ fn generate(
                     return;
                 }
                 m.seq_pos += chunk_len;
+                // The eviction gate remains closed until adaptive KV reaches
+                // its explicit handoff point and finishes every transcode.
+                // Drive that transition at the same bounded committed-prefix
+                // boundaries as the ordinary adaptive prefill path, before
+                // asking eviction to observe the gate.
+                if let Some(ad) = m.kv_adaptive.as_mut() {
+                    match ad.maybe_downshift(gpu, kv, m.seq_pos) {
+                        Ok(steps) => {
+                            for step in steps {
+                                eprintln!(
+                                    "[adaptive-kv] downshift @ pos {} (eviction prefill): {:?} (K={:?} V={:?})",
+                                    m.seq_pos, step, ad.cur_k, ad.cur_v
+                                );
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!(
+                                "[adaptive-kv] maybe_downshift error @ pos {} (eviction prefill): {:?} — poisoning model",
+                                m.seq_pos, e
+                            );
+                            reset_ar_uncommitted_state!();
+                            emit_active_attempt_error(
+                                stdout,
+                                Some(id),
+                                &format!(
+                                    "adaptive KV transition failed during eviction prefill: {e}"
+                                ),
+                                "transient",
+                                true,
+                                false,
+                            );
+                            let _ = stdout.flush();
+                            return;
+                        }
+                    }
+                }
                 if let Some(hipfire_runtime::triattn::EvictionResult {
                     new_physical: new_phys,
                     ..

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -13300,6 +13300,11 @@ fn main() {
                     .and_then(|p| p.get("cask_beta"))
                     .and_then(|v| v.as_u64())
                     .unwrap_or(128) as usize;
+                let cask_handoff_tokens = msg
+                    .get("params")
+                    .and_then(|p| p.get("cask_handoff_tokens"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0) as usize;
                 let cask_core_frac = msg
                     .get("params")
                     .and_then(|p| p.get("cask_core_frac"))
@@ -13328,6 +13333,7 @@ fn main() {
                 let cask = CaskConfig {
                     sidecar: cask_sidecar,
                     cask_m_folding: cask_m_folding_effective,
+                    handoff_tokens: cask_handoff_tokens,
                     budget: cask_budget,
                     beta: cask_beta,
                     core_frac: cask_core_frac,

--- a/crates/hipfire-runtime/examples/triattn_gpu_parity_fwht3.rs
+++ b/crates/hipfire-runtime/examples/triattn_gpu_parity_fwht3.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+//! GPU↔CPU numeric oracle for adaptive FWHT3 TriAttention scoring.
+
+#[cfg(not(feature = "deltanet"))]
+fn main() {
+    eprintln!("build with --features deltanet");
+}
+
+#[cfg(feature = "deltanet")]
+fn main() {
+    use hipfire_runtime::llama::KvCache;
+    use hipfire_runtime::triattn::{self, BandCenter, TriAttnCenters};
+    use rdna_compute::{DType, Gpu};
+
+    const C3: [f32; 8] = [
+        -0.134860, -0.083320, -0.046469, -0.015176, 0.015176, 0.046469, 0.083320, 0.134860,
+    ];
+    const N_HEADS: usize = 16;
+    const N_KV_HEADS: usize = 4;
+    const HEAD_DIM: usize = 256;
+    const SEQ_LEN: usize = 32;
+    const ROPE_THETA: f32 = 10_000_000.0;
+
+    fn lcg(seed: &mut u64) -> f32 {
+        *seed = seed
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((*seed >> 40) as u32 as f32 / (1u32 << 24) as f32) * 2.0 - 1.0
+    }
+
+    fn inverse_fwht_256(x: &mut [f32], signs1: &[f32], signs2: &[f32]) {
+        for (value, sign) in x.iter_mut().zip(signs2) {
+            *value *= sign;
+        }
+        let mut stride = 1;
+        while stride < 256 {
+            for base in (0..256).step_by(stride * 2) {
+                for i in 0..stride {
+                    let a = x[base + i];
+                    let b = x[base + i + stride];
+                    x[base + i] = a + b;
+                    x[base + i + stride] = a - b;
+                }
+            }
+            stride *= 2;
+        }
+        for i in 0..256 {
+            x[i] *= 0.0625 * signs1[i];
+        }
+    }
+
+    let n_bands = HEAD_DIM / 2;
+    let kv_group = N_HEADS / N_KV_HEADS;
+    let p_q = (SEQ_LEN - 1) as f32;
+    let mut seed = 0x5eed_cafe_u64;
+    let mut centers = TriAttnCenters::new(1, N_HEADS, HEAD_DIM, ROPE_THETA, 1.0);
+    let mut centers_flat = Vec::with_capacity(N_HEADS * n_bands * 3);
+    for h in 0..N_HEADS {
+        for f in 0..n_bands {
+            let center = BandCenter {
+                eq_re: 0.3 * lcg(&mut seed),
+                eq_im: 0.3 * lcg(&mut seed),
+                e_abs_q: 0.5 + 0.3 * lcg(&mut seed).abs(),
+            };
+            centers.set(0, h, f, center);
+            centers_flat.extend_from_slice(&[center.eq_re, center.eq_im, center.e_abs_q]);
+        }
+    }
+
+    let mut gpu = Gpu::init().expect("gpu init");
+    let kv = KvCache::new_gpu_fwht3_filtered(&mut gpu, &[true], N_KV_HEADS, HEAD_DIM, SEQ_LEN)
+        .expect("fwht3 cache");
+    let signs1 = kv.givens_cos.as_ref().expect("fwht signs1");
+    let signs2 = kv.givens_sin.as_ref().expect("fwht signs2");
+    let pos_dev = gpu.hip.malloc(4).expect("position buffer");
+    let kv_dim = N_KV_HEADS * HEAD_DIM;
+    for pos in 0..SEQ_LEN {
+        let k_row: Vec<f32> = (0..kv_dim).map(|_| 0.5 * lcg(&mut seed)).collect();
+        let v_row: Vec<f32> = (0..kv_dim).map(|_| 0.5 * lcg(&mut seed)).collect();
+        let k_tmp = gpu.upload_f32(&k_row, &[kv_dim]).expect("upload K");
+        let v_tmp = gpu.upload_f32(&v_row, &[kv_dim]).expect("upload V");
+        gpu.hip
+            .memcpy_htod(&pos_dev, &(pos as i32).to_ne_bytes())
+            .expect("upload position");
+        gpu.kv_cache_write_fwht3_fused(
+            &kv.k_gpu[0],
+            &kv.v_gpu[0],
+            &k_tmp,
+            &v_tmp,
+            &pos_dev,
+            signs1,
+            signs2,
+            N_KV_HEADS,
+            HEAD_DIM,
+            8,
+        )
+        .expect("write fwht3 row");
+    }
+
+    let centers_dev = gpu
+        .upload_f32(&centers_flat, &[centers_flat.len()])
+        .expect("upload centers");
+    let scores_dev = gpu
+        .alloc_tensor(&[N_HEADS * SEQ_LEN], DType::F32)
+        .expect("score buffer");
+    gpu.triattn_score_fwht(
+        &kv.k_gpu[0],
+        &centers_dev,
+        signs1,
+        signs2,
+        &scores_dev,
+        N_HEADS,
+        N_KV_HEADS,
+        HEAD_DIM,
+        HEAD_DIM,
+        ROPE_THETA,
+        p_q,
+        SEQ_LEN,
+        3,
+    )
+    .expect("FWHT3 score");
+    gpu.hip.device_synchronize().expect("score synchronize");
+    let gpu_scores = gpu.download_f32(&scores_dev).expect("download scores");
+    let signs1_cpu = gpu.download_f32(signs1).expect("download signs1");
+    let signs2_cpu = gpu.download_f32(signs2).expect("download signs2");
+    let cache_bytes: Vec<u8> = gpu
+        .download_f32(&kv.k_gpu[0])
+        .expect("download K cache")
+        .into_iter()
+        .flat_map(f32::to_ne_bytes)
+        .collect();
+
+    let bytes_per_head = 4 + HEAD_DIM * 3 / 8;
+    let bytes_per_pos = N_KV_HEADS * bytes_per_head;
+    let mut cpu_scores = vec![0.0; N_HEADS * SEQ_LEN];
+    let mut max_abs = 0.0f32;
+    let mut max_rel = 0.0f32;
+    for h in 0..N_HEADS {
+        let kv_h = h / kv_group;
+        let center_base = h * n_bands;
+        let center_slice = &centers.centers[center_base..center_base + n_bands];
+        for pos in 0..SEQ_LEN {
+            let row = pos * bytes_per_pos + kv_h * bytes_per_head;
+            let cnorm = f32::from_ne_bytes(cache_bytes[row..row + 4].try_into().unwrap());
+            let mut k_post = vec![0.0f32; HEAD_DIM];
+            for tid in 0..32 {
+                let packed_row = row + 4 + tid * 3;
+                let packed = cache_bytes[packed_row] as u32
+                    | ((cache_bytes[packed_row + 1] as u32) << 8)
+                    | ((cache_bytes[packed_row + 2] as u32) << 16);
+                for i in 0..8 {
+                    k_post[tid * 8 + i] = cnorm * C3[((packed >> (i * 3)) & 7) as usize];
+                }
+            }
+            inverse_fwht_256(&mut k_post, &signs1_cpu, &signs2_cpu);
+            let bands = triattn::kpost_per_band(&k_post);
+            let cpu = triattn::s_total(center_slice, &bands, p_q, |f| centers.omega(f));
+            let gpu_value = gpu_scores[h * SEQ_LEN + pos];
+            cpu_scores[h * SEQ_LEN + pos] = cpu;
+            let abs = (cpu - gpu_value).abs();
+            max_abs = max_abs.max(abs);
+            max_rel = max_rel.max(abs / cpu.abs().max(gpu_value.abs()).max(1e-6));
+        }
+    }
+
+    let pearson = triattn::pearson(&cpu_scores, &gpu_scores);
+    eprintln!(
+        "FWHT3 TriAttention GPU/CPU: max_abs={max_abs:.3e} max_rel={max_rel:.3e} r={pearson:.7}"
+    );
+    assert!(pearson > 0.9999, "ranking correlation too low: {pearson}");
+    assert!(max_rel < 5e-3, "relative error too high: {max_rel}");
+}

--- a/crates/hipfire-runtime/src/cask.rs
+++ b/crates/hipfire-runtime/src/cask.rs
@@ -91,6 +91,9 @@ impl CaskCtx {
         kv: &mut KvCache,
         current_physical: usize,
     ) -> HipResult<Option<EvictionResult>> {
+        if !self.base.is_active() {
+            return Ok(None);
+        }
         if current_physical < self.base.budget + self.base.beta {
             return Ok(None);
         }

--- a/crates/hipfire-runtime/src/kv_adaptive.rs
+++ b/crates/hipfire-runtime/src/kv_adaptive.rs
@@ -10,6 +10,8 @@
 //! would let seq_pos overflow the binding buffer. n_kv_heads cancels in each
 //! per-buffer ratio, so the caps are `max_seq * floor_bph / cur_bph`.
 use crate::llama::VMode;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 /// K-cache tier. Mirrors VMode for the V side. fwht4/fwht2 rotate 128-wide,
 /// fwht3 rotates 256-wide.
@@ -121,6 +123,10 @@ pub struct KvAdaptive {
     /// refuse until unload/reload; reset does not clear poison.
     poisoned: bool,
     poison_reason: Option<String>,
+    /// Optional one-way transition into an eviction policy. The shared gate
+    /// stays closed until every adaptive transcode has completed successfully.
+    handoff_at: Option<usize>,
+    eviction_ready: Option<Arc<AtomicBool>>,
 }
 
 impl KvAdaptive {
@@ -193,6 +199,8 @@ impl KvAdaptive {
             margin: crate::llama::PREFILL_MAX_BATCH,
             poisoned: false,
             poison_reason: None,
+            handoff_at: None,
+            eviction_ready: None,
         };
         s.recompute_thresholds();
         s
@@ -254,6 +262,44 @@ impl KvAdaptive {
         self.cur_k = KMode::Fwht4;
         self.cur_v = crate::llama::VMode::Q8;
         self.next_step = 0;
+        if let Some(ready) = &self.eviction_ready {
+            ready.store(false, Ordering::Release);
+        }
+    }
+
+    /// Configure a one-way transition to eviction at a committed position.
+    /// The returned gate is consumed by the eviction context; it remains
+    /// closed until all remaining adaptive steps have succeeded.
+    pub fn configure_eviction_handoff(&mut self, at: usize) -> Arc<AtomicBool> {
+        let ready = Arc::new(AtomicBool::new(false));
+        self.handoff_at = Some(at);
+        self.eviction_ready = Some(Arc::clone(&ready));
+        ready
+    }
+
+    pub fn handoff_at(&self) -> Option<usize> {
+        self.handoff_at
+    }
+
+    pub fn handoff_complete(&self) -> bool {
+        self.eviction_ready
+            .as_ref()
+            .is_some_and(|ready| ready.load(Ordering::Acquire))
+    }
+
+    pub fn eviction_gate(&self) -> Option<Arc<AtomicBool>> {
+        self.eviction_ready.as_ref().map(Arc::clone)
+    }
+
+    fn target_step_count(&self, seq_pos: usize) -> usize {
+        if self.handoff_at.is_some_and(|at| seq_pos >= at) {
+            self.steps.len()
+        } else {
+            self.thresholds
+                .iter()
+                .take_while(|&&threshold| seq_pos >= threshold)
+                .count()
+        }
     }
 
     /// Atomically restore controller + cache encoding to the adaptive start
@@ -312,7 +358,9 @@ impl KvAdaptive {
             ));
         }
         let mut applied = Vec::new();
-        while self.next_step < self.steps.len() && seq_pos >= self.thresholds[self.next_step] {
+        let handoff_crossed = self.handoff_at.is_some_and(|at| seq_pos >= at);
+        let target_step_count = self.target_step_count(seq_pos);
+        while self.next_step < target_step_count {
             let step = self.steps[self.next_step];
             let result = match step {
                 Step::V(nv) => kv.transcode_v_step(gpu, nv, seq_pos).map(|()| {
@@ -330,6 +378,19 @@ impl KvAdaptive {
             }
             applied.push(step);
             self.next_step += 1;
+        }
+        if handoff_crossed {
+            // Release only after every transcode above completed. Eviction's
+            // Acquire pairs with this store, so it cannot observe stale mode
+            // flags or cache bytes on another serving thread.
+            if let Some(ready) = &self.eviction_ready {
+                if !ready.swap(true, Ordering::AcqRel) {
+                    eprintln!(
+                        "[adaptive-kv] handoff complete @ pos {seq_pos}: K={:?} V={:?}; eviction active",
+                        self.cur_k, self.cur_v
+                    );
+                }
+            }
         }
         Ok(applied)
     }
@@ -488,6 +549,28 @@ mod tests {
         assert_eq!(a.cur_v, VMode::Q8);
         assert_eq!(a.next_step, 0);
         assert!(!a.is_poisoned());
+    }
+
+    #[test]
+    fn handoff_forces_floor_and_reset_recloses_gate() {
+        let mut a = KvAdaptive::from_preset(Preset::Aggressive, 10_000, 4, 256);
+        let first_natural_threshold = a.thresholds[0];
+        let handoff_at = first_natural_threshold / 2;
+        let gate = a.configure_eviction_handoff(handoff_at);
+
+        assert!(!gate.load(Ordering::Acquire));
+        assert_eq!(a.target_step_count(handoff_at - 1), 0);
+        assert_eq!(
+            a.target_step_count(handoff_at),
+            a.steps.len(),
+            "handoff must finish every remaining transcode before eviction"
+        );
+
+        gate.store(true, Ordering::Release);
+        assert!(a.handoff_complete());
+        a.reset();
+        assert!(!gate.load(Ordering::Acquire));
+        assert!(!a.handoff_complete());
     }
 
     #[test]

--- a/crates/hipfire-runtime/src/loader_api.rs
+++ b/crates/hipfire-runtime/src/loader_api.rs
@@ -144,3 +144,93 @@ pub struct CaskConfig {
     pub core_frac: f32,
     pub fold_m: usize,
 }
+
+impl CaskConfig {
+    /// Resolve the bounded physical KV window used by CASK/TriAttention.
+    ///
+    /// Keep this next to the shared load contract so the architecture carrier
+    /// allocates KV with the exact same cap later used to size the eviction
+    /// context. A mismatch is especially dangerous for VMM: the virtual reserve
+    /// and mapped-prefix guards must agree with the eviction trigger before the
+    /// first device allocation.
+    pub fn physical_cap(&self, max_seq: usize) -> Result<usize, String> {
+        let override_cap = hipfire_config::developer_var("HIPFIRE_KV_PHYSICAL_CAP")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok());
+        self.physical_cap_with_override(max_seq, override_cap)
+    }
+
+    /// Pure resolution seam used by CPU tests. An explicit override is clamped
+    /// to the safe CASK window, preserving the historical environment-variable
+    /// behavior without mutating process-global state in tests.
+    pub fn physical_cap_with_override(
+        &self,
+        max_seq: usize,
+        override_cap: Option<usize>,
+    ) -> Result<usize, String> {
+        if self.sidecar.is_none() {
+            return Ok(max_seq);
+        }
+        let trigger = self
+            .budget
+            .checked_add(self.beta)
+            .ok_or_else(|| "CASK budget + beta overflowed".to_string())?;
+        let floor = trigger
+            .checked_add(4)
+            .ok_or_else(|| "CASK physical-cap safety margin overflowed".to_string())?;
+        if floor > max_seq {
+            return Err(format!(
+                "CASK requires max_seq >= budget + beta + 4 (got max_seq={max_seq}, budget={}, beta={})",
+                self.budget, self.beta
+            ));
+        }
+        let derived = trigger.saturating_add(256).min(max_seq);
+        Ok(override_cap.unwrap_or(derived).clamp(floor, max_seq))
+    }
+}
+
+#[cfg(test)]
+mod cask_config_tests {
+    use super::CaskConfig;
+
+    fn enabled() -> CaskConfig {
+        CaskConfig {
+            sidecar: Some("centers.bin".into()),
+            budget: 4096,
+            beta: 128,
+            ..CaskConfig::default()
+        }
+    }
+
+    #[test]
+    fn disabled_cask_keeps_full_physical_cap() {
+        assert_eq!(
+            CaskConfig::default()
+                .physical_cap_with_override(32_768, Some(1024))
+                .unwrap(),
+            32_768
+        );
+    }
+
+    #[test]
+    fn enabled_cask_derives_and_clamps_physical_cap() {
+        let cask = enabled();
+        assert_eq!(cask.physical_cap_with_override(32_768, None).unwrap(), 4480);
+        assert_eq!(
+            cask.physical_cap_with_override(32_768, Some(1)).unwrap(),
+            4228
+        );
+        assert_eq!(
+            cask.physical_cap_with_override(5000, Some(99_999)).unwrap(),
+            5000
+        );
+    }
+
+    #[test]
+    fn enabled_cask_rejects_an_impossible_window() {
+        let err = enabled()
+            .physical_cap_with_override(4200, None)
+            .unwrap_err();
+        assert!(err.contains("budget + beta + 4"), "{err}");
+    }
+}

--- a/crates/hipfire-runtime/src/loader_api.rs
+++ b/crates/hipfire-runtime/src/loader_api.rs
@@ -139,6 +139,9 @@ pub trait Carrier {
 pub struct CaskConfig {
     pub sidecar: Option<String>,
     pub cask_m_folding: bool,
+    /// One-way adaptive-KV -> plain TriAttention handoff position. Zero keeps
+    /// the legacy mutual exclusion between adaptive KV and eviction.
+    pub handoff_tokens: usize,
     pub budget: usize,
     pub beta: usize,
     pub core_frac: f32,
@@ -169,6 +172,12 @@ impl CaskConfig {
         override_cap: Option<usize>,
     ) -> Result<usize, String> {
         if self.sidecar.is_none() {
+            return Ok(max_seq);
+        }
+        // A staged adaptive cache reserves its K/V arenas at the adaptive
+        // floor for the full advertised context. It cannot use the ordinary
+        // eviction-bounded physical cap before the handoff has completed.
+        if self.handoff_tokens != 0 {
             return Ok(max_seq);
         }
         let trigger = self
@@ -232,5 +241,16 @@ mod cask_config_tests {
             .physical_cap_with_override(4200, None)
             .unwrap_err();
         assert!(err.contains("budget + beta + 4"), "{err}");
+    }
+
+    #[test]
+    fn staged_handoff_keeps_full_adaptive_physical_cap() {
+        let mut cask = enabled();
+        cask.handoff_tokens = 8192;
+        assert_eq!(
+            cask.physical_cap_with_override(32_768, Some(1024)).unwrap(),
+            32_768,
+            "adaptive floor reservation must not be clamped to the eviction window"
+        );
     }
 }

--- a/crates/hipfire-runtime/src/triattn.rs
+++ b/crates/hipfire-runtime/src/triattn.rs
@@ -42,6 +42,7 @@
 use std::io::{Read, Write};
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::sync::Mutex;
 
 use hip_bridge::HipResult;
@@ -849,6 +850,9 @@ pub struct EvictionCtx {
     pub retain_dev: GpuTensor,
     /// Running count of evictions fired (useful for bench harnesses).
     pub eviction_count: std::cell::Cell<usize>,
+    /// Optional adaptive-KV handoff gate. Closed means the cache is still in
+    /// its adaptive phase and must not be scored or compacted yet.
+    activation_gate: Option<Arc<AtomicBool>>,
 }
 
 impl EvictionCtx {
@@ -927,7 +931,18 @@ impl EvictionCtx {
             v_compact,
             retain_dev,
             eviction_count: std::cell::Cell::new(0),
+            activation_gate: None,
         })
+    }
+
+    pub fn set_activation_gate(&mut self, gate: Arc<AtomicBool>) {
+        self.activation_gate = Some(gate);
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.activation_gate
+            .as_ref()
+            .is_none_or(|gate| gate.load(Ordering::Acquire))
     }
 
     /// If the physical cache has grown to `budget + beta` (or beyond), run
@@ -940,6 +955,9 @@ impl EvictionCtx {
         kv: &mut crate::llama::KvCache,
         current_physical: usize,
     ) -> HipResult<Option<EvictionResult>> {
+        if !self.is_active() {
+            return Ok(None);
+        }
         if current_physical < self.budget + self.beta {
             return Ok(None);
         }
@@ -956,7 +974,10 @@ impl EvictionCtx {
             "TriAttention eviction only supports Q8, asym2, asym3, asym4 KV modes for now (got {tier:?})"
         );
         let k_bytes_per_pos = tier.k_bytes_per_pos(self.n_kv_heads, self.head_dim);
-        let v_bytes_per_pos = self.n_kv_heads * (self.head_dim / 32) * 34;
+        let v_bytes_per_pos = match kv.v_mode {
+            crate::llama::VMode::Q8 => self.n_kv_heads * (self.head_dim / 32) * 34,
+            mode => self.n_kv_heads * (4 + (self.head_dim * mode.bits() as usize) / 8),
+        };
 
         let mut last_retain: Vec<u32> = Vec::new();
         for (fa_i, &layer_idx) in self.fa_layer_ids.iter().enumerate() {
@@ -975,7 +996,22 @@ impl EvictionCtx {
                     p_q,
                     current_physical,
                 )?,
-                KTier::Asym3 { .. } => gpu.triattn_score_asym3(
+                KTier::Asym3 { fwht: true } => gpu.triattn_score_fwht(
+                    &kv.k_gpu[layer_idx],
+                    &centers_layer,
+                    kv.givens_cos.as_ref().expect("fwht3 KV must have signs1"),
+                    kv.givens_sin.as_ref().expect("fwht3 KV must have signs2"),
+                    &self.scores_buf,
+                    self.n_heads,
+                    self.n_kv_heads,
+                    self.head_dim,
+                    self.n_rot,
+                    self.rope_theta,
+                    p_q,
+                    current_physical,
+                    3,
+                )?,
+                KTier::Asym3 { fwht: false } => gpu.triattn_score_asym3(
                     &kv.k_gpu[layer_idx],
                     &centers_layer,
                     kv.givens_cos
@@ -993,7 +1029,22 @@ impl EvictionCtx {
                     p_q,
                     current_physical,
                 )?,
-                KTier::Asym4 { .. } => gpu.triattn_score_asym4(
+                KTier::Asym4 { fwht: true } => gpu.triattn_score_fwht(
+                    &kv.k_gpu[layer_idx],
+                    &centers_layer,
+                    kv.givens_cos.as_ref().expect("fwht4 KV must have signs1"),
+                    kv.givens_sin.as_ref().expect("fwht4 KV must have signs2"),
+                    &self.scores_buf,
+                    self.n_heads,
+                    self.n_kv_heads,
+                    self.head_dim,
+                    self.n_rot,
+                    self.rope_theta,
+                    p_q,
+                    current_physical,
+                    4,
+                )?,
+                KTier::Asym4 { fwht: false } => gpu.triattn_score_asym4(
                     &kv.k_gpu[layer_idx],
                     &centers_layer,
                     kv.givens_cos
@@ -1011,7 +1062,22 @@ impl EvictionCtx {
                     p_q,
                     current_physical,
                 )?,
-                KTier::Asym2 { .. } => gpu.triattn_score_asym2(
+                KTier::Asym2 { fwht: true } => gpu.triattn_score_fwht(
+                    &kv.k_gpu[layer_idx],
+                    &centers_layer,
+                    kv.givens_cos.as_ref().expect("fwht2 KV must have signs1"),
+                    kv.givens_sin.as_ref().expect("fwht2 KV must have signs2"),
+                    &self.scores_buf,
+                    self.n_heads,
+                    self.n_kv_heads,
+                    self.head_dim,
+                    self.n_rot,
+                    self.rope_theta,
+                    p_q,
+                    current_physical,
+                    2,
+                )?,
+                KTier::Asym2 { fwht: false } => gpu.triattn_score_asym2(
                     &kv.k_gpu[layer_idx],
                     &centers_layer,
                     kv.givens_cos
@@ -1080,7 +1146,14 @@ impl EvictionCtx {
         }
 
         kv.compact_offset += current_physical - self.budget;
-        self.eviction_count.set(self.eviction_count.get() + 1);
+        let previous_count = self.eviction_count.get();
+        self.eviction_count.set(previous_count + 1);
+        if previous_count == 0 && self.activation_gate.is_some() {
+            eprintln!(
+                "[adaptive-kv] first eviction: physical {current_physical} -> {} compact_offset={}",
+                self.budget, kv.compact_offset
+            );
+        }
         Ok(Some(EvictionResult {
             new_physical: self.budget,
             retain_mask: last_retain,
@@ -1090,6 +1163,12 @@ impl EvictionCtx {
     /// Release all GPU buffers held by the context. Consumed by value;
     /// the daemon calls this on unload to return VRAM.
     pub fn free_gpu(self, gpu: &mut Gpu) {
+        if self.activation_gate.is_some() {
+            eprintln!(
+                "[adaptive-kv] eviction summary: count={}",
+                self.eviction_count.get()
+            );
+        }
         let _ = gpu.free_tensor(self.centers_dev);
         let _ = gpu.free_tensor(self.scores_buf);
         let _ = gpu.free_tensor(self.k_compact);

--- a/crates/hipfire-runtime/src/triattn.rs
+++ b/crates/hipfire-runtime/src/triattn.rs
@@ -943,6 +943,10 @@ impl EvictionCtx {
         if current_physical < self.budget + self.beta {
             return Ok(None);
         }
+        // Ordinary forwards preflight this prefix before writing it. Keep the
+        // eviction operation independently safe as well: a direct caller must
+        // never launch score/gather kernels across an unmapped VMM tail.
+        kv.require_mapped_capacity(current_physical)?;
         let absolute_pos = current_physical + kv.compact_offset;
         let p_q = absolute_pos as f32;
 

--- a/crates/rdna-compute/src/attention.rs
+++ b/crates/rdna-compute/src/attention.rs
@@ -5883,6 +5883,73 @@ impl Gpu {
         }
     }
 
+    /// TriAttention importance scoring over an adaptive FWHT{2,3,4}
+    /// post-RoPE K cache. The kernel inverse-transforms K before evaluating
+    /// the same trigonometric score used by the Q8/Givens paths.
+    #[allow(clippy::too_many_arguments)]
+    pub fn triattn_score_fwht(
+        &mut self,
+        k_cache: &GpuTensor,
+        centers: &GpuTensor,
+        signs1: &GpuTensor,
+        signs2: &GpuTensor,
+        scores: &GpuTensor,
+        n_heads: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        n_rot: usize,
+        rope_theta: f32,
+        p_q: f32,
+        seq_len: usize,
+        bits: usize,
+    ) -> HipResult<()> {
+        self.bind_thread()?;
+        self.ensure_givens4_kernel(
+            "triattn_score_fwht",
+            kernels::TRIATTN_SCORE_FWHT_SRC,
+            "triattn_score_fwht",
+        )?;
+        let func = &self.functions["triattn_score_fwht"];
+        let mut k_ptr = k_cache.buf.as_ptr();
+        let mut c_ptr = centers.buf.as_ptr();
+        let mut s1_ptr = signs1.buf.as_ptr();
+        let mut s2_ptr = signs2.buf.as_ptr();
+        let mut score_ptr = scores.buf.as_ptr();
+        let mut nh = n_heads as i32;
+        let mut nkv = n_kv_heads as i32;
+        let mut hd = head_dim as i32;
+        let mut nr = n_rot as i32;
+        let mut th = rope_theta;
+        let mut pq = p_q;
+        let mut sl = seq_len as i32;
+        let mut kb = bits as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &mut k_ptr as *mut _ as *mut c_void,
+            &mut c_ptr as *mut _ as *mut c_void,
+            &mut s1_ptr as *mut _ as *mut c_void,
+            &mut s2_ptr as *mut _ as *mut c_void,
+            &mut score_ptr as *mut _ as *mut c_void,
+            &mut nh as *mut _ as *mut c_void,
+            &mut nkv as *mut _ as *mut c_void,
+            &mut hd as *mut _ as *mut c_void,
+            &mut nr as *mut _ as *mut c_void,
+            &mut th as *mut _ as *mut c_void,
+            &mut pq as *mut _ as *mut c_void,
+            &mut sl as *mut _ as *mut c_void,
+            &mut kb as *mut _ as *mut c_void,
+        ];
+        unsafe {
+            self.hip.launch_kernel(
+                func,
+                [seq_len as u32, n_heads as u32, 1],
+                [32, 1, 1],
+                0,
+                self.stream_ref(),
+                &mut params,
+            )
+        }
+    }
+
     /// TriAttention importance scoring over an asym2 post-RoPE K cache.
     /// Same shape as `triattn_score_asym3` but reads the 2-bit packed
     /// layout (4 indices per byte) and the TURBO_C2_256 codebook.

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -4359,6 +4359,9 @@ pub const TRIATTN_SCORE_ASYM4_SRC: &str =
 /// TriAttention scoring on asym2 (Givens-rotated 2-bit) K cache.
 pub const TRIATTN_SCORE_ASYM2_SRC: &str =
     include_str!("../../../kernels/src/triattn_score_asym2.hip");
+/// TriAttention scoring for adaptive signed-FWHT K caches.
+pub const TRIATTN_SCORE_FWHT_SRC: &str =
+    include_str!("../../../kernels/src/triattn_score_fwht.hip");
 
 /// Gather-based compaction for KV eviction: copy `budget` src rows to dst.
 pub const KV_COMPACT_GATHER_SRC: &str = include_str!("../../../kernels/src/kv_compact_gather.hip");

--- a/kernels/src/triattn_score_fwht.hip
+++ b/kernels/src/triattn_score_fwht.hip
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+// TriAttention scoring for adaptive FWHT{2,3,4} post-RoPE K caches.
+// The packed rows share storage with asym{2,3,4}, but require an inverse
+// signed FWHT before their complex bands can be used by TriAttention.
+//
+// Grid: [seq_len, n_heads, 1]. Block: [32, 1, 1]. head_dim must be 256.
+#include <hip/hip_runtime.h>
+#include "turbo_common.h"
+
+__device__ __forceinline__ void triattn_fwht_band(
+    float re,
+    float im,
+    const float* __restrict__ center,
+    int band,
+    int n_rot_bands,
+    int n_rot,
+    float rope_theta,
+    float p_q,
+    float& s_trig,
+    float& s_norm
+) {
+    const float k_mag = sqrtf(re * re + im * im);
+    const float k_phase = atan2f(im, re);
+    const float c_re = center[0];
+    const float c_im = center[1];
+    const float c_abs = center[2];
+    const float c_mag = sqrtf(c_re * c_re + c_im * c_im);
+    const float c_phase = atan2f(c_im, c_re);
+
+    float omega = 0.0f;
+    if (band < n_rot_bands) {
+        const float exponent = -2.0f * (float)band / (float)n_rot;
+        omega = expf(exponent * logf(rope_theta));
+    }
+    s_trig += c_mag * k_mag * cosf(omega * p_q + c_phase - k_phase);
+    float r = (c_abs > 1e-20f) ? (c_mag / c_abs) : 0.0f;
+    if (r > 1.0f) r = 1.0f;
+    s_norm += (1.0f - r) * c_abs * k_mag;
+}
+
+extern "C" __launch_bounds__(32, 16)
+__global__ void triattn_score_fwht(
+    const unsigned char* __restrict__ k_cache,
+    const float* __restrict__ centers,
+    const float* __restrict__ signs1,
+    const float* __restrict__ signs2,
+    float* __restrict__ scores,
+    int n_heads,
+    int n_kv_heads,
+    int head_dim,
+    int n_rot,
+    float rope_theta,
+    float p_q,
+    int seq_len,
+    int bits
+) {
+    const int pos = blockIdx.x;
+    const int h = blockIdx.y;
+    if (pos >= seq_len || h >= n_heads || head_dim != 256) return;
+    const int tid = threadIdx.x;
+    const int kv_group = n_heads / n_kv_heads;
+    const int kv_h = h / kv_group;
+    const int n_bands = head_dim / 2;
+    const int n_rot_bands = n_rot / 2;
+    const int bytes_per_head = 4 + (head_dim * bits) / 8;
+    const int bytes_per_pos = n_kv_heads * bytes_per_head;
+    const unsigned char* row =
+        k_cache + (size_t)pos * bytes_per_pos + kv_h * bytes_per_head;
+    const float cnorm = *(const float*)row;
+    const float* c_head = centers + h * n_bands * 3;
+
+    float s_trig = 0.0f;
+    float s_norm = 0.0f;
+    if (bits == 3) {
+        const unsigned char* packed_base = row + 4 + tid * 3;
+        const unsigned int packed = (unsigned int)packed_base[0]
+            | ((unsigned int)packed_base[1] << 8)
+            | ((unsigned int)packed_base[2] << 16);
+        float v0 = cnorm * TURBO_C3_256[(packed      ) & 7];
+        float v1 = cnorm * TURBO_C3_256[(packed >>  3) & 7];
+        float v2 = cnorm * TURBO_C3_256[(packed >>  6) & 7];
+        float v3 = cnorm * TURBO_C3_256[(packed >>  9) & 7];
+        float v4 = cnorm * TURBO_C3_256[(packed >> 12) & 7];
+        float v5 = cnorm * TURBO_C3_256[(packed >> 15) & 7];
+        float v6 = cnorm * TURBO_C3_256[(packed >> 18) & 7];
+        float v7 = cnorm * TURBO_C3_256[(packed >> 21) & 7];
+        fwht_shfl_inverse_256(
+            v0, v1, v2, v3, v4, v5, v6, v7, signs1, signs2, tid);
+        const float vals[8] = {v0, v1, v2, v3, v4, v5, v6, v7};
+        #pragma unroll
+        for (int pair = 0; pair < 4; ++pair) {
+            const int band = tid * 4 + pair;
+            triattn_fwht_band(
+                vals[pair * 2], vals[pair * 2 + 1], c_head + band * 3,
+                band, n_rot_bands, n_rot, rope_theta, p_q, s_trig, s_norm);
+        }
+    } else {
+        // FWHT2/FWHT4 use two independent 128-wide transforms. Each lane owns
+        // four consecutive values (two complex bands) in each half.
+        const int bytes_per_lane = bits / 2;
+        const int bytes_per_half = 128 * bits / 8;
+        #pragma unroll
+        for (int half = 0; half < 2; ++half) {
+            const unsigned char* packed_base =
+                row + 4 + half * bytes_per_half + tid * bytes_per_lane;
+            unsigned int packed = (unsigned int)packed_base[0];
+            if (bits == 4) packed |= ((unsigned int)packed_base[1] << 8);
+            float v0, v1, v2, v3;
+            if (bits == 2) {
+                v0 = cnorm * TURBO_C2[(packed      ) & 3];
+                v1 = cnorm * TURBO_C2[(packed >>  2) & 3];
+                v2 = cnorm * TURBO_C2[(packed >>  4) & 3];
+                v3 = cnorm * TURBO_C2[(packed >>  6) & 3];
+            } else {
+                v0 = cnorm * TURBO_C4[(packed      ) & 15];
+                v1 = cnorm * TURBO_C4[(packed >>  4) & 15];
+                v2 = cnorm * TURBO_C4[(packed >>  8) & 15];
+                v3 = cnorm * TURBO_C4[(packed >> 12) & 15];
+            }
+            fwht_shfl_inverse(v0, v1, v2, v3, signs1, signs2, tid);
+            const int band0 = half * 64 + tid * 2;
+            triattn_fwht_band(
+                v0, v1, c_head + band0 * 3, band0, n_rot_bands, n_rot,
+                rope_theta, p_q, s_trig, s_norm);
+            triattn_fwht_band(
+                v2, v3, c_head + (band0 + 1) * 3, band0 + 1,
+                n_rot_bands, n_rot, rope_theta, p_q, s_trig, s_norm);
+        }
+    }
+
+    for (int off = 16; off > 0; off >>= 1) {
+        s_trig += __shfl_xor(s_trig, off);
+        s_norm += __shfl_xor(s_norm, off);
+    }
+    if (tid == 0) scores[(size_t)h * seq_len + pos] = s_trig + s_norm;
+}


### PR DESCRIPTION
## Summary

Allow Qwen3.5 CASK/TriAttention eviction to operate on bounded VMM KV caches, and add a one-way adaptive-KV -> TriAttention handoff after the cache reaches its configured floor tier.

This also fixes a correctness bug where AR HipGraph/retained replay captured before KV compaction continued using physical RoPE positions after `compact_offset` became non-zero, causing repetitive decode output.

## What changed

- Derive a bounded physical VMM capacity from the CASK `budget + beta` window.
- Validate eviction-compatible VMM layouts and mapped capacity before score/gather dispatches.
- Support a staged adaptive-KV handoff:
  - adaptive KV owns the cache before `cask_handoff_tokens`;
  - all required K/V downshifts complete at the handoff boundary;
  - TriAttention eviction becomes active only after the handoff;
  - long prefill is chunked at committed boundaries so adaptive transitions happen before the next VMM write can exceed the current tier capacity.
- Add FWHT KV TriAttention scoring and a GPU parity example.
- Make AR HipGraph and retained replay ineligible after KV compaction. Captured routes currently have no dynamic `compact_offset` input, so decode uses eager execution after the first eviction. Graph/replay remains available before compaction.

CASK m-folding and generic speculative decode retain their existing compatibility restrictions. This PR does not combine adaptive KV with DFlash/DSpark.

## Which crate(s) does this touch?

- [x] `kernels/` (HIP source)
- [x] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [x] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [x] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy`
- [ ] `crates/hipfire-quantize`
- [x] examples / daemon
- [ ] docs / CI / scripts

The diff also touches `hipfire-cli`, `hipfire-config`, and `hipfire-loader` to carry the handoff configuration through the typed load path.

## Correctness diagnosis

The original 8K and 16K LongBench runs produced repetitive output. Larger-capacity and mechanism-isolation tests showed that this was not ordinary context loss:

1. `budget=30000`, `beta=128` evicted only 256 of 30,228 prompt tokens, but both gfx1100 and gfx1201 still entered repetition.
2. Moving to a recent-only retention policy and bypassing TriAttention scoring did not change the failure.
3. All six FullAttention layers were checked around the first compaction; the retained K/V source ranges and copied-back prefixes were byte-exact.
4. `budget=32640`, `beta=128` performed the same adaptive handoff but no eviction, and produced coherent output.
5. Disabling only AR graph with `HIPFIRE_AR_GRAPH=0` restored coherent output on both machines.
6. With the eligibility fix applied and AR graph left at its normal default, both machines produced byte-identical output to their explicit `HIPFIRE_AR_GRAPH=0` arm.

The failure was therefore stale captured position semantics after `compact_offset` changed, not score selection, VMM mapping, or KV gather corruption.

## Long-context validation with Qwen3.5 0.8B

Dataset: LongBench-v2 hard30, 30 prompts, raw prompt length 20,400-30,216 tokens. Configuration: `max_seq=32768`, adaptive VMM -> FWHT3/Lloyd3 -> TriAttention, FP32 recurrent state, DFlash/MTP disabled.

Fixed `budget=16384`, `beta=128`, `handoff_tokens=8192` results:

| Machine | Completed | Runtime errors | Parseable choices | Correct | Median prefill | Median decode |
|---|---:|---:|---:|---:|---:|---:|
| gfx1100 GPU1 | 30/30 | 0 | 24/30 | 6/30 | 2417.6 tok/s | 233.8 tok/s |
| gfx1201 R9700 | 30/30 | 0 | 23/30 | 11/30 | 2462.9 tok/s | 259.05 tok/s |

Before the graph/replay fix, the same 16K configuration produced only 3/30 parseable choices on each machine and predominantly repetitive output. These accuracy counts are supplementary coherence evidence, not a claim that 16K eviction is quality-neutral.

Additional boundary tests:

- `budget=32640`, `beta=128`: zero evictions for the 30,228-token case; coherent output on both machines.
- `budget=30000`, `beta=128`: two evictions; coherent output after the fix on both machines.

## Qwen3.5-27B long-context validation

I also ran the same cross-architecture LongBench-v2 validation with `qwen3.5-27b.mq4`.

### Configuration

- Dataset: official LongBench-v2 `hard30` subset, 30 prompts
- Raw prompt length: 20,400–30,216 tokens (20,412–30,228 measured prefill tokens after wrapping)
- Model: `qwen3.5-27b.mq4`
- `max_seq=32768`
- Adaptive VMM -> FWHT3/Lloyd3 -> TriAttention
- CASK budget: 16,384 tokens
- CASK beta: 128
- Adaptive-to-CASK handoff: 8,192 tokens
- KV mode/backend: `q8` / `vmm`
- Recurrent state: FP32
- DFlash and MTP: disabled
- Generation: greedy, 64 output tokens, closed-think prefix
- TP/PP: 1/1

Reproducibility hashes:

```text
model sha256:    ea615949ddf6a180eee03ff6fde39f7e51148f153b1b05f82258b9953088576e
sidecar sha256:  f8ccb3aaeb03f9e791160c60daa07a28833af466afd0761405b458c6e890748b
dataset sha256:  839a19be0b3b1c801a0ca58d388996faff34704e34dd196d54346adf17a1dce9
manifest sha256: 3c44b96ceb15b27a8a50be07fce48fea9933a823cbaee7ba487bf33ea70e42a4
```

### Results

| Machine | Completed | Runtime errors | Parseable choices | Correct | Median prefill | Median decode |
|---|---:|---:|---:|---:|---:|---:|
| gfx1100 GPU1 (W7900) | 30/30 | 0 | 24/30 | 9/30 | 252.1 tok/s | 26.1 tok/s |
| gfx1201 (Radeon AI PRO R9700) | 30/30 | 0 | 22/30 | 8/30 | 260.8 tok/s | 26.2 tok/s |

Both devices completed every 20K–30K-token request without an OOM, daemon failure, or request-level runtime error. The staged adaptive-VMM/CASK path therefore exercised compaction and eviction successfully across all 30 long-context requests on both gfx1100 and gfx1201.

The R9700 had two cold-start outliers near the beginning of the run (`159.4` and `109.5` prefill tok/s, with one `4.7` decode tok/s sample). Subsequent requests stabilized at approximately `248–289` prefill tok/s. The table reports the full-run medians without removing those samples.

The answer counts are supplementary coherence evidence only. They show that the model continued to produce parseable, non-repetitive answers after repeated compaction/eviction, but they are not evidence that a 16K retained budget is quality-neutral relative to an unbounded 32K KV cache.

## Test plan

- [ ] `./scripts/no-gpu-ci.sh` passes, or equivalent CI job is green
- [ ] `cargo build --release --workspace --features deltanet` clean
- [ ] `cargo test --lib --workspace --features deltanet` passes
- [x] Change-gate run and telemetry pasted below
- [ ] If perf-relevant: speed route within its locked baseline (hardware caveat below)
- [x] Qwen3.5 AR graph eligibility unit test
- [x] Adaptive eviction-prefill handoff contract
- [x] Release daemon build on gfx1100 and gfx1201 hosts
- [x] LongBench-v2 hard30, 30/30 on gfx1100 and gfx1201
- [x] 30K near-lossless compact graph/eager A/B on both machines
- [x] 32K zero-eviction boundary control on both machines

<details><summary>change_gate telemetry</summary>

```text
change_gate: INCOMPLETE
host gfx=gfx1100 rocm=6.19.14
estimated=38.8min actual=1m25.0s

PASS: detect.kernels-channel, unit.arch-qwen35, unit.env-docs,
unit.hipfire-cli, unit.hipfire-config, unit.hipfire-loader,
unit.hipfire-runtime, unit.no-gpu-control, unit.rdna-compute

FAIL / needs follow-up:
- redline.capture: daemon closed during load
- serve batteries: selected route arguments use thinking=med (2048) with
  max_tokens=180/300/500, rejected by harness as guaranteed think-only
- serve.loop.cross-request: validation errors on all requests
- speed.arch-fast: cross-device absolute baseline mismatch; see below
```

</details>

Acknowledged blocked routes:

- `serve.battery.qwen35-a3b-q8-wo`: host is gfx1100; route requires gfx1200/gfx1201.
- `serve.battery.qwen35-9b-mq3`: missing `qwen3.5-9b.mq3`.
- `serve.battery.qwen35-lmhead-awq`: missing `qwen3.5-9b.mq4-awq-gptq-f2-lmhead`.
- `serve.battery.qwen35-mq3-awq`: missing `qwen3.5-4b.mq3-awq-only`.
- `serve.reset.qwen2`: required Qwen2 reset models are absent.

### Speed-gate hardware caveat

`speed.arch-fast` reported:

- 4B MQ4 pp32 prefill: `+30.5%`
- 4B MQ4 decode: `-20.1%`

This result should not be treated as a regression gate conclusion because the locked `gfx1100` baseline was recorded on a different gfx1100 board, reportedly a Radeon RX 7900 XTX. The local gfx1100 device has different memory bandwidth, memory clocks, and board-level limits. The fact that prefill is 30.5% above the locked baseline while decode is below it also argues against interpreting the absolute cross-device comparison as a uniform code regression.

A valid performance verdict requires an alternating `origin/beta` versus this branch A/B on the same GPU and software environment. I would appreciate a rerun on the RX 7900 XTX, or whichever machine produced `tests/speed-baselines/gfx1100.txt`, before treating the reported `-20.1%` decode delta as a merge gate.

## Architecture-trait change?

No. This PR does not change the `Architecture` trait surface.
