### PR TITLE
fix(dflash): free the whole DflashState on teardown and on partial-load failure

### DIFF
--- a/crates/hipfire-arch-qwen35/src/dflash_spec.rs
+++ b/crates/hipfire-arch-qwen35/src/dflash_spec.rs
@@ -54,6 +54,36 @@ pub struct DflashState {
     pub ddtree: Option<DdtreeState>,
 }
 
+impl DflashState {
+    /// Destructured without `..` on purpose: a field added later that owns GPU
+    /// memory becomes a compile error here instead of a per-load leak.
+    pub fn free_gpu(self, gpu: &mut Gpu) {
+        let DflashState {
+            draft_config: _,
+            draft_weights,
+            draft_scratch,
+            hidden_rb,
+            verify_scratch,
+            target_snap,
+            gdn_tape,
+            target_hidden_host: _,
+            ctx_capacity: _,
+            block_size: _,
+            ddtree,
+        } = self;
+        draft_weights.free_gpu(gpu);
+        draft_scratch.free_gpu(gpu);
+        hidden_rb.free_gpu(gpu);
+        verify_scratch.free_gpu(gpu);
+        target_snap.free_gpu(gpu);
+        gdn_tape.free_gpu(gpu);
+        if let Some(dd) = ddtree {
+            dd.post_seed_snap.free_gpu(gpu);
+            dd.scratch.free_gpu(gpu);
+        }
+    }
+}
+
 // ─── DFlash state load ────────────────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
@@ -172,8 +202,26 @@ pub fn load_dflash_state(
             requested_ctx, ctx_capacity
         );
     }
-    let draft_weights =
-        DflashWeights::load(gpu, &draft_hfq, &draft_config).map_err(|e| format!("{e}"))?;
+    // Every step below owns GPU memory the later ones need. A bare `?` drops
+    // those without freeing (no `Drop` on the GPU-owning types), so a failed
+    // DFlash load stays resident and the AR fallback it announces then OOMs.
+    macro_rules! or_free {
+        ($e:expr, $ctx:expr $(, $owned:expr)* $(,)?) => {
+            match $e {
+                Ok(v) => v,
+                Err(e) => {
+                    $($owned.free_gpu(gpu);)*
+                    let ctx: &str = $ctx;
+                    return Err(if ctx.is_empty() {
+                        format!("{e}")
+                    } else {
+                        format!("{ctx}: {e}")
+                    });
+                }
+            }
+        };
+    }
+    let draft_weights = or_free!(DflashWeights::load(gpu, &draft_hfq, &draft_config), "");
     let block_size = draft_config.block_size;
     // DDTree verify batches up to `budget + 1` slots (seed + budget nodes), which
     // can exceed the chain block_size+1. Size verify_scratch / GdnTape / hidden
@@ -189,33 +237,36 @@ pub fn load_dflash_state(
     // `gemm_dispatch` requires for MQ4/MQ3/MQ6 draft weights. The carrier
     // refactor regressed this to the `with_mq=false` `::new` constructor →
     // panic "MQ4 dispatch requires mq_x_rot scratch" on any MQ-quantized draft.
-    let draft_scratch = match window {
-        Some(w) => DflashScratch::new_windowed(
-            gpu,
-            &draft_config,
-            block_size,
-            w,
-            // w_full UNBOUNDED: the last (full-attention) layer's ring spans
-            // the whole supported context, matching the artifact's
-            // `layer_types: [sliding x(n-1), full_attention]` semantics — the
-            // NInfer reference keeps one layer genuinely unbounded. The prior
-            // `requested_ctx.min(4 * w)` made the "full" layer a 4W-window
-            // (8192 rows at W=2048), so past 8K NO layer had full reach.
-            // Ring VRAM scales with requested_ctx (~270 MB at 32K rows,
-            // kvd=1024, f32 — see DflashScratch::new_windowed docs).
-            requested_ctx,
-            requested_ctx,
-            draft_weights.has_mq,
-        ),
-        None => DflashScratch::new_with_mq(
-            gpu,
-            &draft_config,
-            block_size,
-            ctx_capacity,
-            draft_weights.has_mq,
-        ),
-    }
-    .map_err(|e| format!("{e}"))?;
+    let draft_scratch = or_free!(
+        match window {
+            Some(w) => DflashScratch::new_windowed(
+                gpu,
+                &draft_config,
+                block_size,
+                w,
+                // w_full UNBOUNDED: the last (full-attention) layer's ring spans
+                // the whole supported context, matching the artifact's
+                // `layer_types: [sliding x(n-1), full_attention]` semantics — the
+                // NInfer reference keeps one layer genuinely unbounded. The prior
+                // `requested_ctx.min(4 * w)` made the "full" layer a 4W-window
+                // (8192 rows at W=2048), so past 8K NO layer had full reach.
+                // Ring VRAM scales with requested_ctx (~270 MB at 32K rows,
+                // kvd=1024, f32 — see DflashScratch::new_windowed docs).
+                requested_ctx,
+                requested_ctx,
+                draft_weights.has_mq,
+            ),
+            None => DflashScratch::new_with_mq(
+                gpu,
+                &draft_config,
+                block_size,
+                ctx_capacity,
+                draft_weights.has_mq,
+            ),
+        },
+        "",
+        draft_weights,
+    );
     let _ = draft_hfq;
     // The hidden-ring STAGING buffers must hold one prefill chunk. Verify
     // cycles seed only `max_n` (= block_size+1) rows, but the prompt seed
@@ -226,37 +277,76 @@ pub fn load_dflash_state(
     // copy on any prompt longer than block_size+1 tokens. Size it to the
     // larger of the two so both paths fit.
     let staging_max_batch = max_n.max(qwen35::PREFILL_MAX_BATCH);
-    let hidden_rb = HiddenStateRingBuffer::new(
-        gpu,
-        target_config.n_layers,
-        draft_config.num_extract(),
-        target_config.dim,
-        ctx_capacity,
-        staging_max_batch,
-    )
-    .map_err(|e| format!("HiddenStateRingBuffer::new: {e}"))?;
+    let hidden_rb = or_free!(
+        HiddenStateRingBuffer::new(
+            gpu,
+            target_config.n_layers,
+            draft_config.num_extract(),
+            target_config.dim,
+            ctx_capacity,
+            staging_max_batch,
+        ),
+        "HiddenStateRingBuffer::new",
+        draft_scratch,
+        draft_weights,
+    );
     let hidden_k = target_config.dim.next_power_of_two();
-    let verify_scratch = VerifyScratch::with_prefill(
-        gpu,
-        max_n,
-        target_config.dim,
-        target_config.vocab_size,
-        hidden_k,
-        target_config,
-    )
-    .map_err(|e| format!("VerifyScratch::with_prefill: {e}"))?;
-    let target_snap = DeltaNetSnapshot::new_for(gpu, target_dn)
-        .map_err(|e| format!("DeltaNetSnapshot::new_for: {e}"))?;
-    let gdn_tape = GdnTape::new_for_config(gpu, target_config, max_n)
-        .map_err(|e| format!("GdnTape::new_for_config: {e}"))?;
+    let verify_scratch = or_free!(
+        VerifyScratch::with_prefill(
+            gpu,
+            max_n,
+            target_config.dim,
+            target_config.vocab_size,
+            hidden_k,
+            target_config,
+        ),
+        "VerifyScratch::with_prefill",
+        hidden_rb,
+        draft_scratch,
+        draft_weights,
+    );
+    let target_snap = or_free!(
+        DeltaNetSnapshot::new_for(gpu, target_dn),
+        "DeltaNetSnapshot::new_for",
+        verify_scratch,
+        hidden_rb,
+        draft_scratch,
+        draft_weights,
+    );
+    let gdn_tape = or_free!(
+        GdnTape::new_for_config(gpu, target_config, max_n),
+        "GdnTape::new_for_config",
+        target_snap,
+        verify_scratch,
+        hidden_rb,
+        draft_scratch,
+        draft_weights,
+    );
     let target_hidden_host = vec![0.0f32; ctx_capacity * target_config.dim];
     // DDTree (budget read once above, used for scratch sizing).
     let ddtree = if ddtree_budget > 0 {
         let topk: usize = gpu.flags.ddtree_topk.or(ddtree_topk_param).unwrap_or(4);
-        let post_seed_snap =
-            DeltaNetSnapshot::new_for(gpu, target_dn).map_err(|e| format!("{e}"))?;
-        let scratch = DdtreeScratch::new(gpu, ddtree_budget)
-            .map_err(|e| format!("DdtreeScratch::new: {e}"))?;
+        let post_seed_snap = or_free!(
+            DeltaNetSnapshot::new_for(gpu, target_dn),
+            "",
+            gdn_tape,
+            target_snap,
+            verify_scratch,
+            hidden_rb,
+            draft_scratch,
+            draft_weights,
+        );
+        let scratch = or_free!(
+            DdtreeScratch::new(gpu, ddtree_budget),
+            "DdtreeScratch::new",
+            post_seed_snap,
+            gdn_tape,
+            target_snap,
+            verify_scratch,
+            hidden_rb,
+            draft_scratch,
+            draft_weights,
+        );
         Some(DdtreeState {
             post_seed_snap,
             scratch,
@@ -818,12 +908,10 @@ impl Speculator for DflashSpeculator {
     }
 
     fn free(self: Box<Self>, gpu: &mut Gpu) {
-        // Mirrors the `unload_model` dflash teardown + the checkpoint-ring free.
         let DflashSpeculator {
             df, checkpoints, ..
         } = *self;
-        df.draft_weights.free_gpu(gpu);
-        df.draft_scratch.free_gpu(gpu);
+        df.free_gpu(gpu);
         for (_, snap) in checkpoints {
             snap.free_gpu(gpu);
         }

--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -1591,6 +1591,15 @@ impl HiddenStateRingBuffer {
         })
     }
 
+    pub fn free_gpu(self, gpu: &mut Gpu) {
+        for t in self.layer_bufs {
+            let _ = gpu.free_tensor(t);
+        }
+        for t in self.staging_bufs {
+            let _ = gpu.free_tensor(t);
+        }
+    }
+
     /// If `target_layer_idx` matches one of the extraction layers, return the
     /// index into `layer_bufs`/`extract_layers` for that layer. Otherwise None.
     #[inline]


### PR DESCRIPTION
## Summary

`DflashState` owns eight GPU allocations; teardown freed two of them, and a failed load freed none. This frees all of them, in both paths.

### Teardown was incomplete

`DflashSpeculator::free` freed `draft_weights` and `draft_scratch` and dropped the rest:

```rust
let DflashSpeculator { df, checkpoints, .. } = *self;
df.draft_weights.free_gpu(gpu);
df.draft_scratch.free_gpu(gpu);
```

Leaked on every load/unload cycle: `hidden_rb`, `verify_scratch`, `target_snap`, `gdn_tape`, and both GPU fields of `ddtree`. `HiddenStateRingBuffer` had no `free_gpu` at all, so its buffers could not be released even by a caller who wanted to — and they are not small: `ctx_capacity × dim × 4 bytes × num_extract`, which for a 27B target with a 5-layer-extract draft is ~3.4 GB at 32K rows before the windowed cap applies.

The comment above that code read *"a drafter that forgets is a compile error, not a silent VRAM leak"*, but nothing enforced it: `..` in the destructuring suppresses the check, and `df` moves in whole and drops without freeing (no `Drop` on the GPU-owning types — the umbrella pattern tracked in #217).

### Partial loads leaked everything

`load_dflash_state` performs eight fallible GPU allocations in sequence, each with `?`. Any failure dropped every previously-allocated one without freeing, so a drafter that fails halfway leaves its memory resident for whatever runs next — including the AR fallback the caller announces.

## What changed

- `HiddenStateRingBuffer::free_gpu` — new; frees `layer_bufs` + `staging_bufs`.
- `DflashState::free_gpu` — new; destructured **without `..`**, so a future GPU-owning field is a compile error here rather than a per-load leak. This is what the old comment promised.
- `DflashSpeculator::free` now delegates to `df.free_gpu(gpu)` instead of hand-picking two fields.
- `load_dflash_state` uses a local `or_free!` macro (same shape as the `alloc!` ledger in `qwen35.rs`) to release everything already held when a later allocation fails. Error strings are unchanged byte-for-byte, and the windowed-vs-Legacy `draft_scratch` selection is untouched — the macro wraps the existing `match window { … }` whole.

No behaviour change on a successful load: the same allocations happen in the same order, and the speculator is built from the same state.

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [ ] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [x] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template — touch only when refining the new-arch reference)
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [ ] docs / CI / scripts

## Test plan

- [x] `./scripts/no-gpu-ci.sh` passes, or equivalent CI job is green
- [x] `cargo build --release --workspace --all-targets --locked` clean
- [x] `cargo test --lib -p hipfire-arch-qwen35` — 177 passed, 0 failed
- [x] **Change gate run and telemetry pasted below.**
- [x] Live DFlash serve unaffected: gfx1100, Qwen3.6-27B `mq4` + `qwen36-27b-dflash-mq4.hfq`, `max_seq 32768`, KV q8 — draft loads windowed (`SWA W=2048`, `layers=5, hidden=5120, block=16`) and serves at `tau=4.26`, 64.9 tok/s decode, 21.5 GB resident.

There is no unit test for the failure path: reproducing it needs a real `hipMalloc` failure mid-load, which the no-GPU CI cannot stage. The `free_gpu` destructuring is the enforceable part — the compiler checks it.

<details><summary>change_gate telemetry</summary>

```
**change_gate: INCOMPLETE**

host gfx=`gfx1100` rocm=`6.18.37` · `e2f7dd1a`..`acc1bb52` · est=9.5min actual=16.8s

### Routes RUN
| route                   | status | duration |
| ----------------------- | ------ | -------- |
| serve.battery.qwen35-4b | fail   | 0.1s     |
| serve.battery.qwen35-9b | fail   | 0.0s     |
| speed.arch-fast         | pass   | 15.7s    |
| unit.arch-qwen35        | pass   | 1.1s     |

### Routes NOT RUN
| route                           | reason                                                                      |
| ------------------------------- | --------------------------------------------------------------------------- |
| serve.battery.qwen35-lmhead-awq | blocked_model: missing model(s): qwen3.5-9b.mq4-awq-gptq-f2-lmhead          |
| serve.dflash.qwen35-27b-fast    | blocked_model: missing model(s): qwen3.5-27b.mq4, qwen35-27b-dflash-mq4.hfq |
| serve.loop.cross-request        | blocked_model: missing model(s): qwen3.5-0.8b.mq4                           |
```

</details>

**Acknowledged, per the template's requirement that blocked routes not be ignored:**

- Three routes are `blocked_model` on this host — `qwen3.5-27b.mq4` + its DFlash draft, `qwen3.5-0.8b.mq4`, and the AWQ-lmhead 9B variant are not present. `serve.dflash.qwen35-27b-fast` is the one that would exercise this diff's surface most directly; I covered the equivalent manually on qwen3.6-27B (see the live-serve line above), but that is not the same artifact the route pins. The gate verdict is therefore `incomplete`, not a pass.
- `serve.battery.qwen35-4b` / `-9b` fail identically on unmodified `beta`: `routes.py` specifies `_serve(max_tokens=180)` / `_serve(max_tokens=300)` while `_serve` defaults to `thinking="med"` (2048-token budget), and `serve_harness.py` hard-fails that combination in pre-flight after 0.06 s ("max_tokens (180) <= thinking budget 'med' … guarantees think-only output"). Not caused by this diff; happy to file separately if not already known.

## Architecture-trait change?

No. `Speculator::free` keeps its signature; only its body changes.

## Related

- #217 — umbrella for GPU-owning structs that leak without `Drop`. This is one instance, fixed by making the omission a compile error rather than by adding `Drop`.
