### PR TITLE
fix(redline): emit uncompressed offload bundles so retained routes load

### DIFF
--- a/crates/rdna-compute/src/compiler.rs
+++ b/crates/rdna-compute/src/compiler.rs
@@ -258,7 +258,7 @@ fn seed_hot_from_cold(cold: &Path, hot: &Path) -> std::io::Result<()> {
 /// Cache-key version. Bump when the kernel ABI or hipcc invocation changes in a
 /// way that makes previously-cached `.hsaco` blobs incompatible, to force a clean
 /// recompile instead of loading a stale "invalid device image".
-const KERNEL_CACHE_ABI: u32 = 2;
+const KERNEL_CACHE_ABI: u32 = 3;
 
 /// Compiles HIP kernel sources to code objects, with caching.
 ///
@@ -800,10 +800,14 @@ impl KernelCompiler {
         obj_path: &Path,
         passthrough: Vec<String>,
     ) -> Vec<String> {
+        // clang ≥19 compresses offload bundles by default. HIP's loader accepts the
+        // compressed container; the public HSA reader Redline uses does not, so a
+        // CCOB blob demotes every retained route to plain HIP.
         let mut args: Vec<String> = vec![
             "--genco".into(),
             format!("--offload-arch={arch}"),
             "-O3".into(),
+            "--no-offload-compress".into(),
         ];
         args.extend(passthrough);
         args.push("-o".into());
@@ -1195,7 +1199,7 @@ mod tests {
 
     #[test]
     fn cache_abi_invalidates_pre_radiowave_compiler_entries() {
-        assert_eq!(KERNEL_CACHE_ABI, 2);
+        assert_eq!(KERNEL_CACHE_ABI, 3);
     }
 
     #[test]
@@ -1564,6 +1568,7 @@ mod tests {
                 "--genco",
                 "--offload-arch=gfx1100",
                 "-O3",
+                "--no-offload-compress",
                 "-I/opt/rocm/include",
                 "-o",
                 "kernel.hsaco",

--- a/crates/redline-rocr/src/runtime.rs
+++ b/crates/redline-rocr/src/runtime.rs
@@ -2295,11 +2295,18 @@ impl Executable {
 }
 
 const CLANG_OFFLOAD_BUNDLE_MAGIC: &[u8] = b"__CLANG_OFFLOAD_BUNDLE__";
+const COMPRESSED_OFFLOAD_BUNDLE_MAGIC: &[u8] = b"CCOB";
 
 /// HIP accepts a clang offload bundle at `hipModuleLoad`, while the public HSA
 /// code-object reader accepts only the embedded AMDGPU ELF. Unwrap exactly one
 /// AMDGPU entry in-process so HIP and AQL consume byte-identical device code.
 fn unwrap_clang_offload_bundle(code: Arc<[u8]>) -> Result<Arc<[u8]>, RuntimeError> {
+    if code.starts_with(COMPRESSED_OFFLOAD_BUNDLE_MAGIC) {
+        return Err(RuntimeError::InvalidOffloadBundle(
+            "compressed bundle (CCOB); rebuild the kernel cache so hipcc runs with \
+             --no-offload-compress, or unbundle it with clang-offload-bundler",
+        ));
+    }
     if !code.starts_with(CLANG_OFFLOAD_BUNDLE_MAGIC) {
         return Ok(code);
     }
@@ -2774,6 +2781,27 @@ mod tests {
         ) {
             let _ = parse_kernel_pm4_metadata(&elf, "kernel.kd", loaded_descriptor);
         }
+    }
+
+    #[test]
+    fn compressed_offload_bundle_is_named_not_passed_to_rocr() {
+        // CCOB v3 header prefix as clang emits it, followed by a zstd frame magic.
+        let mut blob = b"CCOB".to_vec();
+        blob.extend_from_slice(&[3, 0, 1, 0]);
+        blob.extend_from_slice(&[0x28, 0xb5, 0x2f, 0xfd]);
+        let err = unwrap_clang_offload_bundle(Arc::from(blob.as_slice()))
+            .expect_err("a compressed bundle must not reach the HSA code-object reader");
+        assert!(
+            err.to_string().contains("CCOB"),
+            "error must name the container: {err}"
+        );
+    }
+
+    #[test]
+    fn plain_code_object_passes_through_unwrapped() {
+        let elf: Vec<u8> = vec![0x7f, b'E', b'L', b'F', 2, 1, 1, 0];
+        let out = unwrap_clang_offload_bundle(Arc::from(elf.as_slice())).unwrap();
+        assert_eq!(&out[..], &elf[..]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Redline never engages when the kernel JIT is driven by clang ≥ 19: the toolchain compresses offload bundles by default, and the ROCr code-object reader cannot parse the compressed container, so every retained route fails closed to plain HIP. This makes the JIT emit uncompressed bundles and names the container explicitly if one ever reaches the loader anyway. Fixes #576. Refs #569.

## The bug

`unwrap_clang_offload_bundle` (`crates/redline-rocr/src/runtime.rs:2297`) recognises only the uncompressed container:

```rust
const CLANG_OFFLOAD_BUNDLE_MAGIC: &[u8] = b"__CLANG_OFFLOAD_BUNDLE__";
...
if !code.starts_with(CLANG_OFFLOAD_BUNDLE_MAGIC) {
    return Ok(code);            // compressed bundle passed straight to ROCr
}
```

Its doc comment already states the intent — *"HIP accepts a clang offload bundle at `hipModuleLoad`, while the public HSA code-object reader accepts only the embedded AMDGPU ELF"* — the compressed variant of that same container just was not covered. A `CCOB` blob falls through and ROCr answers:

```
[redline] falling back to HIP: load .hipfire_kernels/gfx1100/fused_rmsnorm_mq_rotate_vecsum.hsaco:
          hsa_executable_load_agent_code_object failed with HSA 0x1010:
          HSA_STATUS_ERROR_INVALID_CODE_OBJECT
```

HIP's loader handles the compressed form, which is why ordinary serving is unaffected and only Redline breaks — silently, at HIP-path speed.

## This is the toolchain default, not a local quirk

`clang-offload-bundler` compresses by default since clang 19 (llvm/llvm-project#83605), and the driver injects it itself — `clang++ -### --offload-arch=gfx1100 --cuda-device-only -x hip` shows `-compress` added to the bundler invocation with no user flag involved. Measured on the same source file:

| toolchain | flags | size | magic |
|---|---|---:|---|
| ROCm 6.4.3 (clang 19) | none | 1492 B | `CCOB` |
| ROCm 6.4.3 (clang 19) | `--no-offload-compress` | 8592 B | `__CLANG_OFFLOAD_BUNDLE__` |

Nothing in-tree opts out: `git grep -i offload.compress` over `beta` returns nothing, and `scripts/compile-kernels.sh:133` builds the install-dir blobs with the same `--genco --offload-arch -O3`, so pre-compiled artifacts inherit the same problem on such a host.

On a clean checkout of `beta` @ `ac68ffeb` with an empty cache, the engine compiled **44 blobs, 44 of them `CCOB`**, and `python3 -m tools.redline golden --arch gfx1100` failed at PM4 preflight with the error above, `route state='fallback'`, zero retained rows.

@fivetide reported the same root cause independently on gfx1151 in #569 — different card, different distro, same line of code.

## What changed

- **`direct_hipcc_args` passes `--no-offload-compress`.** Product JIT output is a plain bundle that both loaders accept. The two tests that pin the exact argv and the cache ABI are updated with it.
- **`KERNEL_CACHE_ABI` 2 → 3.** Without this, already-cached `CCOB` blobs are reused and the fix appears to do nothing.
- **`redline-rocr` names the container.** `CCOB` is now detected and rejected with an actionable message instead of handing bytes to ROCr and surfacing an opaque `HSA 0x1010`, so a stale cache or an externally built blob says what it is:

  ```
  invalid clang offload bundle: compressed bundle (CCOB); rebuild the kernel cache so
  hipcc runs with --no-offload-compress, or unbundle it with clang-offload-bundler
  ```

## Evidence

gfx1100, ROCm 7.2.3, qwen3.6-35b-a3b `mq4r`, KV q8, sealed fixture `qwen36-a3b-mq4r-gfx1100-tg128-q8-pm4`:

| | `beta` @ `ac68ffeb` | this PR |
|---|---|---|
| JIT blob magic | 44/44 `CCOB` | **52/52 `__CLANG_OFFLOAD_BUNDLE__`** |
| PM4 preflight | failed, `HSA 0x1010` | **passed, 603 dispatches** |
| retained rows / positions | 0, `route state='fallback'` | **10, positions [128, 255]**, `lifecycle_valid=True` |
| HIP → PM4 | route never ran | 220.4 → 234.6 tok/s (1.064×) |

## The fixture still fails, and not because of this PR

`golden` returns `failed` even with the route working: prepared identity is 603 dispatches / 16803 command dwords against the fixture's 604 / 16832, the tape hash is `9a15e101…` against `43754a60…`, and PM4 median 234.6 is under the 245.0 acceptance floor.

I did not want to hand-wave that as drift, so I measured a control: **unmodified `beta`, with its `CCOB` blobs unbundled by `clang-offload-bundler`** (the workaround in #569), so Redline runs without any code change of mine.

| configuration | HIP | PM4 | speedup | verdict |
|---|---:|---:|---:|---|
| `beta`, blobs unbundled by hand (no diff of mine) | 218.5 | **235.9** | 1.0799 | failed |
| this PR | 220.4 | **234.6** | 1.0644 | failed |
| fixture reference (2026-07-22, `76f2a574`) | 219.6 | 251.8 | 1.1464 | — |

PM4 differs by **−0.56 %** between the control and this PR — inside the ±1–3 % band, and expected, since the diff changes how a blob is packed on disk, not the device code. The identity mismatch and the perf shortfall reproduce with my code absent entirely, so they belong to drift between `76f2a574` and `ac68ffeb`, not to this change. Reading it the other way round: on current `beta` that fixture cannot pass on this host by any route, and this PR is what makes it *run* far enough to say so.

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [x] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [ ] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template — touch only when refining the new-arch reference)
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [ ] docs / CI / scripts
- [x] `crates/redline-rocr`

## Test plan

- [x] `cargo build --release --workspace --all-targets --locked` clean
- [x] `cargo test --release -p rdna-compute --lib compiler::` — 21 passed
- [x] `cargo test --release -p redline-rocr --lib` — 40 passed, including two new ones: a `CCOB` header must be rejected by name, and a plain ELF must still pass through untouched
- [x] `tools.redline golden --arch gfx1100` — route engages (table above); fixture verdict `failed` for the pre-existing reasons analysed above
- [x] `./scripts/no-gpu-ci.sh` — Rust half clean; Python half has two pre-existing failures on this host, identical on unmodified `beta`: `test_kernel_atlas.py::…shell_chains…` hardcodes `/bin/bash` (absent on NixOS) and `check-env-docs.py` flags undocumented `HIPFIRE_Q8_CLASSES` / `HIPFIRE_ROUTED_GL` / `HIPFIRE_E8_HESSIAN_DIR` in `hipfire-quantize`. Neither is touched by this diff.
- [x] **Change gate run and telemetry pasted below.**

<details><summary>change_gate telemetry</summary>

```
**change_gate: FAIL**

host gfx=`gfx1100` rocm=`6.18.37` · `ac68ffebfb82`..`336d7cb216a9` · est=14.5min actual=36.8s

### Routes RUN
| route                  | status | duration |
| ---------------------- | ------ | -------- |
| detect.kernels-channel | pass   | 0.6s     |
| redline.capture        | fail   | 3.2s     |
| speed.arch-fast        | pass   | 20.4s    |
| unit.rdna-compute      | pass   | 6.1s     |
| unit.redline-crates    | pass   | 4.3s     |

### Routes NOT RUN
| route | reason |
| ----- | ------ |
| —     | —      |
```

</details>

**`redline.capture` fails identically on unmodified `beta`.** The route pins `qwen3.5-4b.mq4`, a dense model Redline does not arm for, and `redline_daemon_harness.py:97` then dies on `row["redline_capture"]` with `KeyError` rather than reporting that no capture happened. Same traceback, same line, both branches, same host — I ran it on this branch and on `beta` back to back to be sure. Happy to file that separately if it is not already known.

No route reported `blocked`.

## Not included

Teaching the loader to decompress `CCOB` — the more general fix, and what #569 asks for — needs a zstd implementation (`zstd`/`ruzstd`), neither of which is in `Cargo.lock` today. That is a dependency decision plus a `docs/dependency-adoption-log.md` entry, so it seemed wrong to bundle it into a bug fix; this PR removes the breakage without touching the dependency surface, and #569 stays open for that call. If you would rather have decompression instead, I am happy to write it.

## Architecture-trait change?

No.
