### PR TITLE
fix(grammar): stop masking free text on a partial <tool_call> prefix

### DIFF
--- a/crates/hipfire-arch-qwen35/src/grammar.rs
+++ b/crates/hipfire-arch-qwen35/src/grammar.rs
@@ -576,7 +576,9 @@ impl Matcher {
     ///      enforce the per-token check.
     pub fn is_free(&self) -> bool {
         match self.state {
-            State::Out => !Self::has_open_prefix(&self.partial_buf),
+            // Masking on a partial `<tool_call>` prefix strands free text: a
+            // bare `<` (`<ip>`, `<p>`, `2 < 3`) leaves only `t`/`to`… legal.
+            State::Out => true,
             State::AfterOpen => false,
             State::InArgs => {
                 if self.attractor_detected {
@@ -598,18 +600,6 @@ impl Matcher {
                 !Self::has_close_prefix(&self.partial_buf)
             }
         }
-    }
-
-    /// Does the buffer end with a strict prefix of `<tool_call>` (so a
-    /// follow-up token could complete the open)?
-    fn has_open_prefix(s: &str) -> bool {
-        const OPEN: &str = "<tool_call>";
-        for n in 1..=OPEN.len() {
-            if s.ends_with(&OPEN[..n]) {
-                return true;
-            }
-        }
-        false
     }
 
     /// Does the buffer end with a strict prefix of `</tool_call>`?
@@ -1503,7 +1493,7 @@ mod tests {
         assert!(m.is_token_allowed("<tool"));
         m.advance("<tool");
         assert!(matches!(m.state(), State::Out));
-        assert!(!m.is_free(), "matcher must be constraining mid-marker");
+        assert!(m.is_free(), "a partial marker must not constrain free text");
         assert!(m.is_token_allowed("_call>"));
         m.advance("_call>");
         assert!(matches!(m.state(), State::AfterOpen));
@@ -1695,6 +1685,24 @@ mod tests {
         }
         assert!(matches!(m.state(), State::Out));
         assert!(m.is_free());
+    }
+
+    #[test]
+    fn free_text_angle_bracket_does_not_arm_the_mask() {
+        let mut m = Matcher::new(schemas(&["bash"]));
+        m.advance("HTML: ");
+        assert!(m.is_free());
+
+        m.advance("<");
+        assert!(m.is_free(), "a bare '<' must not constrain the sampler");
+        m.advance("p>hi</p>");
+        assert!(m.is_free());
+
+        m.advance(" and 2 < 3, table: <t");
+        assert!(m.is_free(), "'<t' must not constrain the sampler");
+        m.advance("able><tr></tr></table>");
+        assert!(m.is_free());
+        assert!(matches!(m.state(), State::Out));
     }
 
     #[test]

--- a/crates/hipfire-arch-qwen35/src/grammar.rs
+++ b/crates/hipfire-arch-qwen35/src/grammar.rs
@@ -2537,4 +2537,200 @@ mod tests {
             pick, vocab[pick]
         );
     }
+
+    // ─── PR #567 regression: free text must not arm the <tool_call> mask ──
+    //
+    // Defect: Matcher::is_free() returned false for State::Out whenever the
+    // buffer ended with any prefix of "<tool_call>" (starting at a bare "<").
+    // The sampler then masked free text to only tokens continuing the marker,
+    // stranding prose like "<p>hi</p>", "2 < 3", or even "</think>".
+    // Fix: State::Out is unconditionally free; masking engages only after a
+    // full "<tool_call>" lands (transition to AfterOpen).
+
+    #[test]
+    fn pr567_genuine_tool_call_still_constrains() {
+        // No regression: a real <tool_call> must still arm the grammar.
+        let mut m = Matcher::new(schemas(&["bash"]));
+        m.advance("<tool_call>");
+        assert!(matches!(m.state(), State::AfterOpen));
+        assert!(!m.is_free(), "full <tool_call> must constrain");
+        assert!(!m.is_token_allowed("<|im_start|>"));
+        assert!(m.is_token_allowed("\n"));
+        assert!(m.is_token_allowed("\n{\"name\": \"bash\""));
+        let vocab = vec![
+            "<|im_start|>".to_string(),
+            "\n".to_string(),
+            "hello".to_string(),
+        ];
+        let mut mask = vec![false; vocab.len()];
+        m.token_mask(&vocab, &mut mask);
+        assert!(!mask[0], "attractor must be blocked after genuine open");
+        assert!(mask[1], "header prefix must be allowed");
+        assert!(!mask[2], "free prose must be blocked in AfterOpen");
+    }
+
+    #[test]
+    fn pr567_partial_prefixes_do_not_arm_mask() {
+        // Every strict prefix of "<tool_call>" must leave the sampler free.
+        let prefixes = [
+            "<",
+            "<t",
+            "<to",
+            "<too",
+            "<tool",
+            "<tool_",
+            "<tool_c",
+            "<tool_ca",
+            "<tool_cal",
+            "<tool_call",
+        ];
+        for prefix in prefixes {
+            let mut m = Matcher::new(schemas(&["bash"]));
+            m.advance(&format!("hello {}", prefix));
+            assert!(
+                m.is_free(),
+                "prefix {:?} must not arm mask; partial={:?}",
+                prefix,
+                m.partial()
+            );
+            assert!(matches!(m.state(), State::Out));
+            for tok in ["p>", "table>", " ", " hello", " 3", "</think>", ">"] {
+                assert!(
+                    m.is_token_allowed(tok),
+                    "prefix {:?} must allow token {:?}",
+                    prefix, tok
+                );
+            }
+            let vocab = vec![
+                "p>".to_string(),
+                "table>".to_string(),
+                "</think>".to_string(),
+                "<".to_string(),
+                "hello".to_string(),
+            ];
+            let mut mask = vec![false; vocab.len()];
+            m.token_mask(&vocab, &mut mask);
+            assert!(
+                mask.iter().all(|&b| b),
+                "prefix {:?} must leave token_mask all-true",
+                prefix
+            );
+        }
+        // Bare prefix at buffer start is also free.
+        let mut m = Matcher::new(schemas(&["bash"]));
+        m.advance("<");
+        assert!(m.is_free(), "bare '<' must be free");
+        assert!(m.is_token_allowed("p>"));
+        assert!(m.is_token_allowed("</think>"));
+    }
+
+    #[test]
+    fn pr567_false_start_diverging_is_not_masked() {
+        // A buffer that looked like a prefix then diverged must stay free.
+        let mut m = Matcher::new(schemas(&["bash"]));
+        m.advance("<tool");
+        assert!(m.is_free());
+        assert!(m.is_token_allowed("box>"), "<tool + box> diverges from marker");
+        m.advance("box>");
+        assert!(m.is_free());
+        assert!(matches!(m.state(), State::Out));
+
+        let mut m = Matcher::new(schemas(&["bash"]));
+        m.advance("<tool_cal");
+        assert!(m.is_free());
+        assert!(m.is_token_allowed("X"), "<tool_cal + X diverges");
+        assert!(m.is_token_allowed("x>"));
+
+        let mut m = Matcher::new(schemas(&["bash"]));
+        m.advance("<tool_call");
+        assert!(m.is_free());
+        assert!(m.is_token_allowed("X"), "<tool_call + X is not the marker");
+        assert!(m.is_token_allowed(" extra"));
+
+        // Whole false markers in one advance must not transition.
+        for txt in ["prefix <toolbox> suffix", "<tool_calX", "<tool-call>", "<tool_callX"] {
+            let mut m = Matcher::new(schemas(&["bash"]));
+            m.advance(txt);
+            assert!(
+                matches!(m.state(), State::Out),
+                "{:?} must not transition to AfterOpen",
+                txt
+            );
+            assert!(m.is_free(), "{:?} must be free", txt);
+        }
+    }
+
+    #[test]
+    fn pr567_partial_prefix_at_eos_stays_free() {
+        // Partial prefix at end-of-stream: next sampler step must be unconstrained.
+        let mut m = Matcher::new(schemas(&["bash"]));
+        m.advance("2 <");
+        assert!(m.is_free(), "'2 <' at EOS must be free");
+        for tok in [" 3", ">", " p>", "</think>", " hello", "\n"] {
+            assert!(m.is_token_allowed(tok), "'2 <' must allow {:?}", tok);
+        }
+        let vocab = vec![
+            " 3".to_string(),
+            ">".to_string(),
+            " p>".to_string(),
+            "</think>".to_string(),
+            "<".to_string(),
+        ];
+        let mut mask = vec![false; vocab.len()];
+        m.token_mask(&vocab, &mut mask);
+        assert!(mask.iter().all(|&b| b), "EOS partial must be all-true mask");
+
+        // Another EOS shape: HTML tag start cut off mid-token.
+        let mut m2 = Matcher::new(schemas(&["bash"]));
+        m2.advance("HTML: <table");
+        assert!(m2.is_free(), "HTML prefix at EOS must be free");
+        assert!(m2.is_token_allowed("><tr>"));
+        assert!(m2.is_token_allowed("</think>"));
+    }
+
+    #[test]
+    fn pr567_prefix_split_across_tokens() {
+        // Free-text prefix split across two token emissions must stay free.
+        let mut m = Matcher::new(schemas(&["bash"]));
+        m.advance("<");
+        assert!(m.is_free(), "'<' split must be free");
+        assert!(m.is_token_allowed("p>"));
+        m.advance("p>");
+        assert!(m.is_free());
+        assert!(matches!(m.state(), State::Out));
+
+        let mut m2 = Matcher::new(schemas(&["bash"]));
+        m2.advance("<tool");
+        assert!(m2.is_free());
+        assert!(m2.is_token_allowed("box>"));
+        m2.advance("box>");
+        assert!(m2.is_free());
+
+        // Genuine marker split across tokens must still transition.
+        let mut m3 = Matcher::new(schemas(&["bash"]));
+        m3.advance("<tool");
+        assert!(m3.is_free(), "partial genuine must be free before completion");
+        assert!(m3.is_token_allowed("_call>"));
+        m3.advance("_call>");
+        assert!(matches!(m3.state(), State::AfterOpen));
+        assert!(!m3.is_free(), "full marker split must constrain");
+
+        // Multi-token free sequence: "2" + " <" + " 3"
+        let mut m4 = Matcher::new(schemas(&["bash"]));
+        m4.advance("2");
+        m4.advance(" <");
+        assert!(m4.is_free(), "'2 <' split must be free");
+        assert!(m4.is_token_allowed(" 3"));
+        assert!(m4.is_token_allowed("</think>"));
+
+        // HTML split: "HTML: " + "<" + "t" + "able>"
+        let mut m5 = Matcher::new(schemas(&["bash"]));
+        m5.advance("HTML: ");
+        m5.advance("<");
+        assert!(m5.is_free());
+        m5.advance("t");
+        assert!(m5.is_free());
+        m5.advance("able>");
+        assert!(m5.is_free());
+    }
 }


### PR DESCRIPTION
## Summary

The tool-call grammar arms its logit mask on a **bare `<`** in free text. From there the sampler cannot emit `p>`, `table>`, or even the `</think>` special token — so a model asked to write `<p>hello</p>`, `2 < 3`, or a tagged entity burns its whole budget without producing an answer.

## The bug

`Matcher::is_free()` reports "not free" whenever the buffer ends with any prefix of the open marker:

```rust
pub fn is_free(&self) -> bool {
    match self.state {
        State::Out => !Self::has_open_prefix(&self.partial_buf),
        ...

fn has_open_prefix(s: &str) -> bool {
    const OPEN: &str = "<tool_call>";
    for n in 1..=OPEN.len() {          // n = 1 → a single '<'
        if s.ends_with(&OPEN[..n]) { return true; }
    }
    false
}
```

The loop starts at `n = 1`, so a bare `<` counts as a prefix of `<tool_call>`. Once armed, `is_token_allowed` in `State::Out` admits a token only if the concatenation contains the full marker or **ends with** one of its prefixes:

```rust
State::Out => Self::tail_matches_marker(&combined, "<tool_call>")
```

From a buffer ending in `<`, exactly two classes survive: tokens continuing the marker (`t`, `to`, …) and tokens themselves ending in `<`. Everything else is set to `-inf`; `token_mask` has no escape hatch when the mask empties the vocabulary.

This also blocks the closing think token. `</think>` is a single special token (id 248069), but from a buffer ending in `<` the concatenation ends in `>` — no marker prefix — so the model cannot close its reasoning span either.

Whether it triggers depends on tokenization, and the trap is not exotic:

```
«<group>webservers</group>»  → 27 3938 29        "<" | "group" | ">"    trapped
«таблица: <table>»           → … 361 1938 29     " <" | "table" | ">"   trapped
«2 < 3»                      → 17 361 220 18     "2" | " <" | …        trapped
«<p>привет</p>»              → 7676 29 …         "<p" as one token     safe
```

## The fix

`State::Out` is unconditionally free. The mask engages only once a complete `<tool_call>` marker has been seen, which `advance()` already tracks — `State::AfterOpen` still returns `false`, so the JSON body stays constrained exactly as before. `has_open_prefix` is removed; nothing else called it.

The existing test `open_marker_split_across_tokens` asserted the old mid-marker behaviour and is inverted accordingly; its remaining assertions (that `<tool` + `_call>` still reaches `AfterOpen`) are the property that matters and are unchanged.

## Scope

Grammar is opt-in on this branch — `qwen35_grammar_on` (`prompt_frame.rs:427`) enables it for `HIPFIRE_QWEN35_GRAMMAR=<anything but 0>` or for model paths containing `carnice`, and defaults to off otherwise. So this does not affect a default qwen3.5/3.6 serve; it affects anyone who turns the grammar on.

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [ ] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [x] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template — touch only when refining the new-arch reference)
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [ ] docs / CI / scripts

## Test plan

- [x] `./scripts/no-gpu-ci.sh` passes, or equivalent CI job is green
- [x] `cargo build --release --workspace --all-targets --locked` clean
- [x] `cargo test --lib -p hipfire-arch-qwen35` — 177 passed, 0 failed (includes the new regression test)
- [x] **Change gate run and telemetry pasted below.**
- [x] A/B on a live model, gfx1100, Qwen3.6-27B `mq4`, ctx 32768, KV q8, `HIPFIRE_QWEN35_GRAMMAR=1`, 5 runs per cell. Same `beta` build in both arms; the only difference is `grammar.rs`.

  | probe (5 runs, tools in request) | before (`f063c2786e39`) | after (`b8e7b15547c6`) |
  |---|---|---|
  | `2 < 3` | 5/5 HTTP 500 | 5/5 ok, `<` emitted 5/5 |
  | one line of HTML | 5/5 HTTP 500 | 5/5 ok, `<` emitted 5/5 |
  | tagged-entity answer | 5/5 HTTP 500 | 5/5 ok, `<` emitted 5/5 |

  Failing runs return:

  ```
  daemon error: [validation retryable=false rolled_back=true attempt=1]
    open think span at end of generation (validation)
  ```

  which is the think-span validator catching what the mask caused — the model cannot emit `</think>` from a buffer ending in `<`.

<details><summary>change_gate telemetry</summary>

```
**change_gate: FAIL**

host gfx=`gfx1100` rocm=`6.18.37` · `e2f7dd1a`..`6eb72e53` · est=12.0min actual=3m01.3s

### Routes RUN
| route                   | status | duration |
| ----------------------- | ------ | -------- |
| serve.agentic.a3b-fast  | fail   | 2m33.2s  |
| serve.battery.qwen35-4b | fail   | 0.1s     |
| serve.battery.qwen35-9b | fail   | 0.1s     |
| speed.arch-fast         | pass   | 18.0s    |
| unit.arch-qwen35        | pass   | 9.9s     |

### Routes NOT RUN
| route | reason |
| ----- | ------ |
| —     | —      |
```

</details>

**All three failing routes fail identically on unmodified `beta`** (same host, same models) and are not caused by this diff:

- `serve.battery.qwen35-4b` / `-9b` cannot pass on any branch. `routes.py` specifies `_serve(max_tokens=180)` / `_serve(max_tokens=300)` while `_serve` defaults to `thinking="med"` (2048-token budget), and `serve_harness.py` hard-fails that combination in pre-flight after 0.06 s:

  ```
  serve_harness: max_tokens (180) <= thinking budget 'med' (2048 tok) guarantees
    think-only output with zero visible answer.
  ```

- `serve.agentic.a3b-fast`: `./scripts/agentic-gate.sh --fast` on a clean `beta` checkout produces the same `HARD FAIL` on the same cell — `3.6_hermes_unclamped`, "zero tokens emitted".

Happy to file those two separately if they are not already known.

## Architecture-trait change?

No.
