### PR TITLE
fix(kernels): barrier before LDS reuse in qwen35_fa_prep

### DIFF
--- a/kernels/src/qwen35_fa_prep.gfx1100.hip
+++ b/kernels/src/qwen35_fa_prep.gfx1100.hip
@@ -64,6 +64,8 @@ __global__ void HIPFIRE_QWEN35_FA_PREP_KERNEL(
     const float rms = rsqrtf(sdata[0] / (float)HD + eps);
     const float normed = v * weight[tid] * rms;
     out[tid] = normed;
+    // Lagging waves still read sdata[0] as the sum of squares; rsqrtf of the negative value written below returns NaN.
+    __syncthreads();
     sdata[tid] = normed;
     __syncthreads();
 


### PR DESCRIPTION
## Summary

Adds the missing `__syncthreads()` between the broadcast read of `sdata[0]` and its reuse for the RoPE stage in `qwen35_fa_prep`. Without it, lagging waves read a signed `normed` value as the sum of squares, `rsqrtf` returns NaN, and the whole layer output — then KV / recurrent state — is poisoned, which surfaces as endless `!!!!` mid-response. Fixes #574.

## Which crate(s) does this touch?

- [x] `kernels/` (HIP source)

The `.gfx1151` variant is the same file included under a different kernel name (`kernels.rs:4124`), so it is covered by the same change.

## Evidence

The race is directly measurable: a sum of squares of finite values cannot be negative, so a negative reduction sum can only come from reading `sdata[0]` after it was overwritten. Kernel-side counters (temporary instrumentation, not part of this PR), qwen3.6-35b-a3b mq4p on gfx1100:

| | without barrier | with barrier |
|---|---:|---:|
| kernel calls | 286,156,800 | 1,022,146,560 |
| negative reduction sum | 640 | 0 |
| NaN arriving as kernel input (follow-on) | 13,824 | 0 |
| NaN in hidden state | yes (layers 7/15/19/23/27/39) | no |

End-to-end: without the barrier a serve run degenerated on the first request; with it, a 40-case suite on a 2-GPU data-parallel setup produced no degeneration at all.

Throughput is unaffected: prefill 2.5k → 1.8k tok/s and decode 210 → 150 tok/s across a 20k-token context, matching pre-fix behaviour.

## Test plan

- [x] `cargo build --release --workspace --all-targets` clean
- [x] `cargo test --release -p rdna-compute --lib compiler::` — 21 passed
- [x] `python3 -m tools.change_gate run --base beta` — run; report below. **Verdict is `fail`, and both failures are independent of this change:**
  - `serve.battery.qwen35-4b` — reproduces on unmodified `beta`. `routes.py` drives the harness with `thinking="med"` (2048-token budget) and `max_tokens=180`, and `serve_harness.py` hard-fails that combination ("max_tokens (180) <= thinking budget 'med' (2048 tok) guarantees think-only output"). The 0.8b / 9b batteries have the same shape (80 / 300 tokens).
  - `redline.capture` — `KeyError: 'redline_capture'`. Redline does not engage on this host: the local toolchain emits compressed `CCOB` offload bundles, which the ROCr loader rejects with `HSA_STATUS_ERROR_INVALID_CODE_OBJECT`, so the runtime fails closed to plain HIP. Unrelated to this kernel; filed as #576.

  Both failures also appear in already-merged PRs on this gate — e.g. #572 reports the same `serve.battery.*` rows as `fail 0.1s` with `verdict=incomplete`.
- [x] `detect.kernels-channel` — pass
- [x] `speed.arch-fast` — pass

<details><summary>change_gate telemetry</summary>

```
**change_gate: FAIL**

host gfx=`gfx1100` rocm=`6.18.37` · e2f7dd1a..60a40ff6 · est=15.5min actual=18.9s

### Routes RUN
| route                   | status | duration |
| ----------------------- | ------ | -------- |
| detect.kernels-channel  | pass   | 0.1s     |
| redline.capture         | fail   | 3.1s     |
| serve.battery.qwen35-4b | fail   | 0.1s     |
| speed.arch-fast         | pass   | 15.7s    |

### Routes NOT RUN
| route | reason |
| ----- | ------ |
| —     | —      |

verdict=fail
```

</details>

## Not included

No regression test. A runtime test proved unreliable: the race fired in 1 of 10 isolated runs at 60k launches, and 300k launches without contention produced a false PASS — such a test would pass on a broken kernel most of the time. A deterministic source-level lint (barrier required between a reduction-result read and reuse of that LDS array) is proposed in #574 instead.

## Architecture-trait change?

No.
