### PR TITLE
fix(gemma4): retain mul kernargs during graph capture

### DIFF
--- a/crates/hipfire-arch-gemma4/src/forward.rs
+++ b/crates/hipfire-arch-gemma4/src/forward.rs
@@ -317,25 +317,9 @@ pub fn decode_step_with_graph(
                 _ => None,
             },
         );
-    // DEFAULT OFF pending a fix to the captured decode path.
-    //
-    // Measured on gfx1201 / 12B-it MQ4, prompt "Hello world", greedy:
-    //   graph ON : 49.75 tok/s, output collapses after the first token
-    //              ("Hello!s율 bawass율율 bawaky interracial율jal…")
-    //   graph OFF: 49.72 tok/s, "Hello! How can I help you today?" — byte-
-    //              identical to this PR's own Phase-2 Gate 2 expected output,
-    //              and it stops cleanly on <turn|>.
-    //
-    // This is the failure mode AGENTS.md documents: a captured graph replays
-    // dangling stack-pointer kernargs, so throughput looks right and the tokens
-    // are garbage. All six Gemma4 dispatch helpers added during this port go
-    // through `launch_maybe_blob` and are capture-safe, so the offending raw
-    // launch is elsewhere in the decode body and still needs to be found.
-    //
-    // The graph is worth 0.03 tok/s here (0.06%), so correctness costs nothing.
-    // Re-enable with HIPFIRE_GEMMA4_GRAPH=1 once the capture path is fixed and
-    // a coherence check passes with it on.
-    let graph_on = env_override.unwrap_or(false);
+    // The captured path is the default. Set HIPFIRE_GEMMA4_GRAPH=0 to retain
+    // the eager fallback for diagnostics.
+    let graph_on = env_override.unwrap_or(true);
     if !graph_on {
         return decode_step(cfg, weights, state, gpu, token_id, position);
     }
@@ -382,7 +366,7 @@ pub fn decode_step_with_graph(
             .map_err(|e| format!("gemma4 graph_launch (capture): {e:?}"))?;
         eprintln!(
             "[gemma4 hipGraph] captured decode forward — {} kernarg blobs retained",
-            gpu.graphs.capture_blobs.len()
+            gpu.graphs.ar_forward_blobs.len()
         );
     } else {
         // ── Replay phase ───────────────────────────────────────────────

--- a/crates/rdna-compute/examples/hip_graph_poc.rs
+++ b/crates/rdna-compute/examples/hip_graph_poc.rs
@@ -27,9 +27,9 @@
 //! `hip_bridge::KernargBlob` helper, dispatch paths can build correctly
 //! aligned kernarg buffers without resorting to stack-local addresses.
 //!
-//! This POC proves the fix: it captures a `mul_f32` launch via the blob
-//! path, replays it, and confirms every element of the output matches the
-//! sequential reference.
+//! This POC proves the fix through the production `Gpu::mul_f32` helper:
+//! capture routes it through the blob path, replay is bit-exact with the
+//! sequential reference, and the graph owns the retained kernarg blob.
 //!
 //! Run:
 //!   cargo run --release -p rdna-compute --example hip_graph_poc
@@ -112,39 +112,26 @@ fn main() {
     eprintln!("  blob-direct vs reference: {}/{} match", dim - bad, dim);
     assert_eq!(bad, 0, "blob-path launch outside capture already differs");
 
-    // ─── Graph capture via the blob path ────────────────────────────────
-    eprintln!("\n--- hipGraph capture + replay (blob path) ---");
+    // ─── Graph capture via the production dispatch helper ──────────────
+    eprintln!("\n--- hipGraph capture + replay (Gpu::mul_f32) ---");
     gpu.hip.memcpy_htod(&scratch.buf, as_bytes(&zero)).unwrap();
 
-    gpu.hip
-        .stream_begin_capture(gpu.active_stream.as_ref().unwrap(), 0)
-        .expect("stream_begin_capture");
-
-    // Rebuild the blob — we'll hand this one to the graph and keep it
-    // alive until graph destruction so the captured node's kernarg
-    // pointer stays valid.
-    let mut graph_blob = KernargBlob::new();
-    graph_blob.push_ptr(a.buf.as_ptr());
-    graph_blob.push_ptr(b.buf.as_ptr());
-    graph_blob.push_ptr(scratch.buf.as_ptr());
-    graph_blob.push_i32(n);
-
-    gpu.launch_kernel_blob("mul_f32", grid, block, 0, graph_blob.as_mut_slice())
-        .expect("launch during capture");
-
-    let graph = gpu
-        .hip
-        .stream_end_capture(gpu.active_stream.as_ref().unwrap())
-        .expect("stream_end_capture");
+    gpu.graphs
+        .begin_graph_capture(&gpu.hip, gpu.device_id, gpu.active_stream.as_ref().unwrap())
+        .expect("begin_graph_capture");
+    gpu.mul_f32(&a, &b, &scratch)
+        .expect("mul_f32 during capture");
+    gpu.graphs
+        .end_graph_capture(&gpu.hip, gpu.device_id, gpu.active_stream.as_ref().unwrap())
+        .expect("end_graph_capture");
     eprintln!("  capture succeeded");
-
-    let exec = gpu.hip.graph_instantiate(&graph).expect("graph_instantiate");
+    assert_eq!(gpu.graphs.ar_forward_blobs.len(), 1);
     eprintln!("  instantiated");
 
     // First replay
     gpu.hip.memcpy_htod(&scratch.buf, as_bytes(&zero)).unwrap();
-    gpu.hip
-        .graph_launch(&exec, gpu.active_stream.as_ref().unwrap())
+    gpu.graphs
+        .graph_launch(&gpu.hip, gpu.device_id, gpu.active_stream.as_ref().unwrap())
         .unwrap();
     gpu.hip
         .stream_synchronize(gpu.active_stream.as_ref().unwrap())
@@ -158,7 +145,10 @@ fn main() {
 
     if bad > 0 {
         eprintln!("  FIRST 8 MISMATCHES:");
-        for i in (0..dim).filter(|&i| (graph_out[i] - reference[i]).abs() > 1e-6).take(8) {
+        for i in (0..dim)
+            .filter(|&i| (graph_out[i] - reference[i]).abs() > 1e-6)
+            .take(8)
+        {
             eprintln!(
                 "    [{i}] graph={} ref={} delta={}",
                 graph_out[i],
@@ -172,8 +162,8 @@ fn main() {
 
     // ─── Second replay to prove it's repeatable ─────────────────────────
     gpu.hip.memcpy_htod(&scratch.buf, as_bytes(&zero)).unwrap();
-    gpu.hip
-        .graph_launch(&exec, gpu.active_stream.as_ref().unwrap())
+    gpu.graphs
+        .graph_launch(&gpu.hip, gpu.device_id, gpu.active_stream.as_ref().unwrap())
         .unwrap();
     gpu.hip
         .stream_synchronize(gpu.active_stream.as_ref().unwrap())
@@ -191,8 +181,8 @@ fn main() {
     for _ in 0..50 {
         let t = Instant::now();
         for _ in 0..burst {
-            gpu.hip
-                .graph_launch(&exec, gpu.active_stream.as_ref().unwrap())
+            gpu.graphs
+                .graph_launch(&gpu.hip, gpu.device_id, gpu.active_stream.as_ref().unwrap())
                 .unwrap();
         }
         gpu.hip
@@ -232,8 +222,7 @@ fn main() {
     eprintln!("  graph-replay speedup: {:.2}x", speedup);
 
     // Cleanup the single-node graph
-    gpu.hip.graph_exec_destroy(exec).unwrap();
-    gpu.hip.graph_destroy(graph).unwrap();
+    gpu.graphs.drop_captured_graph(&gpu.hip, gpu.device_id);
 
     // ─── Multi-node graph test ───────────────────────────────────────────
     //
@@ -315,9 +304,8 @@ fn main() {
     let stream = gpu.active_stream.take().unwrap();
     gpu.hip.stream_destroy(stream).unwrap();
 
-    // Keep blob alive until the graph that captured it is destroyed.
+    // Keep the direct-launch blob alive until all work has completed.
     drop(blob);
-    drop(graph_blob);
 
     eprintln!("\n=== POC PASSED — hipGraph capture + blob-path kernargs work bit-exact ===");
 }

--- a/crates/rdna-compute/src/norm.rs
+++ b/crates/rdna-compute/src/norm.rs
@@ -477,29 +477,38 @@ impl Gpu {
     pub fn mul_f32(&mut self, a: &GpuTensor, b: &GpuTensor, c: &GpuTensor) -> HipResult<()> {
         self.bind_thread()?;
         self.ensure_kernel("mul", kernels::MUL_SRC, "mul_f32")?;
-        let func = &self.functions["mul_f32"];
 
         let n = a.numel() as i32;
-        let mut a_ptr = a.buf.as_ptr();
-        let mut b_ptr = b.buf.as_ptr();
-        let mut c_ptr = c.buf.as_ptr();
-        let mut n_val = n;
+        let a_ptr = a.buf.as_ptr();
+        let b_ptr = b.buf.as_ptr();
+        let c_ptr = c.buf.as_ptr();
 
         let mut params: Vec<*mut c_void> = vec![
-            &mut a_ptr as *mut _ as *mut c_void,
-            &mut b_ptr as *mut _ as *mut c_void,
-            &mut c_ptr as *mut _ as *mut c_void,
-            &mut n_val as *mut _ as *mut c_void,
+            &a_ptr as *const _ as *mut c_void,
+            &b_ptr as *const _ as *mut c_void,
+            &c_ptr as *const _ as *mut c_void,
+            &n as *const _ as *mut c_void,
         ];
 
         let block = 256u32;
         let grid = ((n as u32) + block - 1) / block;
         let bytes = crate::profile::elementwise_bytes(n as usize);
         let timer = crate::profile::begin_timer(&self.hip, "elementwise", "mul_f32", bytes);
-        let result = unsafe {
-            self.hip
-                .launch_kernel(func, [grid, 1, 1], [block, 1, 1], 0, None, &mut params)
-        };
+        let result = self.launch_maybe_blob(
+            "mul_f32",
+            [grid, 1, 1],
+            [block, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut blob = hip_bridge::KernargBlob::new();
+                blob.push_ptr(a_ptr);
+                blob.push_ptr(b_ptr);
+                blob.push_ptr(c_ptr);
+                blob.push_i32(n);
+                blob
+            },
+        );
         if let Some(t) = timer {
             t.finish(&self.hip);
         }


### PR DESCRIPTION
## Summary

- retain `mul_f32` kernargs with `launch_maybe_blob` during hipGraph capture
- restore the documented Gemma4 graph-on default while retaining `HIPFIRE_GEMMA4_GRAPH=0` as a diagnostic fallback
- make the hipGraph POC exercise the production `Gpu::mul_f32` helper and verify both first and second replay
- report the retained AR-forward blob count after ownership moves out of the shared capture buffer

Gemma4 uses `mul_f32` in-place in every FFN. The helper called `hipModuleLaunchKernel` with a parameter array pointing at stack locals. During stream capture those addresses outlived the Rust stack frame, so the first captured launch could read invalid kernargs and diverge before graph replay began. The fix uses the existing graph-aware retained-blob launch path; target verification and model math are unchanged.

## Which crates does this touch?

- [x] `rdna-compute`
- [x] `hipfire-arch-gemma4`
- [x] `hipfire-runtime` (production graph POC only)
- [ ] `hipfire-cli`
- [ ] `hipfire-loader`
- [ ] `hipfire-quantize`
- [ ] `redline`

## Test plan

- [x] `cargo build --release --workspace --all-targets --locked`
- [x] `cargo test --locked -p rdna-compute --lib` — 161 passed
- [x] `cargo test --locked -p hipfire-arch-gemma4 --lib` — 15 passed
- [x] `git diff --check`
- [x] production `mul_f32` graph POC on gfx1100 and gfx1201 — 4096/4096 exact on first and second replay
- [x] Gemma4 Q8 graph-on/off correctness on gfx1100 and gfx1201
- [x] long generation: 1024-token graph-on/off output identical on both architectures
- [x] graph-enabled serving battery on gfx1100 — 5/5 coherent; zero empty, runaway, or attractor outputs
- [x] `change_gate.py plan/run --base origin/beta`

### Hardware results

- W7900 / gfx1100 / ROCm 7.14:
  - Gemma4 Q8, 64 tokens: graph-on/off token IDs and text identical
  - Gemma4 Q8, 1024 tokens: graph-on/off text identical
  - same-GPU sequential observation: 37.7 vs 36.3 tok/s (informational; no performance claim)
- R9700 / gfx1201 / ROCm 7.14:
  - Gemma4 Q8, 1024 tokens: default graph path and graph-off text identical
  - same-GPU sequential observation: 37.1 vs 36.1 tok/s (informational; no performance claim)

### Change-gate telemetry

The planner selected four routes (estimated 13.5 minutes; no blocked or excluded routes):

| Route | PR branch | Untouched `origin/beta` control |
|---|---:|---:|
| `detect.kernels-channel` | pass | — |
| `unit.rdna-compute` | pass | — |
| `redline.capture` | fail: rows omit `redline_capture` | same `KeyError: redline_capture` |
| `speed.arch-fast` | 141.5 tok/s, below locked 178 floor | 141.1 tok/s, same failure |

The two failing routes reproduce on an untouched detached worktree at `origin/beta` (`8a8ed770`): the generic Redline harness receives no `redline_capture` field, and the local gfx1100 speed result is already about 141 tok/s. These are recorded as baseline/environment gate failures, not waived as passes. The architecture-specific graph oracle above directly covers this patch.

Full `no-gpu-ci.sh` also reaches the existing beta Redline registry-card mismatch (1 failure, 3 errors); the same failures reproduce unchanged on untouched `origin/beta`.

## Architecture trait note

No architecture trait or public interface changes. The change routes one existing helper through the established graph-aware launch API and retains its packed kernargs only when capture requires it.
