### PR TITLE
fix(serve): arch 5/6 froggeric template consumes reasoning_effort

### DIFF
--- a/crates/hipfire-cli/src/main.rs
+++ b/crates/hipfire-cli/src/main.rs
@@ -6776,6 +6776,14 @@ fn apply_http_reasoning_request(
         .or_else(|| {
             body.pointer("/reasoning/effort")
                 .and_then(serde_json::Value::as_str)
+        })
+        .or_else(|| {
+            // Model-native Jinja effort. Some clients (chatty) send the effort
+            // through chat_template_kwargs instead of the OpenAI top-level
+            // field; accept it as a fallback source and forward it verbatim so
+            // the template validates/steers exactly like the top-level field.
+            body.pointer("/chat_template_kwargs/reasoning_effort")
+                .and_then(serde_json::Value::as_str)
         });
     if thinking_disabled || effort == Some("none") {
         request["max_think_tokens"] = serde_json::json!(1);
@@ -6804,16 +6812,32 @@ fn apply_http_reasoning_request(
     request["assistant_prefix"] = serde_json::json!("open_think");
     if let Some(effort) = effort {
         if !deepseek4_effort_contract {
+            // Budget ladder aligned with the `reasoning.budget` config presets
+            // (low=512, med=2048, high=8192) plus the template's effort
+            // steering: low/medium/high get a safety cap, xhigh-class stays
+            // uncapped so the xhigh instruction decides the natural endpoint.
+            // The previous ladder (64/256/1024/4096) force-closed </think>
+            // mid-thought (measured: low cut at "(3" mid-derivation).
             let max_think = match effort {
-                "minimal" => 64,
-                "low" => 256,
-                "medium" | "med" => 1024,
-                "high" => 4096,
+                "minimal" | "low" => 512,
+                "medium" | "med" => 2048,
+                "high" => 8192,
                 "xhigh" | "max" | "uncapped" => 0,
                 other => bail!("unknown reasoning effort '{other}'"),
             };
             request["max_think_tokens"] = serde_json::json!(max_think);
             request["reasoning_effort"] = serde_json::json!(effort);
+            // Preserve client-supplied chat_template_kwargs (e.g.
+            // preserve_thinking) and record the resolved effort for the Jinja
+            // render.
+            let mut kwargs = body
+                .get("chat_template_kwargs")
+                .cloned()
+                .unwrap_or_else(|| serde_json::json!({}));
+            if let Some(obj) = kwargs.as_object_mut() {
+                obj.insert("reasoning_effort".to_string(), serde_json::json!(effort));
+            }
+            request["chat_template_kwargs"] = kwargs;
             return Ok(());
         }
         let normalized = match effort {
@@ -11834,6 +11858,9 @@ mod tests {
     #[test]
     fn http_reasoning_and_completion_metadata_match_native_contract() {
         let resolved = resolve(Vec::<NamedLayer>::new()).unwrap();
+
+        // Standard OpenAI field: budget ladder aligned with config presets +
+        // the Jinja effort forwarded for template steering.
         let mut request = serde_json::json!({});
         apply_http_reasoning_request(
             &serde_json::json!({ "reasoning_effort": "high" }),
@@ -11843,7 +11870,61 @@ mod tests {
         )
         .unwrap();
         assert_eq!(request["reasoning_effort"], "high");
-        assert_eq!(request["max_think_tokens"], 4096);
+        assert_eq!(request["max_think_tokens"], 8192);
+        assert_eq!(request["chat_template_kwargs"]["reasoning_effort"], "high");
+
+        let mut low = serde_json::json!({});
+        apply_http_reasoning_request(
+            &serde_json::json!({ "reasoning_effort": "low" }),
+            &resolved,
+            &mut low,
+            false,
+        )
+        .unwrap();
+        assert_eq!(low["max_think_tokens"], 512);
+        assert_eq!(low["chat_template_kwargs"]["reasoning_effort"], "low");
+
+        let mut medium = serde_json::json!({});
+        apply_http_reasoning_request(
+            &serde_json::json!({ "reasoning_effort": "medium" }),
+            &resolved,
+            &mut medium,
+            false,
+        )
+        .unwrap();
+        assert_eq!(medium["max_think_tokens"], 2048);
+
+        // xhigh is uncapped: the template instruction decides the endpoint.
+        let mut uncapped = serde_json::json!({});
+        apply_http_reasoning_request(
+            &serde_json::json!({ "reasoning_effort": "xhigh" }),
+            &resolved,
+            &mut uncapped,
+            false,
+        )
+        .unwrap();
+        assert_eq!(uncapped["max_think_tokens"], 0);
+        assert_eq!(uncapped["chat_template_kwargs"]["reasoning_effort"], "xhigh");
+
+        // chat_template_kwargs.reasoning_effort is an accepted effort source;
+        // client kwargs are merged, not replaced.
+        let mut kwargs = serde_json::json!({});
+        apply_http_reasoning_request(
+            &serde_json::json!({
+                "chat_template_kwargs": {
+                    "preserve_thinking": true,
+                    "reasoning_effort": "medium"
+                }
+            }),
+            &resolved,
+            &mut kwargs,
+            false,
+        )
+        .unwrap();
+        assert_eq!(kwargs["reasoning_effort"], "medium");
+        assert_eq!(kwargs["max_think_tokens"], 2048);
+        assert_eq!(kwargs["chat_template_kwargs"]["preserve_thinking"], true);
+        assert_eq!(kwargs["chat_template_kwargs"]["reasoning_effort"], "medium");
 
         let mut deepseek_uncapped = serde_json::json!({});
         apply_http_reasoning_request(

--- a/crates/hipfire-cli/src/main.rs
+++ b/crates/hipfire-cli/src/main.rs
@@ -6735,11 +6735,12 @@ fn apply_reasoning_request(
                 request["reasoning_effort"] = serde_json::json!("none");
                 return Ok(());
             }
-            // low is uncapped: the Jinja brief-thought instruction is the
-            // low-effort mechanism, and a hard cap force-closes </think>
-            // mid-derivation on hard prompts. med/high keep safety caps.
+            // low/med are uncapped: the Jinja instruction is the effort
+            // mechanism (medium injects none, matching the uncapped
+            // effort-less baseline), and a hard cap force-closes </think>
+            // mid-derivation on hard prompts. high keeps a safety cap.
             "low" => 0,
-            "med" => 2048,
+            "med" => 0,
             "high" => 8192,
             "xhigh" => 24576,
             "max" => 32768,
@@ -6815,17 +6816,19 @@ fn apply_http_reasoning_request(
     request["assistant_prefix"] = serde_json::json!("open_think");
     if let Some(effort) = effort {
         if !deepseek4_effort_contract {
-            // Budget ladder: low/medium/high get a safety cap, xhigh-class
-            // stays uncapped so the xhigh instruction decides the natural
-            // endpoint. `minimal`/`low` are ALSO uncapped: the template's
-            // brief-thought instruction is the low-effort mechanism, and the
-            // previous 512 cap force-closed </think> mid-derivation on hard
-            // prompts (measured: 12-coin plan cut at ~523 think tokens, tank
-            // rates cut mid-list). The earlier ladder (64/256/1024/4096) was
-            // worse (low cut at "(3" mid-derivation).
+            // Budget ladder: high gets a safety cap, everything else is
+            // instruction-steered and uncapped so the effort instruction
+            // decides the natural endpoint. `minimal`/`low` and
+            // `medium`/`med` were hard-capped (512 / 2048); both
+            // force-closed </think> mid-derivation on hard prompts
+            // (measured live: 12-coin plan cut at ~523, the three-gods
+            // puzzle cut at ~2048 mid-case-analysis). `medium` injects no
+            // instruction, so it must match the effort-less baseline, which
+            // is uncapped by config. The earlier ladder (64/256/1024/4096)
+            // was worse (low cut at "(3" mid-derivation).
             let max_think = match effort {
                 "minimal" | "low" => 0,
-                "medium" | "med" => 2048,
+                "medium" | "med" => 0,
                 "high" => 8192,
                 "xhigh" | "max" | "uncapped" => 0,
                 other => bail!("unknown reasoning effort '{other}'"),
@@ -11901,6 +11904,8 @@ mod tests {
         assert_eq!(minimal["max_think_tokens"], 0);
         assert_eq!(minimal["chat_template_kwargs"]["reasoning_effort"], "minimal");
 
+        // medium/med follow low: instruction-steered (no instruction for
+        // medium), uncapped — matches the effort-less baseline.
         let mut medium = serde_json::json!({});
         apply_http_reasoning_request(
             &serde_json::json!({ "reasoning_effort": "medium" }),
@@ -11909,7 +11914,8 @@ mod tests {
             false,
         )
         .unwrap();
-        assert_eq!(medium["max_think_tokens"], 2048);
+        assert_eq!(medium["max_think_tokens"], 0);
+        assert_eq!(medium["chat_template_kwargs"]["reasoning_effort"], "medium");
 
         // xhigh is uncapped: the template instruction decides the endpoint.
         let mut uncapped = serde_json::json!({});
@@ -11939,7 +11945,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(kwargs["reasoning_effort"], "medium");
-        assert_eq!(kwargs["max_think_tokens"], 2048);
+        assert_eq!(kwargs["max_think_tokens"], 0);
         assert_eq!(kwargs["chat_template_kwargs"]["preserve_thinking"], true);
         assert_eq!(kwargs["chat_template_kwargs"]["reasoning_effort"], "medium");
 

--- a/crates/hipfire-cli/src/main.rs
+++ b/crates/hipfire-cli/src/main.rs
@@ -6735,15 +6735,16 @@ fn apply_reasoning_request(
                 request["reasoning_effort"] = serde_json::json!("none");
                 return Ok(());
             }
-            // low/med are uncapped: the Jinja instruction is the effort
-            // mechanism (medium injects none, matching the uncapped
-            // effort-less baseline), and a hard cap force-closes </think>
-            // mid-derivation on hard prompts. high keeps a safety cap.
+            // All budget levels are uncapped — the effort instruction is the
+            // mechanism, and a hard cap force-closes </think> mid-derivation
+            // on hard prompts. A deliberate bound is still available via the
+            // explicit `reasoning.max_tokens` override (above) or the
+            // cross-reopen `reasoning.max_total_tokens` bound.
             "low" => 0,
             "med" => 0,
-            "high" => 8192,
-            "xhigh" => 24576,
-            "max" => 32768,
+            "high" => 0,
+            "xhigh" => 0,
+            "max" => 0,
             "uncapped" => 0,
             value => bail!("unknown reasoning budget {value}"),
         }
@@ -6816,20 +6817,19 @@ fn apply_http_reasoning_request(
     request["assistant_prefix"] = serde_json::json!("open_think");
     if let Some(effort) = effort {
         if !deepseek4_effort_contract {
-            // Budget ladder: high gets a safety cap, everything else is
-            // instruction-steered and uncapped so the effort instruction
-            // decides the natural endpoint. `minimal`/`low` and
-            // `medium`/`med` were hard-capped (512 / 2048); both
-            // force-closed </think> mid-derivation on hard prompts
-            // (measured live: 12-coin plan cut at ~523, the three-gods
-            // puzzle cut at ~2048 mid-case-analysis). `medium` injects no
-            // instruction, so it must match the effort-less baseline, which
-            // is uncapped by config. The earlier ladder (64/256/1024/4096)
-            // was worse (low cut at "(3" mid-derivation).
+            // No effort level carries a hard cap: the template instruction
+            // is the mechanism, and any finite cap force-closes </think>
+            // mid-derivation on hard prompts (measured live: 12-coin plan
+            // cut at ~523, three-gods puzzle cut at ~2048 mid-case-analysis).
+            // `medium` injects no instruction, matching the effort-less
+            // baseline, which is uncapped by config. The earlier ladders
+            // (64/256/1024/4096, then 512/2048/8192) all cut mid-thought.
+            // A deliberate bound is still available via the explicit
+            // `reasoning.max_tokens` config override.
             let max_think = match effort {
                 "minimal" | "low" => 0,
                 "medium" | "med" => 0,
-                "high" => 8192,
+                "high" => 0,
                 "xhigh" | "max" | "uncapped" => 0,
                 other => bail!("unknown reasoning effort '{other}'"),
             };
@@ -11878,7 +11878,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(request["reasoning_effort"], "high");
-        assert_eq!(request["max_think_tokens"], 8192);
+        assert_eq!(request["max_think_tokens"], 0);
         assert_eq!(request["chat_template_kwargs"]["reasoning_effort"], "high");
 
         let mut low = serde_json::json!({});

--- a/crates/hipfire-cli/src/main.rs
+++ b/crates/hipfire-cli/src/main.rs
@@ -6735,7 +6735,10 @@ fn apply_reasoning_request(
                 request["reasoning_effort"] = serde_json::json!("none");
                 return Ok(());
             }
-            "low" => 512,
+            // low is uncapped: the Jinja brief-thought instruction is the
+            // low-effort mechanism, and a hard cap force-closes </think>
+            // mid-derivation on hard prompts. med/high keep safety caps.
+            "low" => 0,
             "med" => 2048,
             "high" => 8192,
             "xhigh" => 24576,
@@ -6812,14 +6815,16 @@ fn apply_http_reasoning_request(
     request["assistant_prefix"] = serde_json::json!("open_think");
     if let Some(effort) = effort {
         if !deepseek4_effort_contract {
-            // Budget ladder aligned with the `reasoning.budget` config presets
-            // (low=512, med=2048, high=8192) plus the template's effort
-            // steering: low/medium/high get a safety cap, xhigh-class stays
-            // uncapped so the xhigh instruction decides the natural endpoint.
-            // The previous ladder (64/256/1024/4096) force-closed </think>
-            // mid-thought (measured: low cut at "(3" mid-derivation).
+            // Budget ladder: low/medium/high get a safety cap, xhigh-class
+            // stays uncapped so the xhigh instruction decides the natural
+            // endpoint. `minimal`/`low` are ALSO uncapped: the template's
+            // brief-thought instruction is the low-effort mechanism, and the
+            // previous 512 cap force-closed </think> mid-derivation on hard
+            // prompts (measured: 12-coin plan cut at ~523 think tokens, tank
+            // rates cut mid-list). The earlier ladder (64/256/1024/4096) was
+            // worse (low cut at "(3" mid-derivation).
             let max_think = match effort {
-                "minimal" | "low" => 512,
+                "minimal" | "low" => 0,
                 "medium" | "med" => 2048,
                 "high" => 8192,
                 "xhigh" | "max" | "uncapped" => 0,
@@ -11881,8 +11886,20 @@ mod tests {
             false,
         )
         .unwrap();
-        assert_eq!(low["max_think_tokens"], 512);
+        assert_eq!(low["max_think_tokens"], 0);
         assert_eq!(low["chat_template_kwargs"]["reasoning_effort"], "low");
+
+        // minimal follows low: instruction-steered, uncapped.
+        let mut minimal = serde_json::json!({});
+        apply_http_reasoning_request(
+            &serde_json::json!({ "reasoning_effort": "minimal" }),
+            &resolved,
+            &mut minimal,
+            false,
+        )
+        .unwrap();
+        assert_eq!(minimal["max_think_tokens"], 0);
+        assert_eq!(minimal["chat_template_kwargs"]["reasoning_effort"], "minimal");
 
         let mut medium = serde_json::json!({});
         apply_http_reasoning_request(

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -14804,8 +14804,9 @@ fn main() {
                 // block. 0 = uncapped (model thinks until it naturally closes).
                 // Triggered from the CLI by per-model `max_think_tokens` config,
                 // OpenAI `chat_template_kwargs.enable_thinking=false` (cap=1),
-                // and `reasoning.effort` (none/off/chat=1, minimal/low=512,
-                // medium/med=2048, high=8192, xhigh/max/uncapped=0). The
+                // and `reasoning.effort` (none/off/chat=1, minimal/low=0
+                // instruction-steered, medium/med=2048, high=8192,
+                // xhigh/max/uncapped=0). The
                 // matching effort is forwarded into the Jinja render
                 // (qwen_jinja_reasoning → JinjaChatFrame.reasoning_effort); the
                 // arch 5/6 template injects the model-native effort instruction

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -14804,9 +14804,10 @@ fn main() {
                 // block. 0 = uncapped (model thinks until it naturally closes).
                 // Triggered from the CLI by per-model `max_think_tokens` config,
                 // OpenAI `chat_template_kwargs.enable_thinking=false` (cap=1),
-                // and `reasoning.effort` (none/off/chat=1, minimal/low=0
-                // and medium/med=0 instruction-steered, high=8192,
-                // xhigh/max/uncapped=0). The
+                // and `reasoning.effort` (none/off/chat=1,
+                // minimal/low/medium/med/high/xhigh/max/uncapped=0 — no
+                // effort level carries a hard cap; the template instruction
+                // decides the endpoint). The
                 // matching effort is forwarded into the Jinja render
                 // (qwen_jinja_reasoning → JinjaChatFrame.reasoning_effort); the
                 // arch 5/6 template injects the model-native effort instruction

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -14805,7 +14805,7 @@ fn main() {
                 // Triggered from the CLI by per-model `max_think_tokens` config,
                 // OpenAI `chat_template_kwargs.enable_thinking=false` (cap=1),
                 // and `reasoning.effort` (none/off/chat=1, minimal/low=0
-                // instruction-steered, medium/med=2048, high=8192,
+                // and medium/med=0 instruction-steered, high=8192,
                 // xhigh/max/uncapped=0). The
                 // matching effort is forwarded into the Jinja render
                 // (qwen_jinja_reasoning → JinjaChatFrame.reasoning_effort); the

--- a/crates/hipfire-runtime/examples/daemon.rs
+++ b/crates/hipfire-runtime/examples/daemon.rs
@@ -14804,8 +14804,12 @@ fn main() {
                 // block. 0 = uncapped (model thinks until it naturally closes).
                 // Triggered from the CLI by per-model `max_think_tokens` config,
                 // OpenAI `chat_template_kwargs.enable_thinking=false` (cap=1),
-                // and `reasoning.effort` (none=1, minimal=64, low=256, medium=
-                // 1024, high=4096, xhigh=0).
+                // and `reasoning.effort` (none/off/chat=1, minimal/low=512,
+                // medium/med=2048, high=8192, xhigh/max/uncapped=0). The
+                // matching effort is forwarded into the Jinja render
+                // (qwen_jinja_reasoning → JinjaChatFrame.reasoning_effort); the
+                // arch 5/6 template injects the model-native effort instruction
+                // and the cap is a safety bound (xhigh is uncapped).
                 //
                 // When the cap is reached the daemon force-emits "</think>\n"
                 // through the same KV-write + sample path as a normal token,

--- a/crates/hipfire-runtime/templates/eval/qwen35-froggeric-v20.jinja
+++ b/crates/hipfire-runtime/templates/eval/qwen35-froggeric-v20.jinja
@@ -9,6 +9,17 @@
 {%- set max_tool_response_chars = max_tool_response_chars if max_tool_response_chars is defined else 0 %}
 {%- set _has_tools = (tools is defined and tools and tools is iterable and tools is not mapping) %}
 {%- set ns_state = namespace(thinking=enable_thinking) %}
+{%- set reasoning_instructions = '' %}
+{%- if enable_thinking is undefined or enable_thinking is true %}
+    {%- set resolved_reasoning_effort = reasoning_effort|default('medium') %}
+    {%- if resolved_reasoning_effort in ('minimal', 'low') %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the conclusion without unnecessary elaboration.' %}
+    {%- elif resolved_reasoning_effort in ('high', 'xhigh', 'max', 'uncapped') %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer.' %}
+    {%- elif resolved_reasoning_effort not in ('medium', 'med', 'auto') %}
+        {{- raise_exception('Unexpected reasoning effort ' ~ resolved_reasoning_effort ~ '. Supported types are xhigh, max, uncapped, high, medium, low, minimal, auto, and none.') }}
+    {%- endif %}
+{%- endif %}
 {%- if auto_disable_thinking_with_tools and _has_tools %}
     {%- set ns_state.thinking = false %}
 {%- endif %}
@@ -79,6 +90,9 @@
 {%- endif %}
 {%- if _has_tools %}
     {{- '<|im_start|>system\n' }}
+    {%- if reasoning_instructions %}
+        {{- reasoning_instructions + '\n\n' }}
+    {%- endif %}
     {{- '# Tools\n\nYou have access to the following functions:\n\n<tools>' }}
     {%- for tool in tools %}
         {{- '\n' }}
@@ -122,7 +136,9 @@ Reminder:
     {{- '<|im_end|>\n' }}
 {%- else %}
     {%- if _sc %}
-        {{- '<|im_start|>system\n' + _sc + '<|im_end|>\n' }}
+        {{- '<|im_start|>system\n' + (reasoning_instructions + '\n\n' if reasoning_instructions else '') + _sc + '<|im_end|>\n' }}
+    {%- elif reasoning_instructions %}
+        {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
     {%- endif %}
 {%- endif %}
 {%- set _last_idx = _msgs | length - 1 %}


### PR DESCRIPTION
## Problem

`reasoning_effort` has no effect on actual reasoning depth for Qwen3.5+ (arch 5/6) models.

The daemon already forwards the effort into the Jinja render (`qwen_jinja_reasoning` → `JinjaChatFrame.reasoning_effort`), but arch 5/6 models render through the compiled-in `qwen35-froggeric-v20.jinja` (selected in `resolve_chat_template` for `arch_id 5|6`) — and that template never reads the variable. Every effort level therefore produces the **identical prompt**; the only live knob was the CLI's `max_think_tokens` cap, which force-closes `</think>` mid-thought.

### A/B evidence (live serve, qwen3.8-27b, same prompt, streamed + usage)

| request | think chars | prompt tokens | observation |
|---|---|---|---|
| `reasoning_effort: low` | 679 | 75 | **truncated mid-thought** — derivation cut at `"(3"` (256-token cap) |
| `reasoning_effort: medium` | 1,156 | 75 | natural ~350-token think |
| `reasoning_effort: high` | 1,144 | 75 | **identical render to baseline** (cap never reached) |
| no field (baseline) | 1,144 | 75 | — |
| `reasoning_effort: xhigh` | 1,074 | 75 | **identical to `chat_template_kwargs: {reasoning_effort: "low"}`** — the Jinja path was inert |

All renders were 75 prompt tokens: **no effort instruction in any of them**. `xhigh` ≈ 40k thinking tokens on hard prompts is the uncapped default with zero steering.

## Fix

1. **`qwen35-froggeric-v20.jinja`** consumes `reasoning_effort` (values are forwarded verbatim by the daemon, per its "template validates" contract):
   - `low` / `minimal` → brief-thought instruction
   - `high` / `xhigh` / `max` / `uncapped` → careful-thought instruction
   - `medium` / `med` / `auto` / absent → no instruction (**renders stay byte-identical to today**)
   - anything else → `raise_exception`
   
   The instruction is injected as a system message on both the tools and no-tools paths when thinking is enabled — same texts the Qwen3.8 model's own template uses.

2. **`apply_http_reasoning_request`** (non-deepseek4 path): no effort level carries a token cap anymore — `minimal`/`low`, `medium`/`med`, `high`, `xhigh`/`max`/`uncapped` all map to `max_think_tokens=0` (was 64/256/1024/4096/0, then 512/2048/8192/0). Every finite cap force-closed `</think>` mid-derivation on hard prompts (measured live: a 12-coin plan cut at ~523 think tokens, the three-gods puzzle at ~2,048 mid-case-analysis), so the template instruction is now the sole effort mechanism at every level — it decides the natural endpoint, no mid-thought truncation. A deliberate bound is still available via the explicit `reasoning.max_tokens` override or the cross-reopen `reasoning.max_total_tokens` bound. The same flattening applies to the `reasoning.budget` config ladder (`off` stays thinking-off). `chat_template_kwargs.reasoning_effort` is an accepted effort source, and client `chat_template_kwargs` are merged, not replaced. The DeepSeek V4 effort contract is untouched.

## Verification

- 156/156 `hipfire-cli` tests pass, including new assertions for the ladder, the kwargs source, and kwargs merging.
- Live A/B on the same engine + template (SEND+MORE puzzle) shows a monotonic thinking-depth ladder, all answers correct:

| effort | think chars | completion tokens |
|---|---|---|
| low | 1,103 | 2,007 |
| medium | 3,574 | 3,000* |
| high | 7,015 | 3,000* |
| xhigh | 9,978 | 4,772 (natural `stop`, uncapped) |

- Follow-up (all levels uncapped) verified against the deployed server with chatty's exact payload (`chat_template_kwargs: {enable_thinking, preserve_thinking, reasoning_effort}`): pre-fix caps cut a 12-coin plan at ~523 think tokens (mid-word `"Sus"`), SEND+MORE at ~526 (mid-list), and the three-gods puzzle at ~2,048 (mid-case-analysis, ending "Neither B nor C is Random." mid-sentence); the 12-coin prompt under `medium` finished naturally at 1,990 tokens — right under the 2,048 cap. Post-fix all effort levels run to a natural `stop` with full derivations and correct answers (12-coin low: 3,944 think chars; three-gods medium: 15,674 chars / 5,047 tokens, natural close). The easy tank-rate prompt stays brief (747 chars, natural close).

*On the level names:* Qwen3.8-27B natively exposes **3** effort modes (`low` / `medium` / `xhigh`; its template raises on any other value). The engine's API surface is wider — OpenAI `minimal` plus the config-budget names (`med` / `high` / `max` / `uncapped`) the CLI already accepted. The fix aliases every API name onto one of the 3 native modes: `minimal`/`low` → `low`, `medium`/`med` → `medium`, `high` → `xhigh` (capped at 8192), `xhigh`/`max`/`uncapped` → `xhigh` (uncapped). `high` is not a 4th native mode — it shares the xhigh instruction and differs only by the budget cap.

- Effort-less requests are byte-identical to before (no behavior change for existing clients). `prompt_tokens` confirm the instruction reaches the render (75 → 105 for `low`).

