### PR TITLE
fix(redline): restore GC12 retained replay correctness

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -6920,21 +6920,11 @@ fn ar_graph_eligible_for_kv(requested: bool, compact_offset: usize) -> bool {
 }
 
 #[inline]
-fn retained_replay_eligible(
-    requested: bool,
-    automatic_lifecycle: bool,
-    layer_types: &[LayerType],
-) -> bool {
-    // Production retained AQL/PM4 does not yet reproduce ordinary HIP for
-    // hybrid DeltaNet decode.  The first captured forward is correct, but the
-    // recurrent state diverges after the route takes over.  Keep manual
-    // capture available for the state/logit shadow oracle while serving fails
-    // closed to HIP.  Full-attention-only Qwen carriers are unaffected.
+fn retained_replay_eligible(requested: bool) -> bool {
+    // DeltaNet state updates are part of the retained tape, and gfx12 now
+    // performs the required pre-writer vector-cache acquire.  Hybrid Qwen
+    // routes therefore share the ordinary plain-AR eligibility contract.
     requested
-        && !(automatic_lifecycle
-            && layer_types
-                .iter()
-                .any(|kind| *kind == LayerType::LinearAttention))
 }
 
 /// Zero-alloc forward pass using pre-allocated scratch buffers.
@@ -7069,11 +7059,7 @@ pub fn forward_scratch(
     // Redline's plain-AR capture/replay has the same eligibility contract as
     // the AR HipGraph. MTP/spec re-seed and verify calls must not contaminate
     // or consume the immutable single-token replay sequence.
-    let retained_eligible = retained_replay_eligible(
-        graph_eligible,
-        gpu.replay.automatic_lifecycle_enabled(),
-        &config.layer_types,
-    );
+    let retained_eligible = retained_replay_eligible(graph_eligible);
     gpu.replay.set_forward_eligible(retained_eligible);
     gpu.replay
         .begin_auto_capture_if_armed()
@@ -24696,12 +24682,8 @@ mod tests {
         assert!(!ar_graph_eligible_for_kv(false, 0));
     }
     #[test]
-    fn automatic_retained_replay_fails_closed_for_deltanet() {
-        let hybrid = [LayerType::LinearAttention, LayerType::FullAttention];
-        let full_only = [LayerType::FullAttention, LayerType::FullAttention];
-        assert!(!retained_replay_eligible(true, true, &hybrid));
-        assert!(retained_replay_eligible(true, false, &hybrid));
-        assert!(retained_replay_eligible(true, true, &full_only));
-        assert!(!retained_replay_eligible(false, true, &full_only));
+    fn automatic_retained_replay_accepts_repaired_deltanet_routes() {
+        assert!(retained_replay_eligible(true));
+        assert!(!retained_replay_eligible(false));
     }
 }

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -436,7 +436,10 @@ impl MropeCtx {
             "MropeCtx::pos3 called below base ({pos} < {})",
             self.base
         );
-        match pos.checked_sub(self.base).and_then(|i| self.positions.get(i)) {
+        match pos
+            .checked_sub(self.base)
+            .and_then(|i| self.positions.get(i))
+        {
             Some(p) => *p,
             None => [pos as i32 + self.rope_delta; 3],
         }
@@ -18063,7 +18066,9 @@ pub fn forward_scratch_mrope(
     mrope: Option<&MropeCtx>,
 ) -> HipResult<()> {
     let Some(mc) = mrope else {
-        return forward_scratch(gpu, weights, config, token, pos, kv_cache, dn_state, scratch);
+        return forward_scratch(
+            gpu, weights, config, token, pos, kv_cache, dn_state, scratch,
+        );
     };
     mark_mrope_forward_ineligible(gpu);
     // Embedding lookup into scratch.x + the 1D pos scalar (still consumed by

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -436,10 +436,7 @@ impl MropeCtx {
             "MropeCtx::pos3 called below base ({pos} < {})",
             self.base
         );
-        match pos
-            .checked_sub(self.base)
-            .and_then(|i| self.positions.get(i))
-        {
+        match pos.checked_sub(self.base).and_then(|i| self.positions.get(i)) {
             Some(p) => *p,
             None => [pos as i32 + self.rope_delta; 3],
         }
@@ -6922,14 +6919,6 @@ fn ar_graph_eligible_for_kv(requested: bool, compact_offset: usize) -> bool {
     requested && compact_offset == 0
 }
 
-#[inline]
-fn retained_replay_eligible(requested: bool) -> bool {
-    // DeltaNet state updates are part of the retained tape, and gfx12 now
-    // performs the required pre-writer vector-cache acquire.  Hybrid Qwen
-    // routes therefore share the ordinary plain-AR eligibility contract.
-    requested
-}
-
 /// Zero-alloc forward pass using pre-allocated scratch buffers.
 /// Logits stay on GPU in scratch.logits. Returns nothing — caller uses scratch.logits.
 pub fn forward_scratch(
@@ -7062,8 +7051,7 @@ pub fn forward_scratch(
     // Redline's plain-AR capture/replay has the same eligibility contract as
     // the AR HipGraph. MTP/spec re-seed and verify calls must not contaminate
     // or consume the immutable single-token replay sequence.
-    let retained_eligible = retained_replay_eligible(graph_eligible);
-    gpu.replay.set_forward_eligible(retained_eligible);
+    gpu.replay.set_forward_eligible(graph_eligible);
     gpu.replay
         .begin_auto_capture_if_armed()
         .map_err(|reason| HipError::new(0, reason))?;
@@ -18066,9 +18054,7 @@ pub fn forward_scratch_mrope(
     mrope: Option<&MropeCtx>,
 ) -> HipResult<()> {
     let Some(mc) = mrope else {
-        return forward_scratch(
-            gpu, weights, config, token, pos, kv_cache, dn_state, scratch,
-        );
+        return forward_scratch(gpu, weights, config, token, pos, kv_cache, dn_state, scratch);
     };
     mark_mrope_forward_ineligible(gpu);
     // Embedding lookup into scratch.x + the 1D pos scalar (still consumed by
@@ -24685,10 +24671,5 @@ mod tests {
         assert!(!ar_graph_eligible_for_kv(true, 1));
         assert!(!ar_graph_eligible_for_kv(true, 128));
         assert!(!ar_graph_eligible_for_kv(false, 0));
-    }
-    #[test]
-    fn automatic_retained_replay_accepts_repaired_deltanet_routes() {
-        assert!(retained_replay_eligible(true));
-        assert!(!retained_replay_eligible(false));
     }
 }

--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -6919,6 +6919,24 @@ fn ar_graph_eligible_for_kv(requested: bool, compact_offset: usize) -> bool {
     requested && compact_offset == 0
 }
 
+#[inline]
+fn retained_replay_eligible(
+    requested: bool,
+    automatic_lifecycle: bool,
+    layer_types: &[LayerType],
+) -> bool {
+    // Production retained AQL/PM4 does not yet reproduce ordinary HIP for
+    // hybrid DeltaNet decode.  The first captured forward is correct, but the
+    // recurrent state diverges after the route takes over.  Keep manual
+    // capture available for the state/logit shadow oracle while serving fails
+    // closed to HIP.  Full-attention-only Qwen carriers are unaffected.
+    requested
+        && !(automatic_lifecycle
+            && layer_types
+                .iter()
+                .any(|kind| *kind == LayerType::LinearAttention))
+}
+
 /// Zero-alloc forward pass using pre-allocated scratch buffers.
 /// Logits stay on GPU in scratch.logits. Returns nothing — caller uses scratch.logits.
 pub fn forward_scratch(
@@ -7051,7 +7069,12 @@ pub fn forward_scratch(
     // Redline's plain-AR capture/replay has the same eligibility contract as
     // the AR HipGraph. MTP/spec re-seed and verify calls must not contaminate
     // or consume the immutable single-token replay sequence.
-    gpu.replay.set_forward_eligible(graph_eligible);
+    let retained_eligible = retained_replay_eligible(
+        graph_eligible,
+        gpu.replay.automatic_lifecycle_enabled(),
+        &config.layer_types,
+    );
+    gpu.replay.set_forward_eligible(retained_eligible);
     gpu.replay
         .begin_auto_capture_if_armed()
         .map_err(|reason| HipError::new(0, reason))?;
@@ -24671,5 +24694,14 @@ mod tests {
         assert!(!ar_graph_eligible_for_kv(true, 1));
         assert!(!ar_graph_eligible_for_kv(true, 128));
         assert!(!ar_graph_eligible_for_kv(false, 0));
+    }
+    #[test]
+    fn automatic_retained_replay_fails_closed_for_deltanet() {
+        let hybrid = [LayerType::LinearAttention, LayerType::FullAttention];
+        let full_only = [LayerType::FullAttention, LayerType::FullAttention];
+        assert!(!retained_replay_eligible(true, true, &hybrid));
+        assert!(retained_replay_eligible(true, false, &hybrid));
+        assert!(retained_replay_eligible(true, true, &full_only));
+        assert!(!retained_replay_eligible(false, true, &full_only));
     }
 }

--- a/crates/rdna-compute/src/norm.rs
+++ b/crates/rdna-compute/src/norm.rs
@@ -2466,41 +2466,51 @@ impl Gpu {
             kernels::GATED_DELTA_NET_SRC,
             "gated_delta_net_f32",
         )?;
-        let func = &self.functions["gated_delta_net_f32"];
-        let mut qp = q.buf.as_ptr();
-        let mut kp = k.buf.as_ptr();
-        let mut vp = v.buf.as_ptr();
-        let mut gp = gate.buf.as_ptr();
-        let mut bp = beta.buf.as_ptr();
-        let mut sp = state.buf.as_ptr();
-        let mut op = output.buf.as_ptr();
-        let mut nt = n_tokens as i32;
-        let mut nh = n_heads as i32;
-        let mut hd = head_dim as i32;
+        let qp = q.buf.as_ptr();
+        let kp = k.buf.as_ptr();
+        let vp = v.buf.as_ptr();
+        let gp = gate.buf.as_ptr();
+        let bp = beta.buf.as_ptr();
+        let sp = state.buf.as_ptr();
+        let op = output.buf.as_ptr();
+        let nt = n_tokens as i32;
+        let nh = n_heads as i32;
+        let hd = head_dim as i32;
         let mut params: Vec<*mut c_void> = vec![
-            &mut qp as *mut _ as *mut c_void,
-            &mut kp as *mut _ as *mut c_void,
-            &mut vp as *mut _ as *mut c_void,
-            &mut gp as *mut _ as *mut c_void,
-            &mut bp as *mut _ as *mut c_void,
-            &mut sp as *mut _ as *mut c_void,
-            &mut op as *mut _ as *mut c_void,
-            &mut nt as *mut _ as *mut c_void,
-            &mut nh as *mut _ as *mut c_void,
-            &mut hd as *mut _ as *mut c_void,
+            &qp as *const _ as *mut c_void,
+            &kp as *const _ as *mut c_void,
+            &vp as *const _ as *mut c_void,
+            &gp as *const _ as *mut c_void,
+            &bp as *const _ as *mut c_void,
+            &sp as *const _ as *mut c_void,
+            &op as *const _ as *mut c_void,
+            &nt as *const _ as *mut c_void,
+            &nh as *const _ as *mut c_void,
+            &hd as *const _ as *mut c_void,
         ];
         // 32 threads, tiled S in LDS (4KB per tile). Grid: [n_heads, 128/8=16].
         let n_tiles = (128 / 4) as u32;
-        unsafe {
-            self.hip.launch_kernel(
-                func,
-                [n_heads as u32, n_tiles, 1],
-                [32, 1, 1],
-                0,
-                self.stream_ref(),
-                &mut params,
-            )
-        }
+        self.launch_maybe_blob(
+            "gated_delta_net_f32",
+            [n_heads as u32, n_tiles, 1],
+            [32, 1, 1],
+            0,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(qp);
+                b.push_ptr(kp);
+                b.push_ptr(vp);
+                b.push_ptr(gp);
+                b.push_ptr(bp);
+                b.push_ptr(sp);
+                b.push_ptr(op);
+                b.push_i32(nt);
+                b.push_i32(nh);
+                b.push_i32(hd);
+                b
+            },
+        )
     }
 
     /// GDN recurrence with Q8-quantized S state — tiled LDS + warp-shuffle.

--- a/crates/rdna-compute/src/norm.rs
+++ b/crates/rdna-compute/src/norm.rs
@@ -250,9 +250,8 @@ impl Gpu {
         let shared_mem = block_size * 4;
 
         let bytes = crate::profile::rmsnorm_bytes(batch * n as usize);
-        let timer = crate::profile::begin_timer(
-            &self.hip, "rmsnorm", "rmsnorm_residual_add_f32", bytes,
-        );
+        let timer =
+            crate::profile::begin_timer(&self.hip, "rmsnorm", "rmsnorm_residual_add_f32", bytes);
         let result = self.launch_maybe_blob(
             "rmsnorm_residual_add_f32",
             [batch as u32, 1, 1],
@@ -261,16 +260,22 @@ impl Gpu {
             &mut params,
             || {
                 let mut b = hip_bridge::KernargBlob::new();
-                b.push_ptr(x_ptr); b.push_ptr(w_ptr); b.push_ptr(res_ptr);
-                b.push_ptr(out_ptr); b.push_i32(n_val); b.push_f32(eps_val);
+                b.push_ptr(x_ptr);
+                b.push_ptr(w_ptr);
+                b.push_ptr(res_ptr);
+                b.push_ptr(out_ptr);
+                b.push_i32(n_val);
+                b.push_f32(eps_val);
                 b
             },
         );
-        if let Some(t) = timer { t.finish(&self.hip); }
+        if let Some(t) = timer {
+            t.finish(&self.hip);
+        }
         result
     }
 
-        /// c = a + b (element-wise)
+    /// c = a + b (element-wise)
     pub fn add_f32(&mut self, a: &GpuTensor, b: &GpuTensor, c: &GpuTensor) -> HipResult<()> {
         self.bind_thread()?;
         self.ensure_kernel("add", kernels::ADD_SRC, "add_f32")?;
@@ -5381,7 +5386,11 @@ impl Gpu {
     /// 1D grid over n, block 256.
     pub fn logit_softcap_f32(&mut self, x: &GpuTensor, n: usize, cap: f32) -> HipResult<()> {
         self.bind_thread()?;
-        self.ensure_kernel("logit_softcap_f32", kernels::LOGIT_SOFTCAP_SRC, "logit_softcap_f32")?;
+        self.ensure_kernel(
+            "logit_softcap_f32",
+            kernels::LOGIT_SOFTCAP_SRC,
+            "logit_softcap_f32",
+        )?;
         let xp = x.buf.as_ptr();
         let ni = n as i32;
         let cp = cap;
@@ -5392,16 +5401,25 @@ impl Gpu {
         ];
         let blocks = ((n + 255) / 256) as u32;
         let bytes = crate::profile::elementwise1_bytes(n);
-        let timer = crate::profile::begin_timer(&self.hip, "elementwise", "logit_softcap_f32", bytes);
+        let timer =
+            crate::profile::begin_timer(&self.hip, "elementwise", "logit_softcap_f32", bytes);
         let result = self.launch_maybe_blob(
-            "logit_softcap_f32", [blocks, 1, 1], [256, 1, 1], 0, &mut params,
+            "logit_softcap_f32",
+            [blocks, 1, 1],
+            [256, 1, 1],
+            0,
+            &mut params,
             || {
                 let mut b = hip_bridge::KernargBlob::new();
-                b.push_ptr(xp); b.push_i32(ni); b.push_f32(cp);
+                b.push_ptr(xp);
+                b.push_i32(ni);
+                b.push_f32(cp);
                 b
             },
         );
-        if let Some(t) = timer { t.finish(&self.hip); }
+        if let Some(t) = timer {
+            t.finish(&self.hip);
+        }
         result
     }
 
@@ -5411,36 +5429,67 @@ impl Gpu {
     /// device buffer holding one i32 position (graph-capture-safe). Grid over
     /// n_rot_pairs, block 256.
     pub fn rope_partial_halved_f32(
-        &mut self, q: &GpuTensor, k: &GpuTensor, pos_buf: &DeviceBuffer,
-        n_heads_q: usize, n_heads_k: usize, head_dim: usize, n_rot_pairs: usize, freq_base: f32,
+        &mut self,
+        q: &GpuTensor,
+        k: &GpuTensor,
+        pos_buf: &DeviceBuffer,
+        n_heads_q: usize,
+        n_heads_k: usize,
+        head_dim: usize,
+        n_rot_pairs: usize,
+        freq_base: f32,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        self.ensure_kernel("rope_partial_halved", kernels::ROPE_PARTIAL_HALVED_SRC, "rope_partial_halved_f32")?;
-        let qp = q.buf.as_ptr(); let kp = k.buf.as_ptr();
+        self.ensure_kernel(
+            "rope_partial_halved",
+            kernels::ROPE_PARTIAL_HALVED_SRC,
+            "rope_partial_halved_f32",
+        )?;
+        let qp = q.buf.as_ptr();
+        let kp = k.buf.as_ptr();
         let pp = pos_buf.as_ptr();
-        let nhq = n_heads_q as i32; let nhk = n_heads_k as i32;
-        let hd = head_dim as i32; let nrp = n_rot_pairs as i32; let fb = freq_base;
+        let nhq = n_heads_q as i32;
+        let nhk = n_heads_k as i32;
+        let hd = head_dim as i32;
+        let nrp = n_rot_pairs as i32;
+        let fb = freq_base;
         let block = 256u32;
         let grid = [((n_rot_pairs as u32) + block - 1) / block, 1, 1];
         let bytes = crate::profile::rope_bytes(n_heads_q, n_heads_k, head_dim);
-        let timer = crate::profile::begin_timer(&self.hip, "rope", "rope_partial_halved_f32", bytes);
+        let timer =
+            crate::profile::begin_timer(&self.hip, "rope", "rope_partial_halved_f32", bytes);
         let mut params: Vec<*mut c_void> = vec![
-            &qp as *const _ as *mut c_void, &kp as *const _ as *mut c_void,
-            &pp as *const _ as *mut c_void, &nhq as *const _ as *mut c_void,
-            &nhk as *const _ as *mut c_void, &hd as *const _ as *mut c_void,
-            &nrp as *const _ as *mut c_void, &fb as *const _ as *mut c_void,
+            &qp as *const _ as *mut c_void,
+            &kp as *const _ as *mut c_void,
+            &pp as *const _ as *mut c_void,
+            &nhq as *const _ as *mut c_void,
+            &nhk as *const _ as *mut c_void,
+            &hd as *const _ as *mut c_void,
+            &nrp as *const _ as *mut c_void,
+            &fb as *const _ as *mut c_void,
         ];
         let result = self.launch_maybe_blob(
-            "rope_partial_halved_f32", grid, [block, 1, 1], 0, &mut params,
+            "rope_partial_halved_f32",
+            grid,
+            [block, 1, 1],
+            0,
+            &mut params,
             || {
                 let mut b = hip_bridge::KernargBlob::new();
-                b.push_ptr(qp); b.push_ptr(kp); b.push_ptr(pp);
-                b.push_i32(nhq); b.push_i32(nhk); b.push_i32(hd); b.push_i32(nrp);
+                b.push_ptr(qp);
+                b.push_ptr(kp);
+                b.push_ptr(pp);
+                b.push_i32(nhq);
+                b.push_i32(nhk);
+                b.push_i32(hd);
+                b.push_i32(nrp);
                 b.push_f32(fb);
                 b
             },
         );
-        if let Some(t) = timer { t.finish(&self.hip); }
+        if let Some(t) = timer {
+            t.finish(&self.hip);
+        }
         result
     }
 
@@ -5491,9 +5540,8 @@ impl Gpu {
         let block = 32u32;
         let grid = [n_heads as u32, 1, 1];
         let bytes = crate::profile::rope_bytes(n_heads, n_kv, head_dim);
-        let timer = crate::profile::begin_timer(
-            &self.hip, "rope", "fused_gemma4_qk_norm_rope_f32", bytes,
-        );
+        let timer =
+            crate::profile::begin_timer(&self.hip, "rope", "fused_gemma4_qk_norm_rope_f32", bytes);
         let mut params: Vec<*mut c_void> = vec![
             &qp as *const _ as *mut c_void,
             &kp as *const _ as *mut c_void,
@@ -5516,14 +5564,24 @@ impl Gpu {
             &mut params,
             || {
                 let mut b = hip_bridge::KernargBlob::new();
-                b.push_ptr(qp); b.push_ptr(kp); b.push_ptr(qnw); b.push_ptr(knw);
+                b.push_ptr(qp);
+                b.push_ptr(kp);
+                b.push_ptr(qnw);
+                b.push_ptr(knw);
                 b.push_ptr(pp);
-                b.push_i32(nh); b.push_i32(nkv); b.push_i32(hd); b.push_i32(nrp);
-                b.push_f32(qs); b.push_f32(fb); b.push_f32(ep);
+                b.push_i32(nh);
+                b.push_i32(nkv);
+                b.push_i32(hd);
+                b.push_i32(nrp);
+                b.push_f32(qs);
+                b.push_f32(fb);
+                b.push_f32(ep);
                 b
             },
         );
-        if let Some(t) = timer { t.finish(&self.hip); }
+        if let Some(t) = timer {
+            t.finish(&self.hip);
+        }
         result
     }
 
@@ -5532,9 +5590,16 @@ impl Gpu {
     /// array. Q/K are [batch × n_heads × head_dim] row-major. Grid over
     /// n_rot_pairs × batch, block 256.
     pub fn rope_partial_halved_f32_batched(
-        &mut self, q: &GpuTensor, k: &GpuTensor, positions: &GpuTensor,
-        n_heads_q: usize, n_heads_k: usize, head_dim: usize, n_rot_pairs: usize,
-        freq_base: f32, batch: usize,
+        &mut self,
+        q: &GpuTensor,
+        k: &GpuTensor,
+        positions: &GpuTensor,
+        n_heads_q: usize,
+        n_heads_k: usize,
+        head_dim: usize,
+        n_rot_pairs: usize,
+        freq_base: f32,
+        batch: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
         self.ensure_kernel(
@@ -5542,35 +5607,58 @@ impl Gpu {
             kernels::ROPE_PARTIAL_HALVED_BATCHED_SRC,
             "rope_partial_halved_f32_batched",
         )?;
-        let qp = q.buf.as_ptr(); let kp = k.buf.as_ptr();
+        let qp = q.buf.as_ptr();
+        let kp = k.buf.as_ptr();
         let pp = positions.buf.as_ptr();
-        let nhq = n_heads_q as i32; let nhk = n_heads_k as i32;
-        let hd = head_dim as i32; let nrp = n_rot_pairs as i32; let fb = freq_base;
+        let nhq = n_heads_q as i32;
+        let nhk = n_heads_k as i32;
+        let hd = head_dim as i32;
+        let nrp = n_rot_pairs as i32;
+        let fb = freq_base;
         let bz = batch as i32;
         let block = 256u32;
         let grid = [((n_rot_pairs as u32) + block - 1) / block, batch as u32, 1];
         let bytes = batch * crate::profile::rope_bytes(n_heads_q, n_heads_k, head_dim);
-        let timer = crate::profile::begin_timer(&self.hip, "rope", "rope_partial_halved_f32_batched", bytes);
+        let timer = crate::profile::begin_timer(
+            &self.hip,
+            "rope",
+            "rope_partial_halved_f32_batched",
+            bytes,
+        );
         let mut params: Vec<*mut c_void> = vec![
-            &qp as *const _ as *mut c_void, &kp as *const _ as *mut c_void,
-            &pp as *const _ as *mut c_void, &nhq as *const _ as *mut c_void,
-            &nhk as *const _ as *mut c_void, &hd as *const _ as *mut c_void,
-            &nrp as *const _ as *mut c_void, &fb as *const _ as *mut c_void,
+            &qp as *const _ as *mut c_void,
+            &kp as *const _ as *mut c_void,
+            &pp as *const _ as *mut c_void,
+            &nhq as *const _ as *mut c_void,
+            &nhk as *const _ as *mut c_void,
+            &hd as *const _ as *mut c_void,
+            &nrp as *const _ as *mut c_void,
+            &fb as *const _ as *mut c_void,
             &bz as *const _ as *mut c_void,
         ];
         let result = self.launch_maybe_blob(
-            "rope_partial_halved_f32_batched", grid, [block, 1, 1], 0, &mut params,
+            "rope_partial_halved_f32_batched",
+            grid,
+            [block, 1, 1],
+            0,
+            &mut params,
             || {
                 let mut b = hip_bridge::KernargBlob::new();
-                b.push_ptr(qp); b.push_ptr(kp); b.push_ptr(pp);
-                b.push_i32(nhq); b.push_i32(nhk); b.push_i32(hd); b.push_i32(nrp);
-                b.push_f32(fb); b.push_i32(bz);
+                b.push_ptr(qp);
+                b.push_ptr(kp);
+                b.push_ptr(pp);
+                b.push_i32(nhq);
+                b.push_i32(nhk);
+                b.push_i32(hd);
+                b.push_i32(nrp);
+                b.push_f32(fb);
+                b.push_i32(bz);
                 b
             },
         );
-        if let Some(t) = timer { t.finish(&self.hip); }
+        if let Some(t) = timer {
+            t.finish(&self.hip);
+        }
         result
     }
-
-
 }

--- a/crates/rdna-compute/src/replay.rs
+++ b/crates/rdna-compute/src/replay.rs
@@ -104,14 +104,9 @@ fn gfx1010_dependency_policy_from_config(
     device_name: &str,
 ) -> Result<Gfx1010DependencyPolicy, String> {
     let raw = hipfire_config::process_value("HIPFIRE_REPLAY_PM4_GFX1010_DEPENDENCY");
-    let policy =
-        gfx1010_dependency_policy_from_value(architecture, device_name, raw.as_deref())?;
+    let policy = gfx1010_dependency_policy_from_value(architecture, device_name, raw.as_deref())?;
     if gfx1010_release_wait_required(architecture, device_name) {
-        let source = if raw.is_none() {
-            "default"
-        } else {
-            "explicit"
-        };
+        let source = if raw.is_none() { "default" } else { "explicit" };
         eprintln!("[redline] gfx1010 PM4 dependency mode={policy:?} ({source})");
     }
     Ok(policy)
@@ -4852,8 +4847,7 @@ mod tests {
     #[test]
     fn gfx1010_dependency_policy_defaults_to_release_wait() {
         assert_eq!(
-            gfx1010_dependency_policy_from_value(Pm4Architecture::Gfx10, "gfx1010", None)
-                .unwrap(),
+            gfx1010_dependency_policy_from_value(Pm4Architecture::Gfx10, "gfx1010", None).unwrap(),
             Gfx1010DependencyPolicy::ReleaseWait
         );
         assert_eq!(
@@ -4894,12 +4888,9 @@ mod tests {
             "true",
             "falsé",
         ] {
-            let err = gfx1010_dependency_policy_from_value(
-                Pm4Architecture::Gfx10,
-                "gfx1010",
-                Some(raw),
-            )
-            .unwrap_err();
+            let err =
+                gfx1010_dependency_policy_from_value(Pm4Architecture::Gfx10, "gfx1010", Some(raw))
+                    .unwrap_err();
             assert!(
                 err.contains("HIPFIRE_REPLAY_PM4_GFX1010_DEPENDENCY"),
                 "missing key in error for {raw:?}: {err}"

--- a/crates/rdna-compute/src/replay.rs
+++ b/crates/rdna-compute/src/replay.rs
@@ -924,6 +924,15 @@ fn pointer_effects(kernel: &str) -> Option<Vec<PointerEffect>> {
             write(56),
             write(80),
         ]),
+        "gated_delta_net_f32" => Some(vec![
+            read(0),
+            read(8),
+            read(16),
+            read(24),
+            read(32),
+            write(40),
+            write(48),
+        ]),
         "gated_norm_f32" => Some(vec![read(0), read(8), read(16), write(24)]),
         "gated_norm_mq_rotate_gfx1100" | "gated_norm_mq_rotate_gfx1151" => Some(vec![
             read(0),
@@ -1323,7 +1332,31 @@ fn expected_kernarg_bytes(kernel: &str) -> Option<usize> {
         | "fused_qkvza_hfq4g256_ldsx8"
         | "fused_qkvza_hfq4g256_reduce_chain"
         | "gated_delta_net_q8_fast" => Some(96),
+        "gated_delta_net_f32" => Some(80),
         _ => None,
+    }
+}
+
+fn apply_qwen_q8_full_attention_visibility(
+    launches: &[RecordedHipLaunch],
+    headers: &mut [HeaderPolicy],
+) {
+    // The Q8 full-attention body carries intermediate Q/K/V, tile reductions,
+    // and the gated attention result through separate global-memory buffers.
+    // Same-queue barriers alone reproduced stale intermediates on gfx1201;
+    // restoring the captured HIP dispatches' system scopes for this narrow
+    // body makes the multi-position AQL state/logit/KV shadow bit-exact.
+    debug_assert_eq!(launches.len(), headers.len());
+    let mut full_attention_body = false;
+    for (launch, header) in launches.iter().zip(headers) {
+        let kernel = launch.kernel.as_str();
+        full_attention_body |= kernel == "fused_qkv_hfq4g256";
+        if full_attention_body {
+            *header = HeaderPolicy::RECORDED_DISPATCH;
+        }
+        if full_attention_body && kernel == "gemv_hfq4g256_residual" {
+            full_attention_body = false;
+        }
     }
 }
 
@@ -3260,6 +3293,13 @@ impl ReplayController {
         self.request != ReplayBackendRequest::Hip && self.state != ReplayState::Fallback
     }
 
+    /// Whether this controller owns the production one-shot capture lifecycle.
+    /// Manual shadow/profiling controllers deliberately remain available for
+    /// diagnosing routes which are not yet safe for automatic serving.
+    pub fn automatic_lifecycle_enabled(&self) -> bool {
+        self.auto_lifecycle
+    }
+
     pub fn should_auto_finalize_capture(&self) -> bool {
         self.auto_lifecycle && self.is_recording()
     }
@@ -3467,6 +3507,7 @@ impl ReplayController {
                 _ => {}
             }
         }
+        apply_qwen_q8_full_attention_visibility(&self.recorded[..prefix], &mut headers);
         let graph = if self.request == ReplayBackendRequest::Auto {
             SingleQueueBatchGraph::create_unprofiled_with_dispatch_headers(
                 &device,
@@ -5082,6 +5123,48 @@ mod tests {
 
         assert!(expected_kernarg_bytes("unknown_kernel_xyz").is_none());
         assert!(pointer_effects("unknown_kernel_xyz").is_none());
+    }
+
+    #[test]
+    fn deltanet_f32_retained_effect_contract_covers_recurrent_state() {
+        assert_eq!(expected_kernarg_bytes("gated_delta_net_f32"), Some(80));
+        let effects = pointer_effects("gated_delta_net_f32").expect("GDN FP32 contract");
+        assert_eq!(effects.len(), 7);
+        assert_eq!(effects[5].offset, 40);
+        assert_eq!(effects[5].mode, RecordedAccessMode::Write);
+        assert_eq!(effects[6].offset, 48);
+        assert_eq!(effects[6].mode, RecordedAccessMode::Write);
+    }
+
+    #[test]
+    fn qwen_q8_full_attention_aql_body_uses_system_visibility() {
+        let launch = |kernel: &str| RecordedHipLaunch {
+            kernel: kernel.to_owned(),
+            artifact: None,
+            grid: [1; 3],
+            block: [32, 1, 1],
+            shared_mem: 0,
+            grid_binding: None,
+            kernarg: Vec::new(),
+            accesses: None,
+        };
+        let launches = vec![
+            launch("before"),
+            launch("fused_qkv_hfq4g256"),
+            launch("attention_flash_q8_0_tile"),
+            launch("attention_flash_q8_0_reduce"),
+            launch("gemv_hfq4g256_residual"),
+            launch("after"),
+        ];
+        let mut headers = vec![HeaderPolicy::BATCH_BOUNDARY_INTERNAL_SERIAL; launches.len()];
+
+        apply_qwen_q8_full_attention_visibility(&launches, &mut headers);
+
+        assert_eq!(headers[0], HeaderPolicy::BATCH_BOUNDARY_INTERNAL_SERIAL);
+        assert!(headers[1..=4]
+            .iter()
+            .all(|header| *header == HeaderPolicy::RECORDED_DISPATCH));
+        assert_eq!(headers[5], HeaderPolicy::BATCH_BOUNDARY_INTERNAL_SERIAL);
     }
 
     #[test]

--- a/crates/rdna-compute/src/replay.rs
+++ b/crates/rdna-compute/src/replay.rs
@@ -358,6 +358,18 @@ impl Pm4Commands {
         }
     }
 
+    fn gfx12_system_acquire(&mut self) -> Result<(), String> {
+        match self {
+            Self::Gfx12(commands) => {
+                commands.acquire_system_gfx12();
+                Ok(())
+            }
+            Self::Legacy { .. } => {
+                Err("gfx12 system acquire requested for a legacy PM4 stream".to_owned())
+            }
+        }
+    }
+
     #[cfg(test)]
     fn dependency_mode(&self) -> Option<LegacyDependencyMode> {
         match self {
@@ -2409,6 +2421,12 @@ fn required_mid_acquire(previous: &str, current: &str) -> bool {
     )
 }
 
+/// Reused rotate destinations need their stale GC12 vector-cache line
+/// invalidated before the writer executes in a retained IB.
+fn requires_gfx12_pre_dispatch_vmem_acquire(current: &str) -> bool {
+    current == "mq_rotate_x" || current == "fused_silu_mul_mq_rotate"
+}
+
 fn conservative_mid_acquire_except(previous: &str, current: &str, excluded: Option<&str>) -> bool {
     if previous.starts_with("gated_delta_net_q8_compact2_")
         || current.starts_with("gated_delta_net_q8_compact2_")
@@ -3844,7 +3862,13 @@ impl ReplayController {
                         }
                         Pm4WaitPolicy::Resource => resources_independent,
                     };
-                    if !independent {
+                    // GC12 can retain a vector-cache line for the reused
+                    // rotated-output allocation across dispatches in one IB.
+                    // Invalidate it before the writer starts; a consumer-side
+                    // acquire after the writer is too late for this hazard.
+                    let gfx12_pre_dispatch_acquire = pm4_architecture == Pm4Architecture::Gfx12
+                        && requires_gfx12_pre_dispatch_vmem_acquire(current);
+                    if gfx12_pre_dispatch_acquire || !independent {
                         dependency_waits += 1;
                         boundary.wait_compute_idle = true;
                         commands.wait_compute_idle()?;
@@ -3854,7 +3878,11 @@ impl ReplayController {
                         || self
                             .pm4_mid_acquire_policy
                             .acquire_between(previous, current);
-                    if acquire {
+                    if gfx12_pre_dispatch_acquire {
+                        dependency_acquires += 1;
+                        boundary.acquire_vmem = true;
+                        commands.gfx12_system_acquire()?;
+                    } else if acquire {
                         dependency_acquires += 1;
                         boundary.acquire_vmem = pm4_vmem_acquire_enabled(
                             pm4_architecture,
@@ -5434,6 +5462,16 @@ mod tests {
         assert!(!independent_sibling(
             "gemv_hfq4g256_moe_gate_up_k8_indexed",
             "fused_silu_mul_mq_rotate",
+        ));
+    }
+
+    #[test]
+    fn gfx12_rotated_vmem_writers_require_a_pre_dispatch_acquire() {
+        for producer in ["mq_rotate_x", "fused_silu_mul_mq_rotate"] {
+            assert!(requires_gfx12_pre_dispatch_vmem_acquire(producer));
+        }
+        assert!(!requires_gfx12_pre_dispatch_vmem_acquire(
+            "gemv_hfq4g256_residual"
         ));
     }
 

--- a/crates/rdna-compute/src/replay.rs
+++ b/crates/rdna-compute/src/replay.rs
@@ -122,17 +122,21 @@ enum Gfx11EntryAcquirePolicy {
 
 impl Pm4Architecture {
     fn from_device(device: &GpuDevice) -> Result<Self, String> {
-        let name = device.name().to_ascii_lowercase();
+        Self::from_name(device.name())
+    }
+
+    fn from_name(device_name: &str) -> Result<Self, String> {
+        let name = device_name.to_ascii_lowercase();
         if name.starts_with("gfx10") {
             Ok(Self::Gfx10)
         } else if name.starts_with("gfx11") {
             Ok(Self::Gfx11)
-        } else if name.starts_with("gfx12") {
+        } else if matches!(name.as_str(), "gfx1200" | "gfx1201") {
             Ok(Self::Gfx12)
         } else {
             Err(format!(
                 "retained PM4 has no certified register map for HSA agent {:?}",
-                device.name()
+                device_name
             ))
         }
     }
@@ -4586,6 +4590,20 @@ fn put_u32(bytes: &mut [u8], offset: usize, value: u32) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pm4_architecture_fails_closed_for_unknown_gfx12_devices() {
+        assert_eq!(
+            Pm4Architecture::from_name("gfx1200"),
+            Ok(Pm4Architecture::Gfx12)
+        );
+        assert_eq!(
+            Pm4Architecture::from_name("GFX1201"),
+            Ok(Pm4Architecture::Gfx12)
+        );
+        assert!(Pm4Architecture::from_name("gfx1202").is_err());
+        assert!(Pm4Architecture::from_name("gfx12-future").is_err());
+    }
 
     const A3B_REPLAY_KERNELS: &[&str] = &[
         "fused_rmsnorm_mq_rotate",

--- a/crates/redline-rocr/src/pm4.rs
+++ b/crates/redline-rocr/src/pm4.rs
@@ -104,7 +104,7 @@ impl Gfx12Pm4CommandBuffer {
     /// scalar, and vector cache visibility without carrying removed gfx11
     /// GL1/metadata bits into the merged RDNA4 hierarchy.
     pub fn acquire_system_gfx12(&mut self) {
-        self.emit_acquire_gcr(0x1c1d1);
+        self.emit_acquire_gcr(0xc3b1);
     }
 
     /// Return a copy bracketed by GPU-clock writes. The end timestamp follows
@@ -260,10 +260,10 @@ impl Gfx12Pm4CommandBuffer {
             packet3(PACKET3_ACQUIRE_MEM, 7, false),
             0,
             u32::MAX,
-            0xff,
+            0x00ff_ffff,
             0,
             0,
-            4,
+            0x0000_000a,
             gcr_cntl,
         ]);
     }
@@ -687,9 +687,13 @@ mod tests {
         assert_eq!(commands.dwords()[0], 0xc006_5800);
         assert_eq!(commands.dwords()[7], 0x1c3f1);
         assert_eq!(commands.dwords()[8], 0xc006_5800);
-        assert_eq!(commands.dwords()[15], 0x1c1d1);
+        assert_eq!(commands.dwords()[15], 0xc3b1);
         assert_eq!(commands.dwords()[16], 0xc006_5800);
         assert_eq!(commands.dwords()[23], 0x10180);
+        for base in [8, 16] {
+            assert_eq!(commands.dwords()[base + 3], 0x00ff_ffff);
+            assert_eq!(commands.dwords()[base + 6], 0x0000_000a);
+        }
         assert_eq!(&commands.dwords()[24..], &[0xc000_4600, 0x407]);
     }
 

--- a/crates/redline-rocr/src/pm4.rs
+++ b/crates/redline-rocr/src/pm4.rs
@@ -18,16 +18,15 @@ const PACKET3_RELEASE_MEM: u32 = 0x49;
 const PACKET3_EVENT_WRITE: u32 = 0x46;
 const PACKET3_ACQUIRE_MEM: u32 = 0x58;
 
-// GFX12 SET_SH_REG offsets. The gfx12 register headers number COMPUTE
-// registers from regCOMPUTE_DISPATCH_INITIATOR=0x1ba0; SET_SH_REG retains the
-// architectural 0x200 COMPUTE window used by ROCr's PM4 builders.
+// GC 12.0.x SET_SH_REG offsets used by gfx1200/gfx1201. The register headers
+// number COMPUTE registers from regCOMPUTE_DISPATCH_INITIATOR=0x1ba0;
+// SET_SH_REG retains the architectural 0x200 COMPUTE window used by ROCr's
+// PM4 builders. GC 12.1 relocates these registers and needs a distinct map.
 const COMPUTE_NUM_THREAD_X: u32 = 0x207;
 const COMPUTE_PGM_LO: u32 = 0x20c;
 const COMPUTE_PGM_RSRC1: u32 = 0x212;
 const COMPUTE_RESOURCE_LIMITS: u32 = 0x215;
-const COMPUTE_TMPRING_SIZE: u32 = 0x216;
-const COMPUTE_PGM_RSRC3_GFX12: u32 = 0x223;
-const COMPUTE_STATIC_THREAD_MGMT_SE0: u32 = 0x230;
+const COMPUTE_PGM_RSRC3_GFX12: u32 = 0x228;
 const COMPUTE_USER_DATA_0: u32 = 0x240;
 
 const LDS_SIZE_MASK: u32 = 0x00ff_8000;
@@ -314,7 +313,6 @@ impl Gfx12Pm4CommandBuffer {
         );
         self.set_sh_regs(COMPUTE_PGM_RSRC1, &[pm4.compute_pgm_rsrc1, rsrc2]);
         self.set_sh_regs(COMPUTE_PGM_RSRC3_GFX12, &[pm4.compute_pgm_rsrc3]);
-        self.set_sh_regs(COMPUTE_TMPRING_SIZE, &[0]);
         self.set_sh_regs(
             COMPUTE_NUM_THREAD_X,
             &[
@@ -323,10 +321,10 @@ impl Gfx12Pm4CommandBuffer {
                 u32::from(geometry.workgroup[2]),
             ],
         );
-        // Match ROCr's direct-dispatch template: all waves per SH are allowed
-        // and every shader engine remains eligible.
+        // Match ROCr's direct-dispatch template: all waves per SH are allowed.
+        // TMPRING and STATIC_THREAD_MGMT belong to the queue/MQD; retain KFD's
+        // scratch and CU-affinity state instead of replacing it per dispatch.
         self.set_sh_regs(COMPUTE_RESOURCE_LIMITS, &[0x3ff]);
-        self.set_sh_regs(COMPUTE_STATIC_THREAD_MGMT_SE0, &[u32::MAX; 4]);
         if needs_kernarg {
             let address = kernarg_address as usize as u64;
             self.set_sh_regs(
@@ -372,10 +370,7 @@ impl Gfx12Pm4CommandBuffer {
 
     fn set_sh_regs(&mut self, first: u32, values: &[u32]) {
         debug_assert!(!values.is_empty());
-        let static_registers = matches!(
-            first,
-            COMPUTE_TMPRING_SIZE | COMPUTE_RESOURCE_LIMITS | COMPUTE_STATIC_THREAD_MGMT_SE0
-        );
+        let static_registers = first == COMPUTE_RESOURCE_LIMITS;
         if !self.cache_dynamic_registers && !static_registers {
             self.emit_set_sh_regs(first, values);
             return;
@@ -669,6 +664,11 @@ mod tests {
         assert_eq!(packet3(PACKET3_DISPATCH_DIRECT, 4, true), 0xc003_1502);
         assert_eq!(packet3(PACKET3_EVENT_WRITE, 1, false), 0xc000_4600);
         assert_eq!(packet3(PACKET3_ACQUIRE_MEM, 7, false), 0xc006_5800);
+    }
+
+    #[test]
+    fn gfx120x_program_resource_offset_matches_gc_12_0_headers() {
+        assert_eq!(COMPUTE_PGM_RSRC3_GFX12, 0x228);
     }
 
     #[test]

--- a/registry/redline-golden-v1.json
+++ b/registry/redline-golden-v1.json
@@ -7,7 +7,7 @@
     "file": "qwen3.6-35b-a3b.mq4r",
     "size_bytes": 18700048128,
     "sha256": "4685c140c46b1a6f31a0fd9053bf09d5faf1d2529d715b84794249b66cde0428",
-    "registry_card_sha256": "6a22ac8300e938c3ca562eeb9b5a3159c4e3c8621b1403a69eb3b43eb8707239",
+    "registry_card_sha256": "be7a9f72e572b9e3c33e75954119d6753e0f77c276487ee68717beba9a28fc7f",
     "sampling_profile": "general",
     "sampling_sha256": "6d64d79ecd36dd3f1b026db2fb1ddbcf2e40433349df61c5c182f482e18c6ce4",
     "sampling": {
@@ -71,14 +71,14 @@
         "settle_max_median_drift_pct": 0.5
       },
       "route": {
-        "dispatches": 604,
+        "dispatches": 603,
         "packets": 1,
         "queues": 1,
         "phases": 1,
         "queue_id": 2,
-        "command_dwords": 16832,
+        "command_dwords": 16733,
         "unique_kernels": 22,
-        "sequence_hash": "43754a60ca25f47c",
+        "sequence_hash": "9a15e1013970b7d7",
         "observed_positions": [
           128,
           255
@@ -230,14 +230,14 @@
         "settle_max_median_drift_pct": 0.5
       },
       "route": {
-        "dispatches": 733,
+        "dispatches": 693,
         "packets": 1,
         "queues": 1,
         "phases": 1,
         "queue_id": 2,
-        "command_dwords": 20502,
-        "unique_kernels": 23,
-        "sequence_hash": "3318ffca3daf2338",
+        "command_dwords": 20798,
+        "unique_kernels": 22,
+        "sequence_hash": "c3e02aad4cf40828",
         "observed_positions": [
           128,
           255

--- a/registry/redline-golden-v1.json
+++ b/registry/redline-golden-v1.json
@@ -235,7 +235,7 @@
         "queues": 1,
         "phases": 1,
         "queue_id": 2,
-        "command_dwords": 20511,
+        "command_dwords": 20502,
         "unique_kernels": 23,
         "sequence_hash": "3318ffca3daf2338",
         "observed_positions": [

--- a/scripts/eval_gemma4_eseries.py
+++ b/scripts/eval_gemma4_eseries.py
@@ -355,6 +355,11 @@ def main() -> int:
     parser.add_argument("--repeats", type=int, default=1)
     parser.add_argument("--prefill-batch", type=int, default=8)
     parser.add_argument("--runtime-home", type=Path)
+    parser.add_argument(
+        "--closed-think",
+        action="store_true",
+        help="start generation after a closed thinking span (Qwen no-think validation)",
+    )
     args = parser.parse_args()
     if args.suite == "longbench" and (not args.dataset or not args.manifest):
         parser.error("longbench requires --dataset and --manifest")
@@ -404,6 +409,7 @@ def main() -> int:
         "temperature": 0.0,
         "kv_mode": "q8",
         "prefill_batch": args.prefill_batch,
+        "closed_think": args.closed_think,
         "repeats": args.repeats,
         "manifest": manifest_data,
     }
@@ -440,11 +446,14 @@ def main() -> int:
         if loaded.get("type") != "loaded":
             raise RuntimeError(f"load failed: {loaded}")
         daemon.request({"type": "reset", "attempt_id": 1}, {"reset", "error"}, 60)
-        warm, _ = daemon.request(
-            {
+        warm_request = {
                 "type": "generate", "id": "warmup", "attempt_id": 1,
                 "prompt": "Reply with exactly: ready", "temperature": 0.0, "max_tokens": 8,
-            },
+            }
+        if args.closed_think:
+            warm_request.update(assistant_prefix="closed_think", max_think_tokens=1)
+        warm, _ = daemon.request(
+            warm_request,
             {"done", "error", "aborted"}, args.timeout,
         )
         if warm.get("type") != "done":
@@ -467,6 +476,8 @@ def main() -> int:
                 "repeat_penalty": 1.0,
                 "max_tokens": max_tokens,
             }
+            if args.closed_think:
+                request.update(assistant_prefix="closed_think", max_think_tokens=1)
             started = time.monotonic()
             try:
                 done, events = daemon.request(request, {"done", "error", "aborted"}, args.timeout)

--- a/scripts/redline-greedy-parity.py
+++ b/scripts/redline-greedy-parity.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Production-serving greedy parity gate for Redline auto routing.
+
+Runs identical requests through ordinary HIP and the automatic retained route.
+Unlike the synthetic state shadow, this covers the real prefill -> first direct
+decode -> retained takeover lifecycle and compares committed token streams.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_arm(
+    daemon: Path,
+    model: Path,
+    backend: str,
+    state_quant: str,
+    prompt: str,
+    max_tokens: int,
+    max_seq: int,
+    timeout: float,
+) -> dict:
+    env = dict(os.environ)
+    env.update(
+        HIPFIRE_REPLAY_BACKEND=backend,
+        HIPFIRE_REPLAY_TRANSPORT="pm4",
+        HIPFIRE_EMIT_TOKEN_IDS="1",
+        HIPFIRE_AR_GRAPH="0",
+        HIPFIRE_GRAPH="0",
+    )
+    messages = [
+        {
+            "type": "load",
+            "model": str(model),
+            "params": {
+                "max_seq": max_seq,
+                "kv_mode": "q8",
+                "state_quant": state_quant,
+                "dflash_mode": "off",
+                "mtp_mode": "off",
+                "dspark_mode": "off",
+                "tp": 1,
+                "pp": 1,
+            },
+        },
+        {
+            "type": "generate",
+            "id": f"redline-{backend}-{state_quant}",
+            "attempt_id": 1,
+            "prompt": prompt,
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "repeat_penalty": 1.0,
+            "max_tokens": max_tokens,
+            "max_think_tokens": 1,
+            "assistant_prefix": "closed_think",
+        },
+        {"type": "unload"},
+    ]
+    wire = "".join(json.dumps(row, separators=(",", ":")) + "\n" for row in messages)
+    proc = subprocess.run(
+        [str(daemon)],
+        input=wire,
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=timeout,
+        check=False,
+    )
+    events = []
+    for line in proc.stdout.splitlines():
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    errors = [row for row in events if row.get("type") == "error"]
+    done = next((row for row in reversed(events) if row.get("type") == "done"), None)
+    committed = [row["tok_id"] for row in events if row.get("type") == "committed"]
+    token_text = [row.get("text", "") for row in events if row.get("type") == "token"]
+    stream = committed if committed else token_text
+    visible = "".join(token_text)
+    if proc.returncode != 0 or errors or done is None or not stream:
+        raise RuntimeError(
+            f"{backend}/{state_quant} failed: exit={proc.returncode} "
+            f"errors={errors[:1]} done={done is not None} stream={len(stream)}\n"
+            f"stderr tail:\n{proc.stderr[-4000:]}"
+        )
+    return {
+        "backend": backend,
+        "state_quant": state_quant,
+        "stream": stream,
+        "visible": visible,
+        "done": done,
+        "stderr_tail": proc.stderr[-4000:],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument(
+        "--daemon", type=Path, default=Path("target/release/examples/daemon")
+    )
+    parser.add_argument(
+        "--prompt",
+        default="Explain KV Cache in large-language-model inference with practical details.",
+    )
+    parser.add_argument("--max-tokens", type=int, default=64)
+    parser.add_argument("--max-seq", type=int, default=2048)
+    parser.add_argument(
+        "--state-quant", choices=("q8", "fp32"), action="append", dest="states"
+    )
+    parser.add_argument("--timeout", type=float, default=900.0)
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args()
+
+    model = args.model.expanduser().resolve()
+    daemon = args.daemon.expanduser().resolve()
+    if not model.is_file() or not daemon.is_file():
+        parser.error(f"missing model or daemon: model={model} daemon={daemon}")
+    states = args.states or ["q8", "fp32"]
+    report = {"model": str(model), "daemon": str(daemon), "rows": []}
+    passed = True
+    for state in states:
+        hip = run_arm(
+            daemon, model, "hip", state, args.prompt, args.max_tokens, args.max_seq, args.timeout
+        )
+        auto = run_arm(
+            daemon, model, "auto", state, args.prompt, args.max_tokens, args.max_seq, args.timeout
+        )
+        exact = hip["stream"] == auto["stream"]
+        coherent = len(auto["visible"].strip()) >= 8
+        row = {
+            "state_quant": state,
+            "exact": exact,
+            "coherent": coherent,
+            "tokens": len(auto["stream"]),
+            "hip_visible": hip["visible"],
+            "auto_visible": auto["visible"],
+        }
+        report["rows"].append(row)
+        passed &= exact and coherent
+        print(
+            f"state={state} exact={exact} coherent={coherent} tokens={len(auto['stream'])}",
+            flush=True,
+        )
+        if not exact:
+            first = next(
+                (
+                    i
+                    for i, (left, right) in enumerate(zip(hip["stream"], auto["stream"]))
+                    if left != right
+                ),
+                min(len(hip["stream"]), len(auto["stream"])),
+            )
+            print(f"first divergence={first}", flush=True)
+    report["pass"] = passed
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/change_gate/routes.py
+++ b/tools/change_gate/routes.py
@@ -581,11 +581,12 @@ ROUTES: dict[str, Route] = {
             "scripts/redline_daemon_harness.py",
             "--model",
             "{model}",
+            "--skip-prefill",
             "--out",
             "{out}",
         ),
         8.0,
-        "Resident-daemon Redline phase fingerprint + shadow/parity "
+        "Resident-daemon Redline decode fingerprint + shadow/parity "
         "(scripts/redline_daemon_harness.py; docs/VALIDATION.md retained replay claim — "
         "discovery evidence, not product PM4/AQL route proof without REDLINE.md ladder).",
         models=("qwen3.5-4b.mq4",),


### PR DESCRIPTION
## Summary

Fix the gfx1200/gfx1201 retained-PM4 correctness path independently of the rejected `RELEASE_MEM`/`WAIT_REG_MEM` experiment from #543.

- use the GC12.0 `COMPUTE_PGM_RSRC3` SH-register offset and stop programming queue-owned `COMPUTE_TMPRING_SIZE` / `COMPUTE_STATIC_THREAD_MGMT_SE*` state per dispatch;
- fail closed for unknown future gfx12 device names instead of applying the gfx1200/gfx1201 map by prefix;
- record DeltaNet recurrent-state mutations in the retained resource contract;
- issue the GC12 system acquire immediately before rotate writers that reuse retained output storage, preventing stale vector-cache lines from surviving across replays;
- reseal the changed gfx1100/gfx1201 route identities and add a production greedy HIP/PM4 parity harness;
- scope the change-gate Redline capture to decode, which is the retained route under test.

This does not restore the disproven barrier half of #543 and makes no claim to solve the platform-specific inversion tracked in #534.

Diff note: the repository's changed-file rustfmt gate reformats each touched Rust file in full, including pre-existing beta formatting debt. Those mechanical changes are isolated in the `style: format changed redline paths` commit.

Closes #587.

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [x] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [ ] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template — touch only when refining the new-arch reference)
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [x] docs / CI / scripts

## Correctness and performance evidence

All production A/Bs used `qwen3.6-35b-a3b.mq4r` (SHA-256 `4685c140c46b1a6f31a0fd9053bf09d5faf1d2529d715b84794249b66cde0428`), greedy sampling, Q8 KV, graphs off, isolated daemon homes, and identical prompts for the HIP and auto/PM4 arms.

### LongBench-v2 hard30

Dataset MD5: `394813558a296ba824e9ccc2c43c31fb`; 30 prompts, raw prompt length 20,400-30,216 tokens, `max_seq=32768`, `max_tokens=96`, closed-think evaluation.

| Machine | HIP parse/correct | PM4 parse/correct | HIP decode median | PM4 decode median | Paired decode ratio | Paired prefill ratio | Prediction equality |
|---|---:|---:|---:|---:|---:|---:|---:|
| gfx1100 GPU1 | 24/30, 8/30 | 24/30, 8/30 | 108.85 tok/s | 120.20 tok/s | 1.1025x (+10.25%) | 0.9986x (-0.14%) | 30/30 exact |
| gfx1201 R9700 | 22/30, 10/30 | 22/30, 10/30 | 114.90 tok/s | 139.60 tok/s | 1.2243x (+22.43%) | 0.9994x (-0.06%) | 30/30 exact |

Both arms completed 30/30 with zero runtime errors. Each PM4 arm emitted 31 positive route proofs (one warm-up plus 30 measured prompts).

### Five long-decode prompts

Fixture MD5: `14fa7b959ddd90e6680fec319d8097ef`. The prompts cover a KV-cache guide, a RadixAttention guide, story continuation, Snake code, and Tetris code, with per-task caps from 1,536 through 8,192 tokens and `max_seq=16384`.

| Machine | Completed/errors | HIP decode median | PM4 decode median | Paired decode ratio | Paired prefill ratio | Prediction equality |
|---|---:|---:|---:|---:|---:|---:|
| gfx1100 GPU1 | 5/5, 0 | 159.3 tok/s | 195.5 tok/s | 1.2298x (+22.98%) | 0.9909x (-0.91%) | 5/5 exact |
| gfx1201 R9700 | 5/5, 0 | 144.6 tok/s | 185.5 tok/s | 1.2828x (+28.28%) | 0.9844x (-1.56%) | 5/5 exact |

The observed generation lengths were 874-3,571 tokens. Technical prose and code were coherent where inspected. Some outputs hit their task token cap, and the gfx1100 story repeated near its tail, but HIP and PM4 were byte-identical in every task; those are therefore shared model/cap behaviours rather than retained-route divergence. Each PM4 arm emitted six positive route proofs.

After the final fail-closed architecture guard, an additional 256-token Q8 greedy replay passed on both gfx1100 and gfx1201 with `exact=True` and `coherent=True`.

## Test plan

- [ ] `./scripts/no-gpu-ci.sh` passes, or equivalent CI job is green — all relevant checks pass; the script reaches the pre-existing beta-wide `unit.env-docs` drift listed below
- [x] `cargo build --release --workspace --features deltanet`
- [x] `cargo test --lib --workspace --features deltanet`
- [x] `python3 -m tools.change_gate plan --base origin/beta` — 8 selected, 0 blocked
- [ ] `python3 -m tools.change_gate run --base origin/beta` — 6/8 pass; the two failures are independently controlled below
- [ ] `./scripts/speed-gate.sh --fast` within locked baseline — locked gfx1100 baseline is stale; same-machine beta control is neutral below
- [x] focused `rdna-compute` fail-closed unit test
- [x] gfx1100 and gfx1201 Redline capture/shadow/parity
- [x] gfx1100 and gfx1201 production Q8 route proof and greedy parity
- [x] LongBench-v2 hard30 HIP/PM4 A/B on gfx1100 and gfx1201
- [x] five long-decode HIP/PM4 A/B on gfx1100 and gfx1201

<details><summary>change_gate telemetry and controlled failures</summary>

```text
change_gate: FAIL
host gfx=gfx1100 rocm=6.19.14
base 8a8ed770a5bbe571f33318255c16d909405ab108
head 83a21bce88419dda0837ae78367741634668caaa

detect.kernels-channel  pass
redline.capture         pass
speed.arch-fast         fail
unit.env-docs           fail
unit.hipfire-registry   pass
unit.rdna-compute       pass (165 tests)
unit.redline-crates     pass
unit.tools-redline      pass
blocked routes          0
```

`redline.capture` recorded 426 launches / 19 kernels / sequence hash `eafb504002e1d6c6`, with stable execution and bit-exact AQL shadow output.

`speed.arch-fast` measured 141.7 tok/s against the locked 178 tok/s floor. A detached worktree at the exact `origin/beta` base measured 142.2 tok/s on the same machine and hot cache; this branch measured 142.3 tok/s under the same manual command (+0.07% versus beta). The failure is therefore a stale/mismatched locked baseline, not a branch regression.

`unit.env-docs` reports existing production `HIPFIRE_*` reads across Gemma, Glimmer, DeepSeek, VL, CLI, config, loader, and quantize. This diff introduces no environment-variable reads. The same beta-wide debt is the only terminal failure in the full `no-gpu-ci.sh` run.

</details>

## Architecture-trait change?

No.
