### PR TITLE
perf(qwen35): accelerate MQ4 decode and DFlash sidecar

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35.rs
@@ -436,7 +436,10 @@ impl MropeCtx {
             "MropeCtx::pos3 called below base ({pos} < {})",
             self.base
         );
-        match pos.checked_sub(self.base).and_then(|i| self.positions.get(i)) {
+        match pos
+            .checked_sub(self.base)
+            .and_then(|i| self.positions.get(i))
+        {
             Some(p) => *p,
             None => [pos as i32 + self.rope_delta; 3],
         }
@@ -18054,7 +18057,9 @@ pub fn forward_scratch_mrope(
     mrope: Option<&MropeCtx>,
 ) -> HipResult<()> {
     let Some(mc) = mrope else {
-        return forward_scratch(gpu, weights, config, token, pos, kv_cache, dn_state, scratch);
+        return forward_scratch(
+            gpu, weights, config, token, pos, kv_cache, dn_state, scratch,
+        );
     };
     mark_mrope_forward_ineligible(gpu);
     // Embedding lookup into scratch.x + the 1D pos scalar (still consumed by
@@ -19644,9 +19649,11 @@ fn kv_cache_attention_dispatch(
         ..kv_cache.tier_inputs()
     })
     .map_err(|e| HipError::new(0, &e.to_string()))?;
-    let fused_epilogue = qwen35_fa_epilogue_enabled(gpu, config, wo)
-        && plan.write_key == hipfire_dispatch::types::KernelKey::KvWriteQ8_0
+    let q8_route = plan.write_key == hipfire_dispatch::types::KernelKey::KvWriteQ8_0
         && plan.attend_key == hipfire_dispatch::types::KernelKey::AttnFlashQ8_0;
+    let asym3_route = plan.write_key == hipfire_dispatch::types::KernelKey::KvWriteAsym3
+        && plan.attend_key == hipfire_dispatch::types::KernelKey::AttnFlashAsym3;
+    let fused_epilogue = qwen35_fa_epilogue_enabled(gpu, config, wo) && (q8_route || asym3_route);
     let io = AttnParams {
         q: &s.fa_q,
         k: &s.fa_k,
@@ -20262,6 +20269,8 @@ impl<'a> ForwardBindings for Qwen35Bindings<'a> {
                         &s.pos_buf,
                         config.norm_eps,
                         config.rope_theta,
+                        config.n_heads,
+                        config.n_kv_heads,
                     )?;
                 } else {
                     gpu.rope_partial_interleaved_f32(
@@ -20395,10 +20404,10 @@ impl<'a> ForwardBindings for Qwen35Bindings<'a> {
                         config.norm_eps,
                     )?;
                 }
-                if gdn_compact2_enabled(gpu, config, self.n_v_heads, self.dn_state.quant) {
-                    // The compact Q8 recurrence maps state head h to Q/K head
-                    // h/2 directly. Leave the normalized tensors compact and
-                    // remove this materialization dispatch from the replay tape.
+                if gdn_compact_qk_div(gpu, config, self.n_v_heads, self.dn_state.quant).is_some() {
+                    // The compact Q8 recurrence maps each state head directly
+                    // to its shared Q/K head. Leave the normalized tensors
+                    // compact and remove this materialization dispatch.
                 } else if config.linear_num_key_heads < self.n_v_heads {
                     let ratio = self.n_v_heads / config.linear_num_key_heads;
                     gpu.repeat_interleave_qk_f32(
@@ -20515,8 +20524,9 @@ impl<'a> ForwardBindings for Qwen35Bindings<'a> {
                 config.linear_value_head_dim,
             ),
             StateQuant::Q8 => {
-                if gdn_compact2_enabled(gpu, config, self.n_v_heads, dn.quant) {
-                    gpu.gated_delta_net_q8_compact2(
+                if let Some(qk_head_div) = gdn_compact_qk_div(gpu, config, self.n_v_heads, dn.quant)
+                {
+                    gpu.gated_delta_net_q8_compact(
                         &s.dn_q_raw,
                         &s.dn_k_raw,
                         &s.dn_v,
@@ -20528,6 +20538,7 @@ impl<'a> ForwardBindings for Qwen35Bindings<'a> {
                         1,
                         self.n_v_heads,
                         config.linear_value_head_dim,
+                        qk_head_div,
                         dn.ef_residual(i),
                     )
                 } else {
@@ -20629,12 +20640,52 @@ fn gdn_compact2_enabled(
     arch_enabled && quant == StateQuant::Q8 && config.linear_num_key_heads * 2 == n_v_heads
 }
 
-/// Certified gfx1100 Radiowave schedule: keep DeltaNet's normalized output on
-/// chip and feed the exact MQ rotation directly from LDS. The fixed A3B shape
-/// lets two independent 128-value heads form one 256-value MQ group without
-/// changing either operation's arithmetic order. Enabled by default for the
-/// admitted shape; set `HIPFIRE_GATED_NORM_MQ_ROTATE=0` to restore the two-
-/// dispatch schedule.
+/// 3:1 compact-QK route for Qwen3.6-27B dense. A 512-token graph-on A/B/B/A
+/// measured +0.45%, while profiling confirmed 853 -> 805 dispatches/token and
+/// a net 64.35 us/token reduction in GPU compute. Set
+/// `HIPFIRE_GDN_COMPACT3=0` to restore explicit Q/K materialization.
+fn gdn_compact3_enabled(
+    gpu: &Gpu,
+    config: &Qwen35Config,
+    n_v_heads: usize,
+    quant: StateQuant,
+) -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    let enabled = *ENABLED.get_or_init(|| {
+        hipfire_config::developer_var("HIPFIRE_GDN_COMPACT3")
+            .ok()
+            .as_deref()
+            != Some("0")
+    });
+    enabled
+        && gpu.arch_caps.is_gfx1100()
+        && quant == StateQuant::Q8
+        && config.linear_num_key_heads * 3 == n_v_heads
+        && qwen36_27b_dense_shape(config, n_v_heads)
+}
+
+fn gdn_compact_qk_div(
+    gpu: &Gpu,
+    config: &Qwen35Config,
+    n_v_heads: usize,
+    quant: StateQuant,
+) -> Option<usize> {
+    if gdn_compact2_enabled(gpu, config, n_v_heads, quant) {
+        Some(2)
+    } else if gdn_compact3_enabled(gpu, config, n_v_heads, quant) {
+        Some(3)
+    } else {
+        None
+    }
+}
+
+/// Keep DeltaNet's normalized output on chip and feed the exact MQ rotation
+/// directly from LDS. Each pair of 128-value heads forms one 256-value MQ
+/// group without changing either operation's arithmetic order. The 32-head
+/// A3B route remains isolated from the gfx1100-only 48-head Qwen3.6-27B route;
+/// the latter measured +0.45% over a 512-token A/B/B/A and removes 48
+/// dispatches/token. Set `HIPFIRE_GATED_NORM_MQ_ROTATE=0` to restore both
+/// explicit operations.
 fn gated_norm_mq_rotate_enabled(
     gpu: &Gpu,
     config: &Qwen35Config,
@@ -20648,10 +20699,13 @@ fn gated_norm_mq_rotate_enabled(
             .as_deref()
             != Some("0")
     });
-    enabled
-        && (gpu.arch_caps.is_gfx1100() || gfx1151_radiowave_fusions_enabled(gpu))
+    let admitted_arch_shape = ((gpu.arch_caps.is_gfx1100()
+        || gfx1151_radiowave_fusions_enabled(gpu))
         && config.dim == 2_048
-        && n_v_heads == 32
+        && n_v_heads == 32)
+        || (gpu.arch_caps.is_gfx1100() && qwen36_27b_dense_shape(config, n_v_heads));
+    enabled
+        && admitted_arch_shape
         && config.linear_value_head_dim == 128
         && wo.k == n_v_heads * config.linear_value_head_dim
         && wo.gpu_dtype == DType::MQ4G256
@@ -20660,7 +20714,9 @@ fn gated_norm_mq_rotate_enabled(
 
 /// Collapse full-attention Q/gate deinterleave, Q/K RMS normalization, and
 /// partial half-split RoPE into one head-local launch on the certified gfx1100
-/// shape. Set `HIPFIRE_QWEN35_FA_PREP_FUSE=0` to retain the legacy path.
+/// shapes. The Qwen3.6-27B q24k4 route measured +0.64% over a 512-token
+/// A/B/B/A and reduced 757 -> 709 dispatches/token. Set
+/// `HIPFIRE_QWEN35_FA_PREP_FUSE=0` to retain the legacy path.
 /// The legacy interleaved-RoPE compatibility mode and diagnostic tap retain
 /// the established multi-dispatch path.
 fn qwen35_fa_prep_enabled(gpu: &Gpu, config: &Qwen35Config) -> bool {
@@ -20672,17 +20728,25 @@ fn qwen35_fa_prep_enabled(gpu: &Gpu, config: &Qwen35Config) -> bool {
             != Some("0")
     });
     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
-    enabled
-        && (gpu.arch_caps.is_gfx1100() || gfx1151_radiowave_fusions_enabled(gpu))
-        && !gpu.flags.rope_interleaved_legacy
+    let admitted_arch_shape = ((gpu.arch_caps.is_gfx1100()
+        || gfx1151_radiowave_fusions_enabled(gpu))
         && config.n_heads == 16
-        && config.n_kv_heads == 2
+        && config.n_kv_heads == 2)
+        || (gpu.arch_caps.is_gfx1100()
+            && qwen36_27b_dense_shape(config, config.linear_num_value_heads)
+            && config.n_heads == 24
+            && config.n_kv_heads == 4);
+    enabled
+        && admitted_arch_shape
+        && !gpu.flags.rope_interleaved_legacy
         && config.head_dim == 256
         && n_rot == 64
 }
 
-/// Pair Q8 K/V cache writes and fold the Qwen output gate plus MQ rotation into
-/// the flash-attention reduce epilogue on the certified gfx1100/MQ4 shape. Set
+/// Fold the Qwen output gate plus MQ rotation into the flash-attention reduce
+/// epilogue on certified gfx1100/MQ4 shapes. Extending the existing Q8 reducer
+/// to Qwen3.6-27B's asym3 route measured +0.37% over a 512-token A/B/B/A and
+/// reduced 709 -> 677 dispatches/token; a 1025-token replay remained exact. Set
 /// `HIPFIRE_QWEN35_FA_EPILOGUE_FUSE=0` to retain the legacy path.
 fn qwen35_fa_epilogue_enabled(gpu: &Gpu, config: &Qwen35Config, wo: &WeightTensor) -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
@@ -20692,10 +20756,16 @@ fn qwen35_fa_epilogue_enabled(gpu: &Gpu, config: &Qwen35Config, wo: &WeightTenso
             .as_deref()
             != Some("0")
     });
-    enabled
-        && (gpu.arch_caps.is_gfx1100() || gfx1151_radiowave_fusions_enabled(gpu))
+    let admitted_arch_shape = ((gpu.arch_caps.is_gfx1100()
+        || gfx1151_radiowave_fusions_enabled(gpu))
         && config.n_heads == 16
-        && config.n_kv_heads == 2
+        && config.n_kv_heads == 2)
+        || (gpu.arch_caps.is_gfx1100()
+            && qwen36_27b_dense_shape(config, config.linear_num_value_heads)
+            && config.n_heads == 24
+            && config.n_kv_heads == 4);
+    enabled
+        && admitted_arch_shape
         && config.head_dim == 256
         && wo.gpu_dtype == DType::MQ4G256
         && wo.awq_scale.is_none()
@@ -20735,22 +20805,42 @@ fn qkvza_scalar_prep_enabled(
         && matches!(dtype, DType::MQ4G256 | DType::HFQ4G256)
 }
 
-/// Radiowave experiment: schedule the independent beta/alpha transforms as
-/// one extra workgroup of the following conv/QK-normalization dispatch. This
-/// keeps the hot QKVZA projection unchanged while deleting the same boundary.
+/// Exact dense Qwen3.6-27B shape shared by its gfx1100 decode selectors.
+fn qwen36_27b_dense_shape(config: &Qwen35Config, n_v_heads: usize) -> bool {
+    config.dim == 5_120
+        && config.n_layers == 64
+        && config.n_heads == 24
+        && config.n_kv_heads == 4
+        && config.head_dim == 256
+        && config.linear_num_key_heads == 16
+        && config.linear_key_head_dim == 128
+        && n_v_heads == 48
+        && config.linear_value_head_dim == 128
+        && config.num_experts == 0
+}
+
+/// Schedule the independent beta/alpha transforms as one extra workgroup of
+/// the following conv/QK-normalization dispatch. This keeps the hot QKVZA
+/// projection unchanged while deleting the same boundary.
 fn conv_scalar_prep_enabled(
     gpu: &Gpu,
     config: &Qwen35Config,
     n_v_heads: usize,
     quant: StateQuant,
 ) -> bool {
-    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    let enabled = *ENABLED.get_or_init(|| {
-        hipfire_config::developer_var("HIPFIRE_CONV_SCALAR_PREP")
-            .ok()
-            .as_deref()
-            == Some("1")
-    });
+    static MODE: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
+    let mode = MODE.get_or_init(|| hipfire_config::developer_var("HIPFIRE_CONV_SCALAR_PREP").ok());
+    let enabled = match mode.as_deref() {
+        Some("0") => false,
+        Some("1") => true,
+        _ => {
+            // Qwen3.6-27B dense on W7900/gfx1100: 512-token graph-on
+            // A/B/B/A measured 35.376->35.657 tok/s (+0.79%) and
+            // 28.105->27.891 ms p50 (-0.76%). The fused route deletes
+            // 48 dispatches/token and stayed exact for 1,025 greedy tokens.
+            qwen36_27b_dense_shape(config, n_v_heads)
+        }
+    };
     let shape = hipfire_config::developer_var("HIPFIRE_CONV_QKNORM_SHAPE").ok();
     enabled
         && gpu.arch_caps.is_gfx1100()
@@ -21873,6 +21963,7 @@ fn forward_scratch_layers_multi(
                                 config.head_dim,
                                 kv_cache.physical_cap,
                                 &s.flash_partials,
+                                None,
                             )?;
                         }
                     } else if kv_cache.quant_asym2 {
@@ -22497,6 +22588,7 @@ fn forward_scratch_layers_multi(
                                 config.head_dim,
                                 kv_cache.physical_cap,
                                 &s.flash_partials,
+                                None,
                             )?;
                         }
                     } else if kv_cache.quant_asym2 {
@@ -23217,6 +23309,30 @@ mod tests {
         assert!(!cfg.norm_topk_prob);
         assert!(!cfg.paged_experts);
         assert_eq!(cfg.vram_budget_bytes, u64::MAX);
+    }
+
+    #[test]
+    fn qwen36_27b_dense_shape_is_exact() {
+        let inner = serde_json::json!({
+            "hidden_size": 5120,
+            "num_hidden_layers": 64,
+            "num_attention_heads": 24,
+            "num_key_value_heads": 4,
+            "head_dim": 256,
+            "vocab_size": 248320,
+            "linear_num_key_heads": 16,
+            "linear_num_value_heads": 48,
+            "linear_key_head_dim": 128,
+            "linear_value_head_dim": 128
+        });
+        let mut cfg = from_config_value(&inner).expect("Qwen3.6-27B shape parse");
+        assert!(qwen36_27b_dense_shape(&cfg, 48));
+        assert!(!qwen36_27b_dense_shape(&cfg, 47));
+        cfg.num_experts = 8;
+        assert!(!qwen36_27b_dense_shape(&cfg, 48));
+        cfg.num_experts = 0;
+        cfg.dim = 2_048;
+        assert!(!qwen36_27b_dense_shape(&cfg, 48));
     }
 
     #[test]

--- a/crates/hipfire-dispatch/src/families/attention.rs
+++ b/crates/hipfire-dispatch/src/families/attention.rs
@@ -914,6 +914,7 @@ fn dispatch_attend(
                     io.head_dim,
                     io.physical_cap,
                     fp,
+                    io.output_gate,
                 ))
             }
             KernelKey::AttnFlashAsym3Fwht => {

--- a/crates/hipfire-runtime/src/dflash.rs
+++ b/crates/hipfire-runtime/src/dflash.rs
@@ -749,15 +749,15 @@ pub struct DflashScratch {
     pub max_ctx_len: usize,
 
     // Block-sized activations (B rows).
-    pub x: GpuTensor,             // [B, hidden] — hidden state rolled across layers
-    pub x_norm: GpuTensor,        // [B, hidden]
-    pub q: GpuTensor,             // [B, q_dim]
-    pub k_noise: GpuTensor,       // [B, kv_dim]
-    pub v_noise: GpuTensor,       // [B, kv_dim]
-    pub gate: GpuTensor,          // [B, intermediate]
-    pub up: GpuTensor,            // [B, intermediate]
-    pub gate_up: GpuTensor,       // [B, intermediate]
-    pub attn_out: GpuTensor,      // [B, q_dim]
+    pub x: GpuTensor,        // [B, hidden] — hidden state rolled across layers
+    pub x_norm: GpuTensor,   // [B, hidden]
+    pub q: GpuTensor,        // [B, q_dim]
+    pub k_noise: GpuTensor,  // [B, kv_dim]
+    pub v_noise: GpuTensor,  // [B, kv_dim]
+    pub gate: GpuTensor,     // [B, intermediate]
+    pub up: GpuTensor,       // [B, intermediate]
+    pub gate_up: GpuTensor,  // [B, intermediate]
+    pub attn_out: GpuTensor, // [B, q_dim]
     /// Shared residual plane. Attention and FFN consume it sequentially,
     /// including under the per-layer FFN graph, so separate planes only pin
     /// another B×hidden allocation without enabling overlap.
@@ -788,9 +788,9 @@ pub struct DflashScratch {
     // rebuild_after_eviction / reset); raw poking is no longer possible.
     pub thlog: TargetHiddenLog,
 
-    /// Per-layer cache of `k_ctx` and `v_ctx` (post-GEMM-of-target_hidden_proj,
-    /// K additionally post-RMSNorm-via-k_norm, both pre-RoPE). Filled
-    /// incrementally as draft_forward sees new target_hidden rows.
+    /// Per-layer cache of `k_ctx` and `v_ctx` (post-GEMM-of-target_hidden_proj;
+    /// K additionally post-RMSNorm and post-RoPE). Filled incrementally as
+    /// draft_forward sees new target_hidden rows.
     ///
     /// The win: without this cache, each `draft_forward` call re-ran 2
     /// big GEMMs per layer over ALL L context rows, even though only the
@@ -804,9 +804,11 @@ pub struct DflashScratch {
     ///
     /// Shapes: each entry is `[max_ctx, kv_dim]` f32.
     /// The valid extent of these caches (rows `[0..thlog.proj_cached_rows())`
-    /// have finished fc + hidden_norm projection, per-layer wk/wv GEMMs, and
-    /// k_norm; still pre-RoPE). Tracked by `thlog` so it stays consistent with
-    /// the upload watermark.
+    /// have finished fc + hidden_norm projection, per-layer wk/wv GEMMs,
+    /// k_norm, and K RoPE). Tracked by `thlog` so it stays consistent with the
+    /// upload watermark. Caching post-RoPE is important: absolute positions of
+    /// committed rows do not change, so re-rotating the full historical K span
+    /// every speculative cycle is redundant O(context × layers) work.
     pub k_ctx_cached: Vec<GpuTensor>,
     pub v_ctx_cached: Vec<GpuTensor>,
 
@@ -1399,7 +1401,7 @@ pub const SEED_BACKFILL_CHUNK: usize = 512;
 ///
 /// No-op in Legacy mode or when `prompt_len <= swa_w`. Sets the thlog
 /// full-layer watermark to `prompt_len` so the forward's lazy fill resumes
-/// from the window edge. All GEMMs/norms are row-local: chunked ==
+/// from the window edge. GEMMs, norms, and RoPE are row-local: chunked ==
 /// monolithic bit-exactly.
 pub fn draft_seed_backfill(
     gpu: &mut Gpu,
@@ -1494,6 +1496,23 @@ pub fn draft_seed_backfill(
                     hd,
                     eps,
                 )?;
+                // The steady-state cache stores post-RoPE K, so cold-seed
+                // backfill must establish the same invariant. Prompt rows are
+                // contiguous absolute positions here; upload just this chunk's
+                // position vector into the reusable device buffer.
+                let positions: Vec<i32> = (r2..r2 + step).map(|p| p as i32).collect();
+                upload_slice_i32(gpu, &scratch.positions_k, &positions)?;
+                let positions_view = scratch.positions_k.sub_offset(0, step);
+                gpu.rope_batched_f32(
+                    &scratch.q, // ignored because n_heads_q = 0
+                    &k_slot,
+                    &positions_view,
+                    0,
+                    cfg.n_kv_heads,
+                    hd,
+                    cfg.rope_theta,
+                    step,
+                )?;
                 r2 += step;
             }
         }
@@ -1578,7 +1597,6 @@ pub fn draft_forward_opts(
     let tot = l + b;
     let h = cfg.hidden;
     let ne = cfg.num_extract();
-    let qd = cfg.q_dim();
     let kvd = cfg.kv_dim();
     let hd = cfg.head_dim;
     let eps = cfg.norm_eps;
@@ -1747,7 +1765,7 @@ pub fn draft_forward_opts(
     let fc_start = cached_rows.max(l.saturating_sub(swa_w));
     let delta = l.saturating_sub(fc_start);
     if delta > 0 {
-        for (row0, slot0, len) in ring_segments(fc_start, l, swa_w) {
+        for (_row0, slot0, len) in ring_segments(fc_start, l, swa_w) {
             let th_slice = scratch
                 .target_hidden
                 .sub_offset(slot0 * ne * h, len * ne * h);
@@ -1840,7 +1858,7 @@ pub fn draft_forward_opts(
         // accepted-context rows of target_hidden_proj. INCREMENTAL PATH:
         // only rows past the layer's fill watermark need projection; earlier
         // rows were projected in a prior call and stored in the per-layer
-        // k_ctx_cached / v_ctx_cached buffers (post-k_norm for K).
+        // k_ctx_cached / v_ctx_cached buffers (post-k_norm + post-RoPE for K).
         //
         // Windowed spans: SWA layers read the last `swa_w` context rows, the
         // last (full-attention) layer the last `full_w`. Each cache is a ring
@@ -1935,6 +1953,22 @@ pub fn draft_forward_opts(
                     hd,
                     eps,
                 )?;
+                // Cache K in its final, absolute-position RoPE domain. The
+                // positions buffer holds the live context suffix starting at
+                // pos_base in windowed mode and the full sequence in Legacy.
+                // RoPE is elementwise, so rotating this delta now is bitwise
+                // equivalent to rotating the same rows after concatenation.
+                let fill_positions = scratch.positions_k.sub_offset(row - pos_base, step);
+                gpu.rope_batched_f32(
+                    &scratch.q, // ignored because n_heads_q = 0
+                    &k_slot,
+                    &fill_positions,
+                    0,
+                    cfg.n_kv_heads,
+                    hd,
+                    theta,
+                    step,
+                )?;
                 row += step;
             }
         }
@@ -1949,10 +1983,41 @@ pub fn draft_forward_opts(
             None
         };
 
-        // Concat K = [K_ctx ring span | K_noise] → k_cat [span + B, kv_dim].
-        // The cached K prefix is already post-k_norm (applied incrementally
-        // above); the noise tail still needs k_norm applied below. Ring
-        // segments assemble in absolute-row order; Legacy = one segment.
+        // Per-head RMSNorm on Q: each of B*n_heads rows, size head_dim,
+        // weight [head_dim].
+        gpu.rmsnorm_batched(
+            &scratch.q,
+            &layer.q_norm,
+            &scratch.q,
+            b * cfg.n_heads,
+            hd,
+            eps,
+        )?;
+        // Normalize and rotate the B-row noise K before concatenation. Q and
+        // noise K share the same absolute block positions, so one RoPE launch
+        // handles both. Historical context K is already post-RoPE in its cache.
+        gpu.rmsnorm_batched(
+            &scratch.k_noise,
+            &layer.k_norm,
+            &scratch.k_noise,
+            b * cfg.n_kv_heads,
+            hd,
+            eps,
+        )?;
+        gpu.rope_batched_f32(
+            &scratch.q,
+            &scratch.k_noise,
+            &scratch.positions_q, // [B]
+            cfg.n_heads,
+            cfg.n_kv_heads,
+            hd,
+            theta,
+            b,
+        )?;
+
+        // Concat finalized K = [post-RoPE context ring | post-RoPE noise]
+        // and V = [context ring | noise]. Ring segments assemble in absolute
+        // row order; Legacy is one segment.
         let noise_bytes = (b * kvd) * 4;
         let mut cat_off = 0usize;
         for (_row0, slot0, len) in ring_segments(span_start, l, layer_w) {
@@ -1977,66 +2042,6 @@ pub fn draft_forward_opts(
             .memcpy_dtod_at(&k_cat_l.buf, cat_off, &scratch.k_noise.buf, 0, noise_bytes)?;
         gpu.hip
             .memcpy_dtod_at(&v_cat_l.buf, cat_off, &scratch.v_noise.buf, 0, noise_bytes)?;
-
-        // Per-head RMSNorm on Q: each of B*n_heads rows, size head_dim,
-        // weight [head_dim].
-        gpu.rmsnorm_batched(
-            &scratch.q,
-            &layer.q_norm,
-            &scratch.q,
-            b * cfg.n_heads,
-            hd,
-            eps,
-        )?;
-        // Per-head RMSNorm on the NOISE tail of K_cat only — the cached
-        // prefix was already normed when it was inserted into the layer's
-        // k_ctx_cached. batch = B × n_kv_heads, applied to the last B rows
-        // of k_cat.
-        {
-            let noise_slot = k_cat_l.sub_offset(span * kvd, b * kvd);
-            gpu.rmsnorm_batched(
-                &noise_slot,
-                &layer.k_norm,
-                &noise_slot,
-                b * cfg.n_kv_heads,
-                hd,
-                eps,
-            )?;
-        }
-
-        // RoPE. rope_batched_f32 expects q and k at the SAME batch size,
-        // rotating at per-row positions. We call it twice with a zero
-        // "head count" on the inactive tensor so its loop doesn't execute.
-        // Call 1: rotate Q with positions_q. Pass k as a valid buffer
-        // (scratch.k_noise is shape-compatible; n_heads_k=0 skips its loop).
-        gpu.rope_batched_f32(
-            &scratch.q,
-            &scratch.k_noise,     // ignored because n_heads_k = 0
-            &scratch.positions_q, // [B]
-            cfg.n_heads,
-            0,
-            hd,
-            theta,
-            b,
-        )?;
-        // Call 2: rotate K_cat with positions_k. n_heads_q = 0 skips Q.
-        // Windowed: the layer's context rows are the suffix [span_start..l),
-        // so its positions slice is the device buffer's contiguous
-        // sub-range [span_start−pos_base..tot−pos_base) — zero extra upload,
-        // absolute RoPE phases preserved. Legacy: both bases 0 ⇒ full buffer.
-        let positions_k_span = scratch
-            .positions_k
-            .sub_offset(span_start - pos_base, span + b);
-        gpu.rope_batched_f32(
-            &scratch.q, // ignored because n_heads_q = 0
-            k_cat_l,
-            &positions_k_span,
-            0,
-            cfg.n_kv_heads,
-            hd,
-            theta,
-            span + b,
-        )?;
 
         if let Some(t) = t1 {
             gpu.hip.device_synchronize()?;

--- a/crates/hipfire-runtime/src/dflash.rs
+++ b/crates/hipfire-runtime/src/dflash.rs
@@ -758,15 +758,14 @@ pub struct DflashScratch {
     pub up: GpuTensor,            // [B, intermediate]
     pub gate_up: GpuTensor,       // [B, intermediate]
     pub attn_out: GpuTensor,      // [B, q_dim]
-    pub attn_proj: GpuTensor,     // [B, hidden]
-    pub residual_attn: GpuTensor, // [B, hidden]
-    pub residual_ffn: GpuTensor,  // [B, hidden]
+    /// Shared residual plane. Attention and FFN consume it sequentially,
+    /// including under the per-layer FFN graph, so separate planes only pin
+    /// another B×hidden allocation without enabling overlap.
+    pub residual: GpuTensor, // [B, hidden]
 
     // Context activations (L rows), where L ≤ max_ctx_len.
     pub target_hidden: GpuTensor,      // [L, num_extract × hidden]
     pub target_hidden_proj: GpuTensor, // [L, hidden]
-    pub k_ctx: GpuTensor,              // [L, kv_dim]
-    pub v_ctx: GpuTensor,              // [L, kv_dim]
 
     // Concatenated K/V (L + B rows).
     pub k_cat: GpuTensor, // [L + B, kv_dim]
@@ -960,14 +959,10 @@ impl DflashScratch {
             up: gpu.alloc_tensor(&[b * inter], DType::F32)?,
             gate_up: gpu.alloc_tensor(&[b * inter], DType::F32)?,
             attn_out: gpu.alloc_tensor(&[b * qd], DType::F32)?,
-            attn_proj: gpu.alloc_tensor(&[b * h], DType::F32)?,
-            residual_attn: gpu.alloc_tensor(&[b * h], DType::F32)?,
-            residual_ffn: gpu.alloc_tensor(&[b * h], DType::F32)?,
+            residual: gpu.alloc_tensor(&[b * h], DType::F32)?,
 
             target_hidden: gpu.alloc_tensor(&[l * ne * h], DType::F32)?,
             target_hidden_proj: gpu.alloc_tensor(&[l * h], DType::F32)?,
-            k_ctx: gpu.alloc_tensor(&[l * kvd], DType::F32)?,
-            v_ctx: gpu.alloc_tensor(&[l * kvd], DType::F32)?,
 
             k_cat: gpu.alloc_tensor(&[tot * kvd], DType::F32)?,
             v_cat: gpu.alloc_tensor(&[tot * kvd], DType::F32)?,
@@ -1036,13 +1031,9 @@ impl DflashScratch {
         let _ = gpu.free_tensor(self.up);
         let _ = gpu.free_tensor(self.gate_up);
         let _ = gpu.free_tensor(self.attn_out);
-        let _ = gpu.free_tensor(self.attn_proj);
-        let _ = gpu.free_tensor(self.residual_attn);
-        let _ = gpu.free_tensor(self.residual_ffn);
+        let _ = gpu.free_tensor(self.residual);
         let _ = gpu.free_tensor(self.target_hidden);
         let _ = gpu.free_tensor(self.target_hidden_proj);
-        let _ = gpu.free_tensor(self.k_ctx);
-        let _ = gpu.free_tensor(self.v_ctx);
         let _ = gpu.free_tensor(self.k_cat);
         let _ = gpu.free_tensor(self.v_cat);
         let _ = gpu.free_tensor(self.positions_q);
@@ -1292,10 +1283,10 @@ fn draft_ffn_layer(
     graph_safe: bool,
 ) -> HipResult<()> {
     if graph_safe {
-        gpu.memcpy_dtod_auto(&scratch.residual_ffn.buf, &scratch.x.buf, (b * h) * 4)?;
+        gpu.memcpy_dtod_auto(&scratch.residual.buf, &scratch.x.buf, (b * h) * 4)?;
     } else {
         gpu.hip
-            .memcpy_dtod(&scratch.residual_ffn.buf, &scratch.x.buf, (b * h) * 4)?;
+            .memcpy_dtod(&scratch.residual.buf, &scratch.x.buf, (b * h) * 4)?;
     }
 
     gpu.rmsnorm_batched(&scratch.x, &layer.ffn_norm, &scratch.x_norm, b, h, eps)?;
@@ -1325,9 +1316,9 @@ fn draft_ffn_layer(
         scratch.mq_x_rot.as_ref(),
     )?;
     if graph_safe {
-        gpu.add_f32_graph_safe(&scratch.residual_ffn, &scratch.x, &scratch.x)
+        gpu.add_f32_graph_safe(&scratch.residual, &scratch.x, &scratch.x)
     } else {
-        gpu.add_f32(&scratch.residual_ffn, &scratch.x, &scratch.x)
+        gpu.add_f32(&scratch.residual, &scratch.x, &scratch.x)
     }
 }
 
@@ -1804,7 +1795,7 @@ pub fn draft_forward_opts(
 
         // Residual.
         gpu.hip
-            .memcpy_dtod(&scratch.residual_attn.buf, &scratch.x.buf, (b * h) * 4)?;
+            .memcpy_dtod(&scratch.residual.buf, &scratch.x.buf, (b * h) * 4)?;
 
         // attn_norm.
         gpu.rmsnorm_batched(&scratch.x, &layer.attn_norm, &scratch.x_norm, b, h, eps)?;
@@ -2096,18 +2087,20 @@ pub fn draft_forward_opts(
             None
         };
 
-        // attn_proj = attn_out @ wo^T → [B, hidden]
+        // Write the projection directly into x. The pre-attention x is already
+        // preserved in the shared residual plane, so a dedicated attn_proj
+        // allocation has no lifetime that must overlap this output.
         gemm_dispatch(
             gpu,
             &scratch.attn_out,
             &layer.wo,
-            &scratch.attn_proj,
+            &scratch.x,
             b,
             scratch.mq_x_rot.as_ref(),
         )?;
 
-        // x = residual_attn + attn_proj
-        gpu.add_f32(&scratch.residual_attn, &scratch.attn_proj, &scratch.x)?;
+        // x = residual + projected attention
+        gpu.add_f32(&scratch.residual, &scratch.x, &scratch.x)?;
 
         // Fixed-shape FFN tail. MoE DFlash can optionally capture this as a
         // per-layer/per-B hipGraph; the attention/context work above is left

--- a/crates/rdna-compute/src/attention.rs
+++ b/crates/rdna-compute/src/attention.rs
@@ -110,6 +110,22 @@ pub fn q8_flash_tile_size(
 
 const V_MODE_Q8: i32 = 8;
 
+fn gfx1100_asym3_q8_pair_enabled(gpu: &Gpu, head_dim: usize) -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    gpu.arch_caps.is_gfx1100()
+        && head_dim == 256
+        && !gpu.replay.is_recording()
+        && *ENABLED.get_or_init(|| {
+            // Qwen3.6-27B graph-on decode: three fresh-process samples per
+            // arm measured +0.61% by median (+0.11/+0.45/+0.61% paired),
+            // while attribution removed exactly 16 dispatches/token.
+            hipfire_config::developer_var("HIPFIRE_GFX1100_ASYM3_Q8_PAIR")
+                .ok()
+                .as_deref()
+                != Some("0")
+        })
+}
+
 #[inline]
 fn replay_stable_tile_count(
     actual_tiles: usize,
@@ -3816,56 +3832,8 @@ impl Gpu {
             let ts = tile_size as i32;
             let mt = max_tiles as i32;
             if let Some(gate) = output_gate {
-                let (module, src, kernel) = if self.arch_caps.is_gfx1151() {
-                    (
-                        "attention_flash_q8_0_reduce_gated_mq_rotate_gfx1151",
-                        kernels::ATTENTION_FLASH_Q8_0_REDUCE_GATED_MQ_ROTATE_GFX1151_SRC,
-                        "attention_flash_q8_0_reduce_gated_mq_rotate_gfx1151",
-                    )
-                } else {
-                    (
-                        "attention_flash_q8_0_reduce_gated_mq_rotate_gfx1100",
-                        kernels::ATTENTION_FLASH_Q8_0_REDUCE_GATED_MQ_ROTATE_GFX1100_SRC,
-                        "attention_flash_q8_0_reduce_gated_mq_rotate_gfx1100",
-                    )
-                };
-                self.ensure_kernel(module, src, kernel)?;
-                self.ensure_mq_signs()?;
-                let g_ptr = gate.buf.as_ptr();
-                let s1_ptr = self.scratch.mq_signs1.as_ref().unwrap().buf.as_ptr();
-                let s2_ptr = self.scratch.mq_signs2.as_ref().unwrap().buf.as_ptr();
-                let mut params: Vec<*mut c_void> = vec![
-                    &p_ptr as *const _ as *mut c_void,
-                    &o_ptr as *const _ as *mut c_void,
-                    &g_ptr as *const _ as *mut c_void,
-                    &s1_ptr as *const _ as *mut c_void,
-                    &s2_ptr as *const _ as *mut c_void,
-                    &nh as *const _ as *mut c_void,
-                    &hd as *const _ as *mut c_void,
-                    &pos_ptr as *const _ as *mut c_void,
-                    &ts as *const _ as *mut c_void,
-                    &mt as *const _ as *mut c_void,
-                ];
-                self.launch_maybe_blob(
-                    kernel,
-                    [n_heads as u32, 1, 1],
-                    [256, 1, 1],
-                    ((max_tiles + head_dim) * 4) as u32,
-                    &mut params,
-                    || {
-                        let mut b = hip_bridge::KernargBlob::new();
-                        b.push_ptr(p_ptr);
-                        b.push_ptr(o_ptr);
-                        b.push_ptr(g_ptr);
-                        b.push_ptr(s1_ptr);
-                        b.push_ptr(s2_ptr);
-                        b.push_i32(nh);
-                        b.push_i32(hd);
-                        b.push_ptr(pos_ptr);
-                        b.push_i32(ts);
-                        b.push_i32(mt);
-                        b
-                    },
+                self.attention_flash_reduce_gated_mq_rotate_gfx1100(
+                    partials, out, gate, pos_buf, n_heads, head_dim, tile_size, max_tiles,
                 )?;
             } else {
                 const KERNEL: &str = "attention_flash_q8_0_reduce";
@@ -4202,6 +4170,63 @@ impl Gpu {
         head_dim: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
+        if gfx1100_asym3_q8_pair_enabled(self, head_dim) {
+            const KERNEL: &str = "kv_cache_write_asym3_q8_pair_gfx1100";
+            self.ensure_givens4_kernel(
+                KERNEL,
+                kernels::KV_CACHE_WRITE_ASYM3_Q8_PAIR_GFX1100_SRC,
+                KERNEL,
+            )?;
+            let kd = k_dst.buf.as_ptr();
+            let vd = v_dst.buf.as_ptr();
+            let ks = k_src.buf.as_ptr();
+            let vs = v_src.buf.as_ptr();
+            let p = pos_buf.as_ptr();
+            let ct = cos_theta.buf.as_ptr();
+            let st = sin_theta.buf.as_ptr();
+            let nkv = n_kv_heads as i32;
+            let hd = head_dim as i32;
+            let mut params: Vec<*mut c_void> = vec![
+                &kd as *const _ as *mut c_void,
+                &vd as *const _ as *mut c_void,
+                &ks as *const _ as *mut c_void,
+                &vs as *const _ as *mut c_void,
+                &p as *const _ as *mut c_void,
+                &ct as *const _ as *mut c_void,
+                &st as *const _ as *mut c_void,
+                &nkv as *const _ as *mut c_void,
+                &hd as *const _ as *mut c_void,
+            ];
+            let q8_blocks = n_kv_heads * head_dim / 32;
+            let k_bytes =
+                n_kv_heads * head_dim * 4 + n_kv_heads * (4 + head_dim * 3 / 8) + head_dim * 4;
+            let bytes = k_bytes + crate::profile::kv_cache_write_q8_0_bytes(n_kv_heads, head_dim);
+            let timer = crate::profile::begin_timer(&self.hip, "kv_write", KERNEL, bytes);
+            let result = self.launch_maybe_blob(
+                KERNEL,
+                [(n_kv_heads + q8_blocks) as u32, 1, 1],
+                [32, 1, 1],
+                ((head_dim + 32) * 4) as u32,
+                &mut params,
+                || {
+                    let mut b = hip_bridge::KernargBlob::new();
+                    b.push_ptr(kd);
+                    b.push_ptr(vd);
+                    b.push_ptr(ks);
+                    b.push_ptr(vs);
+                    b.push_ptr(p);
+                    b.push_ptr(ct);
+                    b.push_ptr(st);
+                    b.push_i32(nkv);
+                    b.push_i32(hd);
+                    b
+                },
+            );
+            if let Some(t) = timer {
+                t.finish(&self.hip);
+            }
+            return result;
+        }
         self.ensure_givens4_kernel(
             "kv_cache_write_asym_k_givens3",
             kernels::KV_CACHE_WRITE_ASYM_K_GIVENS3_SRC,
@@ -6273,6 +6298,7 @@ impl Gpu {
         head_dim: usize,
         max_seq: usize,
         partials: &GpuTensor,
+        output_gate: Option<&GpuTensor>,
     ) -> HipResult<()> {
         self.bind_thread()?;
         const TILE_SIZE: usize = 128;
@@ -6334,6 +6360,12 @@ impl Gpu {
             }
         }
 
+        if let Some(gate) = output_gate {
+            return self.attention_flash_reduce_gated_mq_rotate_gfx1100(
+                partials, out, gate, pos_buf, n_heads, head_dim, TILE_SIZE, max_tiles,
+            );
+        }
+
         self.ensure_kernel(
             "attention_flash_q8_0_reduce",
             kernels::ATTENTION_FLASH_Q8_0_REDUCE_SRC,
@@ -6369,6 +6401,79 @@ impl Gpu {
             }
         }
         Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn attention_flash_reduce_gated_mq_rotate_gfx1100(
+        &mut self,
+        partials: &GpuTensor,
+        out: &GpuTensor,
+        gate: &GpuTensor,
+        pos_buf: &DeviceBuffer,
+        n_heads: usize,
+        head_dim: usize,
+        tile_size: usize,
+        max_tiles: usize,
+    ) -> HipResult<()> {
+        let (module, src, kernel) = if self.arch_caps.is_gfx1151() {
+            (
+                "attention_flash_q8_0_reduce_gated_mq_rotate_gfx1151",
+                kernels::ATTENTION_FLASH_Q8_0_REDUCE_GATED_MQ_ROTATE_GFX1151_SRC,
+                "attention_flash_q8_0_reduce_gated_mq_rotate_gfx1151",
+            )
+        } else {
+            (
+                "attention_flash_q8_0_reduce_gated_mq_rotate_gfx1100",
+                kernels::ATTENTION_FLASH_Q8_0_REDUCE_GATED_MQ_ROTATE_GFX1100_SRC,
+                "attention_flash_q8_0_reduce_gated_mq_rotate_gfx1100",
+            )
+        };
+        self.ensure_kernel(module, src, kernel)?;
+        self.ensure_mq_signs()?;
+
+        let p_ptr = partials.buf.as_ptr();
+        let o_ptr = out.buf.as_ptr();
+        let g_ptr = gate.buf.as_ptr();
+        let s1_ptr = self.scratch.mq_signs1.as_ref().unwrap().buf.as_ptr();
+        let s2_ptr = self.scratch.mq_signs2.as_ref().unwrap().buf.as_ptr();
+        let nh = n_heads as i32;
+        let hd = head_dim as i32;
+        let pos_ptr = pos_buf.as_ptr();
+        let ts = tile_size as i32;
+        let mt = max_tiles as i32;
+        let mut params: Vec<*mut c_void> = vec![
+            &p_ptr as *const _ as *mut c_void,
+            &o_ptr as *const _ as *mut c_void,
+            &g_ptr as *const _ as *mut c_void,
+            &s1_ptr as *const _ as *mut c_void,
+            &s2_ptr as *const _ as *mut c_void,
+            &nh as *const _ as *mut c_void,
+            &hd as *const _ as *mut c_void,
+            &pos_ptr as *const _ as *mut c_void,
+            &ts as *const _ as *mut c_void,
+            &mt as *const _ as *mut c_void,
+        ];
+        self.launch_maybe_blob(
+            kernel,
+            [n_heads as u32, 1, 1],
+            [256, 1, 1],
+            ((max_tiles + head_dim) * 4) as u32,
+            &mut params,
+            || {
+                let mut b = hip_bridge::KernargBlob::new();
+                b.push_ptr(p_ptr);
+                b.push_ptr(o_ptr);
+                b.push_ptr(g_ptr);
+                b.push_ptr(s1_ptr);
+                b.push_ptr(s2_ptr);
+                b.push_i32(nh);
+                b.push_i32(hd);
+                b.push_ptr(pos_ptr);
+                b.push_i32(ts);
+                b.push_i32(mt);
+                b
+            },
+        )
     }
 
     /// Fused K+V write for asym2: K at givens2 (rotated 2-bit), V at Q8_0 (normal space).

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -3332,6 +3332,12 @@ impl Gpu {
                     "fused_gate_up_hfq4g256",
                     kernels::FUSED_GATE_UP_HFQ4G256_SRC.to_string(),
                 ));
+                if self.arch_caps.is_gfx1100() {
+                    specs.push((
+                        "fused_gate_up_hfq4g256_stage_x32_gfx1100",
+                        kernels::FUSED_GATE_UP_HFQ4G256_STAGE_X32_GFX1100_SRC.to_string(),
+                    ));
+                }
                 // gfx906/gfx908/gfx94x wave64-native variants — cut
                 // wavefront pressure in half on the hottest kernels. Wave32
                 // block=[32,1,1] kernels otherwise waste the upper 32 lanes
@@ -3445,6 +3451,12 @@ impl Gpu {
                     "fused_gate_up_hfq4g256",
                     kernels::FUSED_GATE_UP_HFQ4G256_SRC.to_string(),
                 ));
+                if self.arch_caps.is_gfx1100() {
+                    specs.push((
+                        "fused_gate_up_hfq4g256_stage_x32_gfx1100",
+                        kernels::FUSED_GATE_UP_HFQ4G256_STAGE_X32_GFX1100_SRC.to_string(),
+                    ));
+                }
                 specs.push((
                     "fused_rmsnorm_mq_rotate",
                     kernels::FUSED_RMSNORM_MQ_ROTATE_SRC.to_string(),
@@ -3666,6 +3678,12 @@ impl Gpu {
                     "kv_cache_write_asym_k_givens3",
                     assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS3_SRC),
                 ));
+                if self.arch_caps.is_gfx1100() && head_dim == 256 {
+                    specs.push((
+                        "kv_cache_write_asym3_q8_pair_gfx1100",
+                        assemble_asym(kernels::KV_CACHE_WRITE_ASYM3_Q8_PAIR_GFX1100_SRC),
+                    ));
+                }
                 specs.push((
                     "kv_cache_write_asym_k_givens3_batched",
                     assemble_asym(kernels::KV_CACHE_WRITE_ASYM_K_GIVENS3_BATCHED_SRC),

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -2549,6 +2549,9 @@ impl Gpu {
         bias: Option<(*mut c_void, *mut c_void, *mut c_void)>,
     ) -> HipResult<()> {
         self.bind_thread()?;
+        // Qwen3.6-27B MQ4 on gfx1100: staging each 32-value activation quad
+        // before the K=5120 FullAttention QKV weight stream reduced graph-on
+        // ABBA decode 36.668->36.452 tok/s (-0.59%). Keep weight-first order.
         if self.arch_caps.gemv_dp4a_enabled() {
             debug_assert!(bias.is_none(), "Qwen2 bias fold is disabled on dp4a");
             return self.fused_qkv_hfq4g256_dp4a(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k);
@@ -2931,6 +2934,9 @@ impl Gpu {
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
+        // Qwen3.6-27B MQ4 on gfx1100: the existing hoist-X32 schedule for
+        // K=5120 QKVZA reduced graph-on ABBA decode 36.562->36.460 tok/s
+        // (-0.28%). Keep the scalar activation schedule as the default.
         if self.arch_caps.gemv_dp4a_enabled() {
             return self.fused_qkvza_hfq4g256_dp4a(
                 a_qkv, a_z, a_beta, a_alpha, x, y_qkv, y_z, y_beta, y_alpha, qkv_m, z_m, beta_m,
@@ -22405,6 +22411,15 @@ impl Gpu {
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
+        // Qwen3.6-27B MQ4 on gfx1100: direct u16->f16 nibble conversion plus
+        // v_dot2 cut VGPRs 80->71, but narrowed max consecutive VMEM 16->6.
+        // Fresh-process graph-on ABBA measured 36.817->36.523 tok/s (-0.80%).
+        // Pairing independent gate/up waves in one 64-thread workgroup stayed
+        // bit-exact with the same 80 VGPR and VMEM16 issue window, but reduced
+        // graph-on decode 36.727->36.476 tok/s (-0.68%). Keep 32-thread WGs.
+        // Reusing the batched WMMA kernel at B=1 stayed coherent but repeated
+        // its 16-column work plus per-layer F32->F16 casts: graph-on ABBA fell
+        // 35.844->29.848 tok/s (-16.73%). Keep WMMA for real batches only.
         // gfx906 dp4a opt-in: pre-quantize x to Q8_1 and use the
         // v_dot4_i32_i8 path. PMC at 2026-05-05 showed this kernel
         // was memory-bound; dp4a's 75% x-traffic reduction lands on
@@ -22421,7 +22436,176 @@ impl Gpu {
             && gate_m == 19_968
             && up_m == 19_968
             && k == 6_656;
-        let (func_name, block, grid_x) = if glimmer_gate_up_k6656_gfx1100 {
+        static GFX1100_DENSE_GATE_UP_STAGE_X32: OnceLock<bool> = OnceLock::new();
+        let dense_gate_up_stage_x32_gfx1100 = self.arch_caps.is_gfx1100()
+            && gate_m == 17_408
+            && up_m == 17_408
+            && k == 5_120
+            && *GFX1100_DENSE_GATE_UP_STAGE_X32.get_or_init(|| {
+                hipfire_config::developer_var("HIPFIRE_GFX1100_DENSE_GATE_UP_STAGE_X32")
+                    .map_or(true, |value| value != "0")
+            });
+        static GFX1100_DENSE_GATE_UP_PAIR: OnceLock<bool> = OnceLock::new();
+        let dense_gate_up_pair_gfx1100 = self.arch_caps.is_gfx1100()
+            && gate_m == 17_408
+            && up_m == 17_408
+            && k == 5_120
+            && *GFX1100_DENSE_GATE_UP_PAIR.get_or_init(|| {
+                hipfire_config::developer_var("HIPFIRE_GFX1100_DENSE_GATE_UP_PAIR").as_deref()
+                    == Ok("1")
+            });
+        static GFX1100_DENSE_GATE_UP_PAIR2: OnceLock<bool> = OnceLock::new();
+        let dense_gate_up_pair2_gfx1100 = self.arch_caps.is_gfx1100()
+            && gate_m == 17_408
+            && up_m == 17_408
+            && k == 5_120
+            && *GFX1100_DENSE_GATE_UP_PAIR2.get_or_init(|| {
+                hipfire_config::developer_var("HIPFIRE_GFX1100_DENSE_GATE_UP_PAIR2").as_deref()
+                    == Ok("1")
+            });
+        static GFX1100_DENSE_GATE_UP_DOT_REFORM: OnceLock<bool> = OnceLock::new();
+        // Qwen3.6-27B MQ4, W7900/gfx1100: two fresh-process alternating
+        // campaigns measured +0.42% and +0.49% decode throughput. Keep this
+        // explicit because the algebraic rewrite changes FP association even
+        // though the screened 65-token greedy trace remained byte-exact.
+        let dense_gate_up_dot_reform_gfx1100 = self.arch_caps.is_gfx1100()
+            && gate_m == 17_408
+            && up_m == 17_408
+            && k == 5_120
+            && *GFX1100_DENSE_GATE_UP_DOT_REFORM.get_or_init(|| {
+                hipfire_config::developer_var("HIPFIRE_GFX1100_DENSE_GATE_UP_DOT_REFORM")
+                    .as_deref()
+                    == Ok("1")
+            });
+        static GFX1100_DENSE_GATE_UP_QUAD_PREFETCH: OnceLock<bool> = OnceLock::new();
+        // Qwen3.6-27B MQ4, W7900/gfx1100: a fresh-process 128-token
+        // A/B/B/A measured +0.42% throughput and -0.42% p50 latency. Keep
+        // opt-in: 92 VGPR remains spill-free, but the gain is too small to
+        // promote without broader hardware evidence.
+        let dense_gate_up_quad_prefetch_gfx1100 = self.arch_caps.is_gfx1100()
+            && gate_m == 17_408
+            && up_m == 17_408
+            && k == 5_120
+            && *GFX1100_DENSE_GATE_UP_QUAD_PREFETCH.get_or_init(|| {
+                hipfire_config::developer_var(
+                    "HIPFIRE_GFX1100_DENSE_GATE_UP_QUAD_PREFETCH",
+                )
+                .as_deref()
+                    == Ok("1")
+            });
+        static GFX1100_DENSE_GATE_UP_SETPRIO: OnceLock<bool> = OnceLock::new();
+        let dense_gate_up_setprio_gfx1100 = self.arch_caps.is_gfx1100()
+            && gate_m == 17_408
+            && up_m == 17_408
+            && k == 5_120
+            && *GFX1100_DENSE_GATE_UP_SETPRIO.get_or_init(|| {
+                hipfire_config::developer_var("HIPFIRE_GFX1100_DENSE_GATE_UP_SETPRIO")
+                    .as_deref()
+                    == Ok("1")
+            });
+        static GFX1100_DENSE_GATE_UP_LANE0_HEADERS: OnceLock<bool> = OnceLock::new();
+        let dense_gate_up_lane0_headers_gfx1100 = self.arch_caps.is_gfx1100()
+            && gate_m == 17_408
+            && up_m == 17_408
+            && k == 5_120
+            && *GFX1100_DENSE_GATE_UP_LANE0_HEADERS.get_or_init(|| {
+                hipfire_config::developer_var(
+                    "HIPFIRE_GFX1100_DENSE_GATE_UP_LANE0_HEADERS",
+                )
+                .as_deref()
+                    == Ok("1")
+            });
+        let dense_gate_up_dot_prefetch_gfx1100 = dense_gate_up_dot_reform_gfx1100
+            && dense_gate_up_quad_prefetch_gfx1100;
+        let (func_name, block, grid_x) = if dense_gate_up_pair2_gfx1100 {
+            self.ensure_kernel(
+                "fused_gate_up_hfq4g256_pair2_gfx1100",
+                kernels::FUSED_GATE_UP_HFQ4G256_PAIR2_GFX1100_SRC,
+                "fused_gate_up_hfq4g256_pair2_gfx1100",
+            )?;
+            (
+                "fused_gate_up_hfq4g256_pair2_gfx1100",
+                [32u32, 1, 1],
+                gate_m as u32,
+            )
+        } else if dense_gate_up_pair_gfx1100 {
+            self.ensure_kernel(
+                "fused_gate_up_hfq4g256_pair_gfx1100",
+                kernels::FUSED_GATE_UP_HFQ4G256_PAIR_GFX1100_SRC,
+                "fused_gate_up_hfq4g256_pair_gfx1100",
+            )?;
+            (
+                "fused_gate_up_hfq4g256_pair_gfx1100",
+                [32u32, 1, 1],
+                gate_m as u32,
+            )
+        } else if dense_gate_up_dot_prefetch_gfx1100 {
+            self.ensure_kernel(
+                "fused_gate_up_hfq4g256_dot_prefetch_gfx1100",
+                kernels::FUSED_GATE_UP_HFQ4G256_DOT_PREFETCH_GFX1100_SRC,
+                "fused_gate_up_hfq4g256_dot_prefetch_gfx1100",
+            )?;
+            (
+                "fused_gate_up_hfq4g256_dot_prefetch_gfx1100",
+                [32u32, 1, 1],
+                (gate_m + up_m) as u32,
+            )
+        } else if dense_gate_up_dot_reform_gfx1100 {
+            self.ensure_kernel(
+                "fused_gate_up_hfq4g256_dot_reform_gfx1100",
+                kernels::FUSED_GATE_UP_HFQ4G256_DOT_REFORM_GFX1100_SRC,
+                "fused_gate_up_hfq4g256_dot_reform_gfx1100",
+            )?;
+            (
+                "fused_gate_up_hfq4g256_dot_reform_gfx1100",
+                [32u32, 1, 1],
+                (gate_m + up_m) as u32,
+            )
+        } else if dense_gate_up_quad_prefetch_gfx1100 {
+            self.ensure_kernel(
+                "fused_gate_up_hfq4g256_quad_prefetch_gfx1100",
+                kernels::FUSED_GATE_UP_HFQ4G256_QUAD_PREFETCH_GFX1100_SRC,
+                "fused_gate_up_hfq4g256_quad_prefetch_gfx1100",
+            )?;
+            (
+                "fused_gate_up_hfq4g256_quad_prefetch_gfx1100",
+                [32u32, 1, 1],
+                (gate_m + up_m) as u32,
+            )
+        } else if dense_gate_up_setprio_gfx1100 {
+            self.ensure_kernel(
+                "fused_gate_up_hfq4g256_setprio_gfx1100",
+                kernels::FUSED_GATE_UP_HFQ4G256_SETPRIO_GFX1100_SRC,
+                "fused_gate_up_hfq4g256_setprio_gfx1100",
+            )?;
+            (
+                "fused_gate_up_hfq4g256_setprio_gfx1100",
+                [32u32, 1, 1],
+                (gate_m + up_m) as u32,
+            )
+        } else if dense_gate_up_lane0_headers_gfx1100 {
+            self.ensure_kernel(
+                "fused_gate_up_hfq4g256_lane0_headers_gfx1100",
+                kernels::FUSED_GATE_UP_HFQ4G256_LANE0_HEADERS_GFX1100_SRC,
+                "fused_gate_up_hfq4g256_lane0_headers_gfx1100",
+            )?;
+            (
+                "fused_gate_up_hfq4g256_lane0_headers_gfx1100",
+                [32u32, 1, 1],
+                (gate_m + up_m) as u32,
+            )
+        } else if dense_gate_up_stage_x32_gfx1100 {
+            self.ensure_kernel(
+                "fused_gate_up_hfq4g256_stage_x32_gfx1100",
+                kernels::FUSED_GATE_UP_HFQ4G256_STAGE_X32_GFX1100_SRC,
+                "fused_gate_up_hfq4g256_stage_x32_gfx1100",
+            )?;
+            (
+                "fused_gate_up_hfq4g256_stage_x32_gfx1100",
+                [32u32, 1, 1],
+                (gate_m + up_m) as u32,
+            )
+        } else if glimmer_gate_up_k6656_gfx1100 {
             self.ensure_kernel(
                 "fused_glimmer_gate_up_hfq4g256_k6656_gfx1100",
                 kernels::FUSED_GLIMMER_GATE_UP_HFQ4G256_K6656_GFX1100_SRC,

--- a/crates/rdna-compute/src/gemv.rs
+++ b/crates/rdna-compute/src/gemv.rs
@@ -83,6 +83,41 @@ fn e8_ldsx_enabled() -> bool {
     })
 }
 
+fn gfx1100_awq_norm_direct_enabled(gpu: &Gpu, k: usize) -> bool {
+    use std::sync::OnceLock;
+    static FLAG: OnceLock<bool> = OnceLock::new();
+    if !gpu.arch_caps.is_gfx1100() {
+        return false;
+    }
+    // Keep one symbol implementation for the process lifetime: ensure_kernel
+    // caches functions by symbol, while prefill and decode share this route.
+    // Qwen3.6-27B K=5120 measured +2.44% over a 512-token A/B/B/A; rocprof
+    // measured 14.859 -> 9.116 us/launch, and a 1025-token replay was exact.
+    *FLAG.get_or_init(|| {
+        k == 5_120
+            && hipfire_config::developer_var("HIPFIRE_GFX1100_AWQ_NORM_DIRECT")
+                .ok()
+                .as_deref()
+                != Some("0")
+    })
+}
+
+fn awq_norm_kernel(gpu: &Gpu, k: usize) -> (&'static str, &'static str, u32) {
+    if gfx1100_awq_norm_direct_enabled(gpu, k) {
+        (
+            "fused_rmsnorm_mq_rotate_awq_direct_gfx1100",
+            kernels::FUSED_RMSNORM_MQ_ROTATE_AWQ_DIRECT_GFX1100_SRC,
+            (256 * 4) as u32,
+        )
+    } else {
+        (
+            "fused_rmsnorm_mq_rotate_awq",
+            kernels::FUSED_RMSNORM_MQ_ROTATE_AWQ_SRC,
+            ((k + 256) * 4) as u32,
+        )
+    }
+}
+
 /// HIPFIRE_E8_DGPU_TWIN: on RDNA3 dGPU (gfx1100/1101/1102), route E8 MoE
 /// GEMVs to the 4-way-unroll gfx11_dgpu twin rather than the gfx1151 kernel.
 ///
@@ -2540,11 +2575,8 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         self.ensure_mq_signs()?;
-        self.ensure_kernel(
-            "fused_rmsnorm_mq_rotate_awq",
-            kernels::FUSED_RMSNORM_MQ_ROTATE_AWQ_SRC,
-            "fused_rmsnorm_mq_rotate_awq",
-        )?;
+        let (module, source, shared_mem) = awq_norm_kernel(self, k);
+        self.ensure_kernel(module, source, "fused_rmsnorm_mq_rotate_awq")?;
         let s1_ptr = self.scratch.mq_signs1.as_ref().unwrap().buf.as_ptr();
         let s2_ptr = self.scratch.mq_signs2.as_ref().unwrap().buf.as_ptr();
 
@@ -2566,9 +2598,7 @@ impl Gpu {
             &kv as *const _ as *mut c_void,
             &eps_v as *const _ as *mut c_void,
         ];
-
         let block_size = 256u32;
-        let shared_mem = ((k + 256) * 4) as u32;
         // Bandwidth: read x + weight + awq_scale + signs + write x_rot.
         let bytes = k * 4 * 4 + 2 * 256 * 4;
         let timer =
@@ -2620,11 +2650,8 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         self.ensure_mq_signs()?;
-        self.ensure_kernel(
-            "fused_rmsnorm_mq_rotate_awq",
-            kernels::FUSED_RMSNORM_MQ_ROTATE_AWQ_SRC,
-            "fused_rmsnorm_mq_rotate_awq",
-        )?;
+        let (module, source, shared_mem) = awq_norm_kernel(self, k);
+        self.ensure_kernel(module, source, "fused_rmsnorm_mq_rotate_awq")?;
         let s1_ptr = self.scratch.mq_signs1.as_ref().unwrap().buf.as_ptr();
         let s2_ptr = self.scratch.mq_signs2.as_ref().unwrap().buf.as_ptr();
 
@@ -2647,7 +2674,6 @@ impl Gpu {
             &mut eps_v as *mut _ as *mut c_void,
         ];
         let block_size = 256u32;
-        let shared_mem = ((k + 256) * 4) as u32;
         let bytes = (k * 4 * 4 + 2 * 256 * 4) * batch_size;
         let timer = crate::profile::begin_timer(
             &self.hip,
@@ -3258,10 +3284,10 @@ impl Gpu {
         let k = n_heads.checked_mul(head_dim).ok_or_else(|| {
             hip_bridge::HipError::new(1, "gated_norm_rotate_mq_gfx1100: size overflow")
         })?;
-        if n_heads != 32 || head_dim != 128 {
+        if !matches!(n_heads, 32 | 48) || head_dim != 128 {
             return Err(hip_bridge::HipError::new(
                 1,
-                "gated_norm_rotate_mq_gfx1100: expected 32 heads with head_dim=128",
+                "gated_norm_rotate_mq_gfx1100: expected 32 or 48 heads with head_dim=128",
             ));
         }
         if x.numel() < k || z.numel() < k || weight.numel() < head_dim || x_rot.numel() < k {
@@ -3279,7 +3305,19 @@ impl Gpu {
             ));
         }
         self.ensure_mq_signs()?;
-        let (module, src, kernel) = if self.arch_caps.is_gfx1151() {
+        let (module, src, kernel) = if n_heads == 48 {
+            if !self.arch_caps.is_gfx1100() {
+                return Err(hip_bridge::HipError::new(
+                    1,
+                    "48-head gated norm/MQ rotation is certified only on gfx1100",
+                ));
+            }
+            (
+                "gated_norm_mq_rotate_k6144_gfx1100",
+                kernels::gated_norm_mq_rotate_k6144_gfx1100_src(),
+                "gated_norm_mq_rotate_k6144_gfx1100",
+            )
+        } else if self.arch_caps.is_gfx1151() {
             (
                 "gated_norm_mq_rotate_gfx1151",
                 kernels::GATED_NORM_MQ_ROTATE_GFX1151_SRC,
@@ -6452,6 +6490,9 @@ impl Gpu {
             && self.flags.rdna3_hfq4_lm_head_k2048
             && m == 248_320
             && k == 2_048;
+        // Qwen3.6-27B's K=5120 LM head did not benefit from baking in its 20
+        // groups: graph-on ABBA decode fell 36.633->36.589 tok/s (-0.12%).
+        // Keep the generic loop despite its larger static instruction count.
         let func_name = if gfx1151_lm_head_dot2 {
             self.ensure_kernel(
                 "gemv_hfq4g256_lm_head_dot2_gfx1151",

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -1080,7 +1080,16 @@ pub const FUSED_RMSNORM_MQ_ROTATE_VECSUM_SIGN_CONST_GFX1100_SRC: &str = concat!(
     include_str!("../../../kernels/src/fused_rmsnorm_mq_rotate_vecsum.gfx1100.hip")
 );
 pub const FUSED_RMSNORM_MQ_ROTATE_AWQ_SRC: &str =
+    // gfx1100 K=5120: preserving the reduction tree while replacing its
+    // wave-local tail with shuffles was token-exact but reduced graph-on ABBA
+    // decode 36.922->36.773 tok/s (-0.40%); retain the LDS barrier tree.
+    // Native/refined reciprocal gained 0.3-0.5% but diverged by token 190/286;
+    // a 1025-token-exact FMA quotient correction retained only +0.12% ABBA.
+    // Keep the IEEE divide: its special-case work is not the decode bottleneck.
     include_str!("../../../kernels/src/fused_rmsnorm_mq_rotate_awq.hip");
+pub const FUSED_RMSNORM_MQ_ROTATE_AWQ_DIRECT_GFX1100_SRC: &str =
+    // K=5120 direct float4 path: certified default for Qwen3.6-27B on gfx1100.
+    include_str!("../../../kernels/src/fused_rmsnorm_mq_rotate_awq_direct.gfx1100.hip");
 
 pub const RMSNORM_REDUCE_GFX942_SRC: &str =
     include_str!("../../../kernels/src/rmsnorm_reduce.gfx942.hip");
@@ -1098,6 +1107,18 @@ pub const FUSED_SILU_MUL_MQ_ROTATE_SRC: &str =
     include_str!("../../../kernels/src/fused_silu_mul_mq_rotate.hip");
 pub const GATED_NORM_MQ_ROTATE_GFX1100_SRC: &str =
     include_str!("../../../kernels/src/gated_norm_mq_rotate.gfx1100.hip");
+pub fn gated_norm_mq_rotate_k6144_gfx1100_src() -> &'static str {
+    static SRC: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    SRC.get_or_init(|| {
+        format!(
+            "#define HIPFIRE_GATED_NORM_MQ_ROTATE_KERNEL gated_norm_mq_rotate_k6144_gfx1100\n{}",
+            GATED_NORM_MQ_ROTATE_GFX1100_SRC.replace(
+                "if (n_heads != 32 || head_dim != 128) return;",
+                "if (n_heads != 48 || head_dim != 128) return;",
+            )
+        )
+    })
+}
 pub const GATED_NORM_MQ_ROTATE_GFX1151_SRC: &str = concat!(
     "#define HIPFIRE_GATED_NORM_MQ_ROTATE_KERNEL gated_norm_mq_rotate_gfx1151\n",
     include_str!("../../../kernels/src/gated_norm_mq_rotate.gfx1100.hip")
@@ -2925,12 +2946,6 @@ pub const GEMM_HFQ4G256_RESIDUAL_WMMA_GFX1100_MUSE_RM_PK_SRC: &str =
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_GFX1100_MUSE_RM_PIPE_SRC: &str =
     include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_gfx1100_muse_rm_pipe.hip");
 
-
-
-
-
-
-
 pub const GEMM_HFQ4G256_LMHEAD_WMMA_GFX12_SRC: &str =
     include_str!("../../../kernels/src/gemm_hfq4g256_lmhead_wmma.gfx12.hip");
 // Q8_1 MMQ prefill variant — opt-in via HIPFIRE_MMQ=1, gated to RDNA3/3.5.
@@ -4168,7 +4183,106 @@ pub const ATTENTION_GQA_WARP_DV_SRC: &str =
 
 /// Fused Gate+Up HFQ4-G256: two GEMVs in one launch (saves 1 launch per layer).
 /// Grid: [gate_m + up_m, 1, 1]. Each block processes one row from gate or up weight.
+/// A gfx1100 dense-only SLC-bit A/B was flat: 36.698 -> 36.688 tok/s
+/// (-0.03%, graph-on Qwen3.6-27B, 2026-08-18); retain temporal CPOL zero.
 pub const FUSED_GATE_UP_HFQ4G256_SRC: &str = concat!(
+    "#define HIPFIRE_GFX12_WEIGHT_CACHE_ELIGIBLE 1\n",
+    include_str!("../../../kernels/src/gfx12_weight_cache_policy.inc"),
+    include_str!("../../../kernels/src/fused_gate_up_hfq4g256.hip")
+);
+/// gfx1100 Qwen3.6-27B dense decode: stage the full 32-value activation quad
+/// before the independent weight stream. The production-shape oracle is
+/// bit-exact; isolated ABBA improved 92.645->90.302 us (-2.53%), while three
+/// graph-on model campaigns improved decode by +0.22%, +0.50%, and +0.73%.
+/// Baking in the admitted K=5120 shape keeps 80 VGPR with no spills, reduces
+/// static instructions 575->374, and improved 512-token decode by +0.92%.
+/// Also baking gate_m=up_m=17408 retained 80 VGPR/374 instructions but reduced
+/// graph-on ABBA decode 36.950->36.825 tok/s (-0.34%); keep M runtime-bound.
+/// Relaxing launch bounds from 16 to 8 blocks/CU retained 80 VGPR but grew
+/// static instructions 457->470 and waits 75->78, so the tighter bound stays.
+/// Combining staging with algebraic dequant cut 374->355 instructions but
+/// raised VGPR 80->90, diverged at token 76, and reduced ABBA decode by 0.11%.
+/// A 16-entry subwave nibble LUT kept 80 VGPR but grew 374->391 instructions
+/// and 15->24 waits through 32 extra bpermutes, so it was rejected pre-runtime.
+/// Interleaving gate/up blocks was token-exact with the same 80 VGPR, but its
+/// graph-on ABBA gain was only 0.13%; sequential projection rows remain simpler.
+/// Assigning one HFQ group to each 8-lane subwave cut VMEM issues 16->10 and
+/// VGPR 80->78, but changed the reduction at token 76 and reduced graph-on
+/// ABBA decode 35.706->35.662 tok/s (-0.12%); strided scalar loads stay.
+pub const FUSED_GATE_UP_HFQ4G256_STAGE_X32_GFX1100_SRC: &str = concat!(
+    "#define HIPFIRE_FUSED_GATE_UP_KERNEL fused_gate_up_hfq4g256_stage_x32_gfx1100\n",
+    "#define HIPFIRE_FUSED_GATE_UP_K5120 1\n",
+    "#define HIPFIRE_HFQ4_STAGE_X32 1\n",
+    "#define HIPFIRE_GFX12_WEIGHT_CACHE_ELIGIBLE 1\n",
+    include_str!("../../../kernels/src/gfx12_weight_cache_policy.inc"),
+    include_str!("../../../kernels/src/fused_gate_up_hfq4g256.hip")
+);
+/// gfx1100 dense decode experiment: pair corresponding gate/up rows in one
+/// wave and reuse each activation slice while preserving per-output math.
+pub const FUSED_GATE_UP_HFQ4G256_PAIR_GFX1100_SRC: &str = concat!(
+    "#define HIPFIRE_GFX12_WEIGHT_CACHE_ELIGIBLE 1\n",
+    include_str!("../../../kernels/src/gfx12_weight_cache_policy.inc"),
+    include_str!("../../../kernels/src/fused_gate_up_hfq4g256_pair.gfx1100.hip")
+);
+/// gfx1100 dense decode experiment: pair gate/up rows while retaining two
+/// adjacent HFQ groups to recover VMEM concurrency lost by the pair1 screen.
+/// A fresh-process 128-token A/B/B/A recovered pair1's regression but measured
+/// only +0.28%, showing activation reuse is not a material dense-decode lever.
+pub const FUSED_GATE_UP_HFQ4G256_PAIR2_GFX1100_SRC: &str = concat!(
+    "#define HIPFIRE_FUSED_GATE_UP_PAIR_KERNEL fused_gate_up_hfq4g256_pair2_gfx1100\n",
+    "#define HIPFIRE_GATE_UP_PAIR2 1\n",
+    "#define HIPFIRE_GFX12_WEIGHT_CACHE_ELIGIBLE 1\n",
+    include_str!("../../../kernels/src/gfx12_weight_cache_policy.inc"),
+    include_str!("../../../kernels/src/fused_gate_up_hfq4g256_pair.gfx1100.hip")
+);
+/// gfx1100 dense decode experiment: factor each group's dequantized dot into
+/// `scale * dot(nibble, x) + zero * sum(x)` to shorten the FP dependency chain.
+pub const FUSED_GATE_UP_HFQ4G256_DOT_REFORM_GFX1100_SRC: &str = concat!(
+    "#define HIPFIRE_FUSED_GATE_UP_KERNEL fused_gate_up_hfq4g256_dot_reform_gfx1100\n",
+    "#define HIPFIRE_HFQ4_DOT_REFORM 1\n",
+    "#define HIPFIRE_GFX12_WEIGHT_CACHE_ELIGIBLE 1\n",
+    include_str!("../../../kernels/src/gfx12_weight_cache_policy.inc"),
+    include_str!("../../../kernels/src/fused_gate_up_hfq4g256.hip")
+);
+/// gfx1100 dense decode experiment: issue the next four HFQ groups before
+/// computing the current four so streamed weight fetch overlaps the FMA chain.
+pub const FUSED_GATE_UP_HFQ4G256_QUAD_PREFETCH_GFX1100_SRC: &str = concat!(
+    "#define HIPFIRE_FUSED_GATE_UP_KERNEL fused_gate_up_hfq4g256_quad_prefetch_gfx1100\n",
+    "#define HIPFIRE_HFQ4_QUAD_PREFETCH 1\n",
+    "#define HIPFIRE_GFX12_WEIGHT_CACHE_ELIGIBLE 1\n",
+    include_str!("../../../kernels/src/gfx12_weight_cache_policy.inc"),
+    include_str!("../../../kernels/src/fused_gate_up_hfq4g256.hip")
+);
+/// Combined gfx1100 dense decode screen for the independently positive
+/// dequantization and across-quad prefetch schedules. A fresh-process
+/// 128-token A/C/C/A measured only +0.24%, below either arm alone; retaining
+/// the explicit combination records that the two levers are not additive.
+pub const FUSED_GATE_UP_HFQ4G256_DOT_PREFETCH_GFX1100_SRC: &str = concat!(
+    "#define HIPFIRE_FUSED_GATE_UP_KERNEL fused_gate_up_hfq4g256_dot_prefetch_gfx1100\n",
+    "#define HIPFIRE_HFQ4_DOT_REFORM 1\n",
+    "#define HIPFIRE_HFQ4_QUAD_PREFETCH 1\n",
+    "#define HIPFIRE_GFX12_WEIGHT_CACHE_ELIGIBLE 1\n",
+    include_str!("../../../kernels/src/gfx12_weight_cache_policy.inc"),
+    include_str!("../../../kernels/src/fused_gate_up_hfq4g256.hip")
+);
+/// gfx1100 dense decode experiment: raise wave priority only while issuing
+/// each quad's VMEM loads, then restore normal priority for dequant/FMA work.
+/// A fresh-process 128-token A/B/B/A measured +0.08%, inside noise; retain as
+/// a negative oracle rather than applying FeatherOps' WMMA heuristic to GEMV.
+pub const FUSED_GATE_UP_HFQ4G256_SETPRIO_GFX1100_SRC: &str = concat!(
+    "#define HIPFIRE_FUSED_GATE_UP_KERNEL fused_gate_up_hfq4g256_setprio_gfx1100\n",
+    "#define HIPFIRE_HFQ4_SETPRIO 1\n",
+    "#define HIPFIRE_GFX12_WEIGHT_CACHE_ELIGIBLE 1\n",
+    include_str!("../../../kernels/src/gfx12_weight_cache_policy.inc"),
+    include_str!("../../../kernels/src/fused_gate_up_hfq4g256.hip")
+);
+/// gfx1100 dense decode experiment: load each wave-uniform scale/zero header
+/// on lane 0 and broadcast it through scalar readlane instructions. A
+/// fresh-process 128-token A/B/B/A measured -0.27%; coalescing already absorbs
+/// the redundant addresses, while readlane/wait serialization adds cost.
+pub const FUSED_GATE_UP_HFQ4G256_LANE0_HEADERS_GFX1100_SRC: &str = concat!(
+    "#define HIPFIRE_FUSED_GATE_UP_KERNEL fused_gate_up_hfq4g256_lane0_headers_gfx1100\n",
+    "#define HIPFIRE_HFQ4_LANE0_HEADERS 1\n",
     "#define HIPFIRE_GFX12_WEIGHT_CACHE_ELIGIBLE 1\n",
     include_str!("../../../kernels/src/gfx12_weight_cache_policy.inc"),
     include_str!("../../../kernels/src/fused_gate_up_hfq4g256.hip")
@@ -4226,7 +4340,8 @@ pub const FUSED_GATE_UP_HFQ4G256_WAVE64_SRC: &str =
 // VALUBusy) so dp4a's 75 % x-traffic reduction lands on the right
 // bottleneck. Activations must be pre-quantized to block_q8_1_mmq
 // (use ensure_q8_1_mmq_x). Skip on gemv_residual — it was ILP-bound
-// and got its win from the prefetch variant instead.
+// and got its win from the prefetch variant instead. This remains gfx906-only:
+// hipcc rejects `__builtin_amdgcn_sdot4` on gfx1100 (no `dot1-insts`).
 pub const FUSED_GATE_UP_HFQ4G256_WAVE64_DP4A_SRC: &str =
     include_str!("../../../kernels/src/fused_gate_up_hfq4g256_wave64_dp4a.hip");
 
@@ -4438,6 +4553,8 @@ pub const KV_CACHE_WRITE_ASYM_K_GIVENS4_SRC: &str =
     include_str!("../../../kernels/src/kv_cache_write_asym_k_givens4.hip");
 pub const KV_CACHE_WRITE_ASYM_K_GIVENS3_SRC: &str =
     include_str!("../../../kernels/src/kv_cache_write_asym_k_givens3.hip");
+pub const KV_CACHE_WRITE_ASYM3_Q8_PAIR_GFX1100_SRC: &str =
+    include_str!("../../../kernels/src/kv_cache_write_asym3_q8_pair.gfx1100.hip");
 pub const KV_CACHE_WRITE_ASYM_K_GIVENS2_SRC: &str =
     include_str!("../../../kernels/src/kv_cache_write_asym_k_givens2.hip");
 pub const ATTENTION_FLASH_ASYM4_TILE_SRC: &str =
@@ -4663,6 +4780,16 @@ pub const ROPE_PARTIAL_HALVED_BATCHED_SRC: &str =
 #[cfg(feature = "deltanet")]
 pub const QWEN35_FA_PREP_GFX1100_SRC: &str =
     include_str!("../../../kernels/src/qwen35_fa_prep.gfx1100.hip");
+#[cfg(feature = "deltanet")]
+pub fn qwen36_27b_fa_prep_gfx1100_src() -> &'static str {
+    static SRC: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    SRC.get_or_init(|| {
+        format!(
+            "#define HIPFIRE_QWEN35_FA_PREP_KERNEL qwen36_27b_fa_prep_gfx1100\n{}",
+            QWEN35_FA_PREP_GFX1100_SRC.replace("constexpr int NQ = 16;", "constexpr int NQ = 24;",)
+        )
+    })
+}
 #[cfg(feature = "deltanet")]
 pub const QWEN35_FA_PREP_GFX1151_SRC: &str = concat!(
     "#define HIPFIRE_QWEN35_FA_PREP_KERNEL qwen35_fa_prep_gfx1151\n",
@@ -4923,6 +5050,10 @@ pub const GATED_DELTA_NET_Q8_FAST_SRC: &str =
 /// head directly, eliminating the materializing repeat-interleave launch.
 pub const GATED_DELTA_NET_Q8_COMPACT2_B2_SRC: &str = concat!(
     "#define HIPFIRE_GDN_QK_HEAD_DIV 2\n#define HIPFIRE_GDN_MIN_BLOCKS 2\n#define HIPFIRE_GDN_KERNEL gated_delta_net_q8_compact2_b2\n",
+    include_str!("../../../kernels/src/gated_delta_net_q8_fast.hip")
+);
+pub const GATED_DELTA_NET_Q8_COMPACT3_B2_SRC: &str = concat!(
+    "#define HIPFIRE_GDN_QK_HEAD_DIV 3\n#define HIPFIRE_GDN_MIN_BLOCKS 2\n#define HIPFIRE_GDN_KERNEL gated_delta_net_q8_compact3_b2\n",
     include_str!("../../../kernels/src/gated_delta_net_q8_fast.hip")
 );
 pub const GATED_DELTA_NET_Q8_COMPACT2_B4_SRC: &str = concat!(
@@ -6344,6 +6475,9 @@ mod dispatch_tests {
     fn gfx1100_q8_decode_fusions_are_translation_unit_isolated() {
         assert!(!KV_CACHE_WRITE_Q8_0_SRC.contains("kv_cache_write_q8_0_pair"));
         assert!(KV_CACHE_WRITE_Q8_0_PAIR_GFX1100_SRC.contains("kv_cache_write_q8_0_pair"));
+        assert!(!KV_CACHE_WRITE_ASYM_K_GIVENS3_SRC.contains("kv_cache_write_asym3_q8_pair_gfx1100"));
+        assert!(KV_CACHE_WRITE_ASYM3_Q8_PAIR_GFX1100_SRC
+            .contains("kv_cache_write_asym3_q8_pair_gfx1100"));
         assert!(!ATTENTION_FLASH_Q8_0_REDUCE_SRC
             .contains("attention_flash_q8_0_reduce_gated_mq_rotate_gfx1100"));
         assert!(ATTENTION_FLASH_Q8_0_REDUCE_GATED_MQ_ROTATE_GFX1100_SRC
@@ -6354,12 +6488,34 @@ mod dispatch_tests {
         assert!(GATED_NORM_MQ_ROTATE_GFX1151_SRC.starts_with(
             "#define HIPFIRE_GATED_NORM_MQ_ROTATE_KERNEL gated_norm_mq_rotate_gfx1151"
         ));
+        let k6144 = gated_norm_mq_rotate_k6144_gfx1100_src();
+        assert!(k6144.starts_with(
+            "#define HIPFIRE_GATED_NORM_MQ_ROTATE_KERNEL gated_norm_mq_rotate_k6144_gfx1100"
+        ));
+        assert!(k6144.contains("if (n_heads != 48 || head_dim != 128) return;"));
         assert!(MOE_DOWN_COMBINE_RMSNORM_MQ_ROTATE_VECSUM_GFX1151_SRC.starts_with(
             "#define HIPFIRE_MOE_COMBINE_RMSNORM_MQ_KERNEL moe_down_combine_rmsnorm_mq_rotate_vecsum_gfx1151"
         ));
         #[cfg(feature = "deltanet")]
         assert!(QWEN35_FA_PREP_GFX1151_SRC
             .starts_with("#define HIPFIRE_QWEN35_FA_PREP_KERNEL qwen35_fa_prep_gfx1151"));
+        #[cfg(feature = "deltanet")]
+        {
+            let q24k4 = qwen36_27b_fa_prep_gfx1100_src();
+            assert!(q24k4
+                .starts_with("#define HIPFIRE_QWEN35_FA_PREP_KERNEL qwen36_27b_fa_prep_gfx1100"));
+            assert!(q24k4.contains("constexpr int NQ = 24;"));
+        }
+    }
+
+    #[test]
+    fn gfx1100_awq_direct_keeps_abi_and_drops_full_lds_stage() {
+        assert!(FUSED_RMSNORM_MQ_ROTATE_AWQ_DIRECT_GFX1100_SRC
+            .contains("void fused_rmsnorm_mq_rotate_awq("));
+        assert!(FUSED_RMSNORM_MQ_ROTATE_AWQ_DIRECT_GFX1100_SRC
+            .contains("extern __shared__ float reduce[];"));
+        assert!(!FUSED_RMSNORM_MQ_ROTATE_AWQ_DIRECT_GFX1100_SRC.contains("x_shared"));
+        assert!(FUSED_RMSNORM_MQ_ROTATE_AWQ_SRC.contains("float* x_shared"));
     }
 
     #[test]

--- a/crates/rdna-compute/src/norm.rs
+++ b/crates/rdna-compute/src/norm.rs
@@ -965,11 +965,11 @@ impl Gpu {
         result
     }
 
-    /// Exact gfx1100 Qwen3.6-35B full-attention preparation. Replaces the
+    /// Exact gfx1100 Qwen3.6 full-attention preparation. Replaces the
     /// dependent deinterleave, Q RMS, K RMS, and partial half-split RoPE
     /// dispatches with one head-local launch. Admission is enforced by the
-    /// architecture layer; this launcher intentionally exposes only the fixed
-    /// 16Q/2K, head_dim=256, n_rot=64 shape.
+    /// architecture layer; this launcher exposes only the fixed 16Q/2K and
+    /// 24Q/4K, head_dim=256, n_rot=64 shapes.
     #[cfg(feature = "deltanet")]
     #[allow(clippy::too_many_arguments)]
     pub fn qwen35_fa_prep_gfx1100(
@@ -983,9 +983,29 @@ impl Gpu {
         pos_buf: &hip_bridge::DeviceBuffer,
         eps: f32,
         freq_base: f32,
+        n_heads: usize,
+        n_kv_heads: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        let (module, src, kernel) = if self.arch_caps.is_gfx1151() {
+        if !matches!((n_heads, n_kv_heads), (16, 2) | (24, 4)) {
+            return Err(hip_bridge::HipError::new(
+                1,
+                "fused FA prep requires 16Q/2K or 24Q/4K heads",
+            ));
+        }
+        let (module, src, kernel) = if n_heads == 24 {
+            if !self.arch_caps.is_gfx1100() {
+                return Err(hip_bridge::HipError::new(
+                    1,
+                    "24Q/4K fused FA prep is certified only on gfx1100",
+                ));
+            }
+            (
+                "qwen36_27b_fa_prep_gfx1100",
+                kernels::qwen36_27b_fa_prep_gfx1100_src(),
+                "qwen36_27b_fa_prep_gfx1100",
+            )
+        } else if self.arch_caps.is_gfx1151() {
             (
                 "qwen35_fa_prep_gfx1151",
                 kernels::QWEN35_FA_PREP_GFX1151_SRC,
@@ -1020,10 +1040,18 @@ impl Gpu {
             &ep as *const _ as *mut c_void,
             &fb as *const _ as *mut c_void,
         ];
-        let bytes = (16 * 256 * 3 + 2 * 256 * 2 + 18 * 256) * 4;
+        let bytes = (n_heads * 256 * 3
+            + n_kv_heads * 256 * 2
+            + (n_heads + n_kv_heads) * 256)
+            * 4;
         let timer = crate::profile::begin_timer(&self.hip, "fused", kernel, bytes);
-        let result =
-            self.launch_maybe_blob(kernel, [18, 1, 1], [256, 1, 1], 0, &mut params, || {
+        let result = self.launch_maybe_blob(
+            kernel,
+            [(n_heads + n_kv_heads) as u32, 1, 1],
+            [256, 1, 1],
+            0,
+            &mut params,
+            || {
                 let mut b = hip_bridge::KernargBlob::new();
                 b.push_ptr(qip);
                 b.push_ptr(qp);
@@ -1035,7 +1063,8 @@ impl Gpu {
                 b.push_f32(ep);
                 b.push_f32(fb);
                 b
-            });
+            },
+        );
         if let Some(t) = timer {
             t.finish(&self.hip);
         }
@@ -2659,14 +2688,14 @@ impl Gpu {
         result
     }
 
-    /// Decode-only Q8 GDN path for a 2:1 value-head:QK-head layout.
+    /// Decode-only Q8 GDN path for a compact value-head:QK-head layout.
     ///
-    /// `q` and `k` remain compact (`n_heads / 2` heads). The kernel maps state
-    /// head `h` to Q/K head `h / 2`, avoiding a separate repeat-interleave
-    /// materialization. The launch ABI intentionally matches the regular fast
-    /// kernel so replay's dynamic stochastic-rounding frame patch is shared.
+    /// `q` and `k` remain compact (`n_heads / qk_head_div` heads). The kernel
+    /// maps state head `h` to Q/K head `h / qk_head_div`, avoiding a separate
+    /// repeat-interleave materialization. The launch ABI intentionally matches
+    /// the regular fast kernel so replay's dynamic frame patch is shared.
     #[cfg(feature = "deltanet")]
-    pub fn gated_delta_net_q8_compact2(
+    pub fn gated_delta_net_q8_compact(
         &mut self,
         q: &GpuTensor,
         k: &GpuTensor,
@@ -2679,16 +2708,30 @@ impl Gpu {
         n_tokens: usize,
         n_heads: usize,
         head_dim: usize,
+        qk_head_div: usize,
         ef_residual: Option<&GpuTensor>,
     ) -> HipResult<()> {
         self.bind_thread()?;
+        if !matches!(qk_head_div, 2 | 3) || n_heads % qk_head_div != 0 {
+            return Err(hip_bridge::HipError::new(
+                0,
+                "compact GDN requires a divisible 2:1 or 3:1 value-head:QK-head ratio",
+            ));
+        }
         let gfx1151_r8 = self.arch_caps.is_gfx1151()
             && hipfire_config::developer_var("HIPFIRE_GFX1151_GDN_R8").as_deref() == Ok("1");
         let gfx1151_r4x2 = self.arch_caps.is_gfx1151()
             && hipfire_config::developer_var("HIPFIRE_GFX1151_GDN_R4X2").as_deref() == Ok("1");
         let gfx1151_dpp = self.arch_caps.is_gfx1151()
             && hipfire_config::developer_var("HIPFIRE_GFX1151_GDN_DPP").as_deref() == Ok("1");
-        let (kernel_name, kernel_src, n_tiles, block_size) = if gfx1151_dpp {
+        let (kernel_name, kernel_src, n_tiles, block_size) = if qk_head_div == 3 {
+            (
+                "gated_delta_net_q8_compact3_b2",
+                kernels::GATED_DELTA_NET_Q8_COMPACT3_B2_SRC,
+                128 / 4,
+                32,
+            )
+        } else if gfx1151_dpp {
             (
                 "gated_delta_net_q8_compact2_dpp_gfx1151",
                 kernels::GATED_DELTA_NET_Q8_COMPACT2_DPP_GFX1151_SRC,
@@ -2834,7 +2877,7 @@ impl Gpu {
     /// cannot serve both `s_q8` ([n_heads x HD x HD] per slot) and `s_scales`
     /// ([n_heads x HD] per slot), and `s_ef_residual` was never strided at all.
     /// It was also actively harmful — `gated_delta_net_q8_fast.hip` is the
-    /// shared source for the `gated_delta_net_q8_compact2_*` variants too, so
+    /// shared source for the compact Q/K variants too, so
     /// two extra params changed the ABI of kernels whose launch sites still
     /// packed the old 13, and the single-sequence decode path segfaulted inside
     /// hipModuleLaunchKernel. The params are gone; the ABI is single again.

--- a/crates/rdna-compute/src/replay.rs
+++ b/crates/rdna-compute/src/replay.rs
@@ -601,7 +601,16 @@ const fn write(offset: usize) -> PointerEffect {
 fn pointer_effects(kernel: &str) -> Option<Vec<PointerEffect>> {
     if matches!(
         kernel,
-        "fused_gate_up_hfq4g256" | "fused_gate_up_hfq4g256_k1024_gfx1201"
+        "fused_gate_up_hfq4g256"
+            | "fused_gate_up_hfq4g256_k1024_gfx1201"
+            | "fused_gate_up_hfq4g256_dot_reform_gfx1100"
+            | "fused_gate_up_hfq4g256_dot_prefetch_gfx1100"
+            | "fused_gate_up_hfq4g256_pair_gfx1100"
+            | "fused_gate_up_hfq4g256_pair2_gfx1100"
+            | "fused_gate_up_hfq4g256_quad_prefetch_gfx1100"
+            | "fused_gate_up_hfq4g256_setprio_gfx1100"
+            | "fused_gate_up_hfq4g256_lane0_headers_gfx1100"
+            | "fused_gate_up_hfq4g256_stage_x32_gfx1100"
     ) {
         return Some(vec![read(0), read(8), read(16), write(24), write(32)]);
     }
@@ -715,7 +724,7 @@ fn pointer_effects(kernel: &str) -> Option<Vec<PointerEffect>> {
     {
         return Some(vec![read(0), write(8), write(16)]);
     }
-    if kernel.starts_with("gated_delta_net_q8_compact2_") {
+    if kernel.starts_with("gated_delta_net_q8_compact") {
         return Some(vec![
             read(0),
             read(8),
@@ -925,7 +934,9 @@ fn pointer_effects(kernel: &str) -> Option<Vec<PointerEffect>> {
             write(80),
         ]),
         "gated_norm_f32" => Some(vec![read(0), read(8), read(16), write(24)]),
-        "gated_norm_mq_rotate_gfx1100" | "gated_norm_mq_rotate_gfx1151" => Some(vec![
+        "gated_norm_mq_rotate_gfx1100"
+        | "gated_norm_mq_rotate_k6144_gfx1100"
+        | "gated_norm_mq_rotate_gfx1151" => Some(vec![
             read(0),
             read(8),
             read(16),
@@ -933,7 +944,9 @@ fn pointer_effects(kernel: &str) -> Option<Vec<PointerEffect>> {
             read(32),
             write(40),
         ]),
-        "qwen35_fa_prep_gfx1100" | "qwen35_fa_prep_gfx1151" => Some(vec![
+        "qwen35_fa_prep_gfx1100"
+        | "qwen36_27b_fa_prep_gfx1100"
+        | "qwen35_fa_prep_gfx1151" => Some(vec![
             read(0),
             write(8),
             write(16),
@@ -1130,7 +1143,16 @@ fn expected_kernarg_bytes(kernel: &str) -> Option<usize> {
     }
     if matches!(
         kernel,
-        "fused_gate_up_hfq4g256" | "fused_gate_up_hfq4g256_k1024_gfx1201"
+        "fused_gate_up_hfq4g256"
+            | "fused_gate_up_hfq4g256_k1024_gfx1201"
+            | "fused_gate_up_hfq4g256_dot_reform_gfx1100"
+            | "fused_gate_up_hfq4g256_dot_prefetch_gfx1100"
+            | "fused_gate_up_hfq4g256_pair_gfx1100"
+            | "fused_gate_up_hfq4g256_pair2_gfx1100"
+            | "fused_gate_up_hfq4g256_quad_prefetch_gfx1100"
+            | "fused_gate_up_hfq4g256_setprio_gfx1100"
+            | "fused_gate_up_hfq4g256_lane0_headers_gfx1100"
+            | "fused_gate_up_hfq4g256_stage_x32_gfx1100"
     ) {
         return Some(64);
     }
@@ -1224,7 +1246,7 @@ fn expected_kernarg_bytes(kernel: &str) -> Option<usize> {
         return Some(80);
     }
 
-    if kernel.starts_with("gated_delta_net_q8_compact2_") {
+    if kernel.starts_with("gated_delta_net_q8_compact") {
         return Some(96);
     }
     if kernel == "conv1d_silu_split_qknorm_b256_scalar_prep" {
@@ -1300,8 +1322,10 @@ fn expected_kernarg_bytes(kernel: &str) -> Option<usize> {
         | "conv1d_gated_decode_f32" => Some(48),
         "conv1d_silu_split_f32"
         | "gated_norm_mq_rotate_gfx1100"
+        | "gated_norm_mq_rotate_k6144_gfx1100"
         | "gated_norm_mq_rotate_gfx1151"
         | "qwen35_fa_prep_gfx1100"
+        | "qwen36_27b_fa_prep_gfx1100"
         | "qwen35_fa_prep_gfx1151"
         | "attention_flash_q8_0_reduce_gated_mq_rotate_gfx1100"
         | "attention_flash_q8_0_reduce_gated_mq_rotate_gfx1151"
@@ -2348,8 +2372,8 @@ impl Pm4MidAcquirePolicy {
 }
 
 fn required_mid_acquire(previous: &str, current: &str) -> bool {
-    if previous.starts_with("gated_delta_net_q8_compact2_")
-        || current.starts_with("gated_delta_net_q8_compact2_")
+    if previous.starts_with("gated_delta_net_q8_compact")
+        || current.starts_with("gated_delta_net_q8_compact")
     {
         return true;
     }
@@ -2377,8 +2401,8 @@ fn required_mid_acquire(previous: &str, current: &str) -> bool {
 }
 
 fn conservative_mid_acquire_except(previous: &str, current: &str, excluded: Option<&str>) -> bool {
-    if previous.starts_with("gated_delta_net_q8_compact2_")
-        || current.starts_with("gated_delta_net_q8_compact2_")
+    if previous.starts_with("gated_delta_net_q8_compact")
+        || current.starts_with("gated_delta_net_q8_compact")
     {
         return true;
     }
@@ -3394,7 +3418,7 @@ impl ReplayController {
                 .with_dynamic_group_bytes(launch.shared_mem)
                 .map_err(|error| format!("{symbol}: {error}"))?;
             if launch.kernel == "gated_delta_net_q8_fast"
-                || launch.kernel.starts_with("gated_delta_net_q8_compact2_")
+                || launch.kernel.starts_with("gated_delta_net_q8_compact")
             {
                 if metadata.kernarg_segment_size < 80 {
                     return Err(format!(
@@ -3595,7 +3619,7 @@ impl ReplayController {
                 .validate_geometry(geometry)
                 .map_err(|error| format!("{symbol}: {error}"))?;
             if launch.kernel == "gated_delta_net_q8_fast"
-                || launch.kernel.starts_with("gated_delta_net_q8_compact2_")
+                || launch.kernel.starts_with("gated_delta_net_q8_compact")
             {
                 if metadata.kernarg_segment_size < 80 {
                     return Err(format!(
@@ -4547,8 +4571,10 @@ mod tests {
         "gated_delta_net_q8_fast",
         "gated_norm_f32",
         "gated_norm_mq_rotate_gfx1100",
+        "gated_norm_mq_rotate_k6144_gfx1100",
         "gated_norm_mq_rotate_gfx1151",
         "qwen35_fa_prep_gfx1100",
+        "qwen36_27b_fa_prep_gfx1100",
         "qwen35_fa_prep_gfx1151",
         "mq_rotate_x",
         "gemv_hfq4g256_residual",
@@ -5396,6 +5422,10 @@ mod tests {
             "fused_qk_l2_norm_scale_f32",
             "gated_delta_net_q8_compact2_b2"
         ));
+        assert!(Pm4MidAcquirePolicy::RequiredOnly.acquire_between(
+            "fused_qk_l2_norm_scale_f32",
+            "gated_delta_net_q8_compact3_b2"
+        ));
         assert_eq!(Pm4MidAcquirePolicy::from_value("invalid"), None);
     }
 
@@ -5554,6 +5584,18 @@ mod tests {
         );
         assert!(pointer_effects("gated_delta_net_q8_compact2_b2").is_some());
         assert_eq!(
+            expected_kernarg_bytes("gated_delta_net_q8_compact3_b2"),
+            Some(96)
+        );
+        assert!(pointer_effects("gated_delta_net_q8_compact3_b2").is_some());
+        assert_eq!(
+            expected_kernarg_bytes("gated_norm_mq_rotate_k6144_gfx1100"),
+            Some(64)
+        );
+        assert!(pointer_effects("gated_norm_mq_rotate_k6144_gfx1100").is_some());
+        assert_eq!(expected_kernarg_bytes("qwen36_27b_fa_prep_gfx1100"), Some(64));
+        assert!(pointer_effects("qwen36_27b_fa_prep_gfx1100").is_some());
+        assert_eq!(
             expected_kernarg_bytes("conv1d_silu_split_qknorm_b256"),
             Some(80)
         );
@@ -5583,6 +5625,14 @@ mod tests {
         for kernel in [
             "fused_gate_up_hfq4g256",
             "fused_gate_up_hfq4g256_k1024_gfx1201",
+            "fused_gate_up_hfq4g256_dot_reform_gfx1100",
+            "fused_gate_up_hfq4g256_dot_prefetch_gfx1100",
+            "fused_gate_up_hfq4g256_pair_gfx1100",
+            "fused_gate_up_hfq4g256_pair2_gfx1100",
+            "fused_gate_up_hfq4g256_quad_prefetch_gfx1100",
+            "fused_gate_up_hfq4g256_setprio_gfx1100",
+            "fused_gate_up_hfq4g256_lane0_headers_gfx1100",
+            "fused_gate_up_hfq4g256_stage_x32_gfx1100",
         ] {
             assert_eq!(expected_kernarg_bytes(kernel), Some(64));
             assert_eq!(

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -553,6 +553,15 @@ Copyable user, developer, and retained-PM4 TOML profiles are in
 | `HIPFIRE_GEMV_ROWS` | crates/rdna-compute/src/dispatch.rs, crates/rdna-compute/src/feature_flags.rs |
 | `HIPFIRE_GEN` | crates/hipfire-runtime/examples/a3b_multiturn_oneshot.rs |
 | `HIPFIRE_GEN_STEPS` | crates/hipfire-runtime/examples/oracle_xcheck.rs |
+| `HIPFIRE_GFX1100_AWQ_NORM_DIRECT` | crates/rdna-compute/src/gemv.rs |
+| `HIPFIRE_GFX1100_ASYM3_Q8_PAIR` | crates/rdna-compute/src/attention.rs |
+| `HIPFIRE_GFX1100_DENSE_GATE_UP_DOT_REFORM` | crates/rdna-compute/src/gemm.rs |
+| `HIPFIRE_GFX1100_DENSE_GATE_UP_LANE0_HEADERS` | crates/rdna-compute/src/gemm.rs |
+| `HIPFIRE_GFX1100_DENSE_GATE_UP_PAIR` | crates/rdna-compute/src/gemm.rs |
+| `HIPFIRE_GFX1100_DENSE_GATE_UP_PAIR2` | crates/rdna-compute/src/gemm.rs |
+| `HIPFIRE_GFX1100_DENSE_GATE_UP_QUAD_PREFETCH` | crates/rdna-compute/src/gemm.rs |
+| `HIPFIRE_GFX1100_DENSE_GATE_UP_SETPRIO` | crates/rdna-compute/src/gemm.rs |
+| `HIPFIRE_GFX1100_DENSE_GATE_UP_STAGE_X32` | crates/rdna-compute/src/gemm.rs |
 | `HIPFIRE_GFX1100_ROUTER_W64` | crates/hipfire-dispatch/src/pipeline/mod.rs |
 | `HIPFIRE_GFX1151_ATTENTION_TILE_DPP` | crates/rdna-compute/src/attention.rs |
 | `HIPFIRE_GFX1151_ATTENTION_TILE_DPP_REDUCE` | crates/rdna-compute/src/kernels.rs |

--- a/kernels/src/attention_dflash_wmma.gfx12.hip
+++ b/kernels/src/attention_dflash_wmma.gfx12.hip
@@ -139,11 +139,23 @@ __global__ void attention_dflash_wmma_f32_gfx12(
 
         // Stage V tile into LDS in natural [k, d] layout.
         const int v_writer_row = half;     // K-tile row
-        for (int d = my_col_base; d < my_col_base + cols_per_half; ++d) {
-            float vv = (k_valid && v_writer_row < kt_size)
-                ? my_v_row[d]
-                : 0.0f;
-            V_lds[v_writer_row * head_dim + d] = vv;
+        int d = my_col_base;
+        const int d_end = my_col_base + cols_per_half;
+        for (; d + 16 <= d_end; d += 16) {
+            #pragma unroll
+            for (int j = 0; j < 16; ++j) {
+                float vv = (k_valid && v_writer_row < kt_size)
+                    ? my_v_row[d + j]
+                    : 0.0f;
+                V_lds[v_writer_row * head_dim + d + j] = vv;
+            }
+        }
+        // head_dim is only required to be a multiple of 16, so a half-row
+        // can have an 8-element tail (e.g. head_dim=80). Keep that tail
+        // scalar; the common 128/160/256 shapes stay entirely vectorized.
+        for (; d < d_end; ++d) {
+            V_lds[v_writer_row * head_dim + d] =
+                (k_valid && v_writer_row < kt_size) ? my_v_row[d] : 0.0f;
         }
         __syncthreads();
 

--- a/kernels/src/attention_dflash_wmma.hip
+++ b/kernels/src/attention_dflash_wmma.hip
@@ -179,11 +179,23 @@ __global__ void attention_dflash_wmma_f32(
         // softmax only touches lanes 0..15; lanes 16..31 cover V loads
         // for the back half). All 32 lanes write 8 floats each.
         const int v_writer_row = half;     // K-tile row
-        for (int d = my_col_base; d < my_col_base + cols_per_half; ++d) {
-            float vv = (k_valid && v_writer_row < kt_size)
-                ? my_v_row[d]
-                : 0.0f;
-            V_lds[v_writer_row * head_dim + d] = vv;
+        int d = my_col_base;
+        const int d_end = my_col_base + cols_per_half;
+        for (; d + 16 <= d_end; d += 16) {
+            #pragma unroll
+            for (int j = 0; j < 16; ++j) {
+                float vv = (k_valid && v_writer_row < kt_size)
+                    ? my_v_row[d + j]
+                    : 0.0f;
+                V_lds[v_writer_row * head_dim + d + j] = vv;
+            }
+        }
+        // head_dim is only required to be a multiple of 16, so a half-row
+        // can have an 8-element tail (e.g. head_dim=80). Keep that tail
+        // scalar; the common 128/160/256 shapes stay entirely vectorized.
+        for (; d < d_end; ++d) {
+            V_lds[v_writer_row * head_dim + d] =
+                (k_valid && v_writer_row < kt_size) ? my_v_row[d] : 0.0f;
         }
         __syncthreads();
 

--- a/kernels/src/fused_gate_up_hfq4g256.hip
+++ b/kernels/src/fused_gate_up_hfq4g256.hip
@@ -8,6 +8,26 @@
 #define HIPFIRE_FUSED_GATE_UP_KERNEL fused_gate_up_hfq4g256
 #endif
 
+#ifndef HIPFIRE_HFQ4_DOT_REFORM
+#define HIPFIRE_HFQ4_DOT_REFORM 0
+#endif
+
+#ifndef HIPFIRE_HFQ4_QUAD_PREFETCH
+#define HIPFIRE_HFQ4_QUAD_PREFETCH 0
+#endif
+
+#ifndef HIPFIRE_HFQ4_SETPRIO
+#define HIPFIRE_HFQ4_SETPRIO 0
+#endif
+
+#ifndef HIPFIRE_HFQ4_LANE0_HEADERS
+#define HIPFIRE_HFQ4_LANE0_HEADERS 0
+#endif
+
+#ifndef HIPFIRE_HFQ4_STAGE_X32
+#define HIPFIRE_HFQ4_STAGE_X32 0
+#endif
+
 // Fused Gate+Up HFQ4-G256: two GEMVs in one launch (saves 1 launch per
 // FFN layer vs separate gate/up calls). Grid = [gate_m + up_m] — each
 // block processes one row from either A_gate or A_up based on its index.
@@ -44,6 +64,8 @@ extern "C" __global__ void HIPFIRE_FUSED_GATE_UP_KERNEL(
 
 #if defined(HIPFIRE_FUSED_GATE_UP_K1024)
     const int groups_per_row = 4;
+#elif defined(HIPFIRE_FUSED_GATE_UP_K5120)
+    const int groups_per_row = 20;
 #elif defined(HIPFIRE_GLIMMER_GATE_UP_K6656)
     // Muse Glimmer AR decode fused gate+up path: exact host-enforced shape is
     // gate_m=up_m=19968, K=6656 (26 groups, quads=6, tail=2). Arithmetic
@@ -63,13 +85,139 @@ extern "C" __global__ void HIPFIRE_FUSED_GATE_UP_KERNEL(
     const int quads = groups_per_row >> 2;
     const int tail = groups_per_row & 3;
 
+#if HIPFIRE_HFQ4_QUAD_PREFETCH
+    #define LOAD_QUAD(q_idx, sc0v, zp0v, sc1v, zp1v, sc2v, zp2v, sc3v, zp3v, pk0v, pk1v, pk2v, pk3v) do { \
+        const int g_ = (q_idx) << 2; \
+        const char* gp0_ = row_ptr + g_ * 136; \
+        const char* gp1_ = gp0_ + 136; \
+        const char* gp2_ = gp1_ + 136; \
+        const char* gp3_ = gp2_ + 136; \
+        (sc0v) = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp0_, (g_ + 0) * 136)); \
+        (zp0v) = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp0_ + 4, (g_ + 0) * 136 + 4)); \
+        (sc1v) = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp1_, (g_ + 1) * 136)); \
+        (zp1v) = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp1_ + 4, (g_ + 1) * 136 + 4)); \
+        (sc2v) = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp2_, (g_ + 2) * 136)); \
+        (zp2v) = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp2_ + 4, (g_ + 2) * 136 + 4)); \
+        (sc3v) = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp3_, (g_ + 3) * 136)); \
+        (zp3v) = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp3_ + 4, (g_ + 3) * 136 + 4)); \
+        (pk0v) = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp0_ + 8 + boff, (g_ + 0) * 136 + 8 + boff); \
+        (pk1v) = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp1_ + 8 + boff, (g_ + 1) * 136 + 8 + boff); \
+        (pk2v) = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp2_ + 8 + boff, (g_ + 2) * 136 + 8 + boff); \
+        (pk3v) = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp3_ + 8 + boff, (g_ + 3) * 136 + 8 + boff); \
+    } while (0)
+    #if HIPFIRE_HFQ4_DOT_REFORM
+    #define PREFETCH_DOG(pk, sc, zp, b, a) do { \
+        const float4 xa = *reinterpret_cast<const float4*>(x + (b)); \
+        const float4 xb = *reinterpret_cast<const float4*>(x + (b) + 4); \
+        const float q01 = (float)((pk) & 0xFu) * xa.x \
+                        + (float)(((pk) >> 4) & 0xFu) * xa.y; \
+        const float q23 = (float)(((pk) >> 8) & 0xFu) * xa.z \
+                        + (float)(((pk) >> 12) & 0xFu) * xa.w; \
+        const float q45 = (float)(((pk) >> 16) & 0xFu) * xb.x \
+                        + (float)(((pk) >> 20) & 0xFu) * xb.y; \
+        const float q67 = (float)(((pk) >> 24) & 0xFu) * xb.z \
+                        + (float)(((pk) >> 28) & 0xFu) * xb.w; \
+        const float qdot = (q01 + q23) + (q45 + q67); \
+        const float xsum = ((xa.x + xa.y) + (xa.z + xa.w)) \
+                         + ((xb.x + xb.y) + (xb.z + xb.w)); \
+        (a) += (sc) * qdot + (zp) * xsum; \
+    } while (0)
+    #else
+    #define PREFETCH_DOG(pk, sc, zp, b, a) \
+        (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)] \
+             + (sc * (float)(((pk) >> 4) & 0xFu)  + zp) * x[(b) + 1] \
+             + (sc * (float)(((pk) >> 8) & 0xFu)  + zp) * x[(b) + 2] \
+             + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * x[(b) + 3] \
+             + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * x[(b) + 4] \
+             + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
+             + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
+             + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+    #endif
+
+    if (quads > 0) {
+        float sc0, zp0, sc1, zp1, sc2, zp2, sc3, zp3;
+        unsigned int pk0, pk1, pk2, pk3;
+        LOAD_QUAD(0, sc0, zp0, sc1, zp1, sc2, zp2, sc3, zp3,
+                     pk0, pk1, pk2, pk3);
+
+        for (int q = 0; q < quads - 1; q++) {
+            float n_sc0, n_zp0, n_sc1, n_zp1, n_sc2, n_zp2, n_sc3, n_zp3;
+            unsigned int n_pk0, n_pk1, n_pk2, n_pk3;
+            LOAD_QUAD(q + 1,
+                      n_sc0, n_zp0, n_sc1, n_zp1, n_sc2, n_zp2, n_sc3, n_zp3,
+                      n_pk0, n_pk1, n_pk2, n_pk3);
+
+            const int base = (q << 2) * 256 + tid * 8;
+            PREFETCH_DOG(pk0, sc0, zp0, base, acc0);
+            PREFETCH_DOG(pk1, sc1, zp1, base + 256, acc1);
+            PREFETCH_DOG(pk2, sc2, zp2, base + 512, acc2);
+            PREFETCH_DOG(pk3, sc3, zp3, base + 768, acc3);
+
+            sc0 = n_sc0; zp0 = n_zp0; sc1 = n_sc1; zp1 = n_zp1;
+            sc2 = n_sc2; zp2 = n_zp2; sc3 = n_sc3; zp3 = n_zp3;
+            pk0 = n_pk0; pk1 = n_pk1; pk2 = n_pk2; pk3 = n_pk3;
+        }
+
+        const int base = ((quads - 1) << 2) * 256 + tid * 8;
+        PREFETCH_DOG(pk0, sc0, zp0, base, acc0);
+        PREFETCH_DOG(pk1, sc1, zp1, base + 256, acc1);
+        PREFETCH_DOG(pk2, sc2, zp2, base + 512, acc2);
+        PREFETCH_DOG(pk3, sc3, zp3, base + 768, acc3);
+    }
+    #undef PREFETCH_DOG
+    #undef LOAD_QUAD
+#else
     for (int q = 0; q < quads; q++) {
+#if HIPFIRE_HFQ4_SETPRIO
+        asm volatile("s_setprio 1" ::: "memory");
+#endif
         const int g = q << 2;
+        const int base = g * 256 + tid * 8;
+#if HIPFIRE_HFQ4_STAGE_X32
+        const float4 x0a = *reinterpret_cast<const float4*>(x + base);
+        const float4 x0b = *reinterpret_cast<const float4*>(x + base + 4);
+        const float4 x1a = *reinterpret_cast<const float4*>(x + base + 256);
+        const float4 x1b = *reinterpret_cast<const float4*>(x + base + 260);
+        const float4 x2a = *reinterpret_cast<const float4*>(x + base + 512);
+        const float4 x2b = *reinterpret_cast<const float4*>(x + base + 516);
+        const float4 x3a = *reinterpret_cast<const float4*>(x + base + 768);
+        const float4 x3b = *reinterpret_cast<const float4*>(x + base + 772);
+#endif
         const char* gp0 = row_ptr + g * 136;
         const char* gp1 = gp0 + 136;
         const char* gp2 = gp1 + 136;
         const char* gp3 = gp2 + 136;
 
+#if HIPFIRE_HFQ4_LANE0_HEADERS
+        unsigned int sc0_bits = 0, zp0_bits = 0, sc1_bits = 0, zp1_bits = 0;
+        unsigned int sc2_bits = 0, zp2_bits = 0, sc3_bits = 0, zp3_bits = 0;
+        if (tid == 0) {
+            sc0_bits = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp0, (g + 0) * 136);
+            zp0_bits = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp0 + 4, (g + 0) * 136 + 4);
+            sc1_bits = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp1, (g + 1) * 136);
+            zp1_bits = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp1 + 4, (g + 1) * 136 + 4);
+            sc2_bits = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp2, (g + 2) * 136);
+            zp2_bits = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp2 + 4, (g + 2) * 136 + 4);
+            sc3_bits = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp3, (g + 3) * 136);
+            zp3_bits = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp3 + 4, (g + 3) * 136 + 4);
+        }
+        const float sc0 = __builtin_bit_cast(float,
+            (unsigned int)__builtin_amdgcn_readlane((int)sc0_bits, 0));
+        const float zp0 = __builtin_bit_cast(float,
+            (unsigned int)__builtin_amdgcn_readlane((int)zp0_bits, 0));
+        const float sc1 = __builtin_bit_cast(float,
+            (unsigned int)__builtin_amdgcn_readlane((int)sc1_bits, 0));
+        const float zp1 = __builtin_bit_cast(float,
+            (unsigned int)__builtin_amdgcn_readlane((int)zp1_bits, 0));
+        const float sc2 = __builtin_bit_cast(float,
+            (unsigned int)__builtin_amdgcn_readlane((int)sc2_bits, 0));
+        const float zp2 = __builtin_bit_cast(float,
+            (unsigned int)__builtin_amdgcn_readlane((int)zp2_bits, 0));
+        const float sc3 = __builtin_bit_cast(float,
+            (unsigned int)__builtin_amdgcn_readlane((int)sc3_bits, 0));
+        const float zp3 = __builtin_bit_cast(float,
+            (unsigned int)__builtin_amdgcn_readlane((int)zp3_bits, 0));
+#else
         float sc0 = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp0, (g + 0) * 136));
         float zp0 = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp0 + 4, (g + 0) * 136 + 4));
         float sc1 = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp1, (g + 1) * 136));
@@ -78,14 +226,49 @@ extern "C" __global__ void HIPFIRE_FUSED_GATE_UP_KERNEL(
         float zp2 = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp2 + 4, (g + 2) * 136 + 4));
         float sc3 = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp3, (g + 3) * 136));
         float zp3 = __builtin_bit_cast(float, HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp3 + 4, (g + 3) * 136 + 4));
+#endif
 
         unsigned int pk0 = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp0 + 8 + boff, (g + 0) * 136 + 8 + boff);
         unsigned int pk1 = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp1 + 8 + boff, (g + 1) * 136 + 8 + boff);
         unsigned int pk2 = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp2 + 8 + boff, (g + 2) * 136 + 8 + boff);
         unsigned int pk3 = HIPFIRE_WEIGHT_LOAD_PTR_U32(row_rsrc, gp3 + 8 + boff, (g + 3) * 136 + 8 + boff);
+#if HIPFIRE_HFQ4_SETPRIO
+        asm volatile("s_setprio 0" ::: "memory");
+#endif
 
-        int base = g * 256 + tid * 8;
-
+        #if HIPFIRE_HFQ4_STAGE_X32
+        #define DOG_X8(pk, sc, zp, a, xa, xb) \
+            (a) += (sc * (float)((pk) & 0xFu)         + zp) * (xa).x \
+                 + (sc * (float)(((pk) >> 4) & 0xFu)  + zp) * (xa).y \
+                 + (sc * (float)(((pk) >> 8) & 0xFu)  + zp) * (xa).z \
+                 + (sc * (float)(((pk) >> 12) & 0xFu) + zp) * (xa).w \
+                 + (sc * (float)(((pk) >> 16) & 0xFu) + zp) * (xb).x \
+                 + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * (xb).y \
+                 + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * (xb).z \
+                 + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * (xb).w
+        DOG_X8(pk0, sc0, zp0, acc0, x0a, x0b);
+        DOG_X8(pk1, sc1, zp1, acc1, x1a, x1b);
+        DOG_X8(pk2, sc2, zp2, acc2, x2a, x2b);
+        DOG_X8(pk3, sc3, zp3, acc3, x3a, x3b);
+        #undef DOG_X8
+        #elif HIPFIRE_HFQ4_DOT_REFORM
+        #define DOG(pk, sc, zp, b, a) do { \
+            const float4 xa = *reinterpret_cast<const float4*>(x + (b)); \
+            const float4 xb = *reinterpret_cast<const float4*>(x + (b) + 4); \
+            const float q01 = (float)((pk) & 0xFu) * xa.x \
+                            + (float)(((pk) >> 4) & 0xFu) * xa.y; \
+            const float q23 = (float)(((pk) >> 8) & 0xFu) * xa.z \
+                            + (float)(((pk) >> 12) & 0xFu) * xa.w; \
+            const float q45 = (float)(((pk) >> 16) & 0xFu) * xb.x \
+                            + (float)(((pk) >> 20) & 0xFu) * xb.y; \
+            const float q67 = (float)(((pk) >> 24) & 0xFu) * xb.z \
+                            + (float)(((pk) >> 28) & 0xFu) * xb.w; \
+            const float qdot = (q01 + q23) + (q45 + q67); \
+            const float xsum = ((xa.x + xa.y) + (xa.z + xa.w)) \
+                             + ((xb.x + xb.y) + (xb.z + xb.w)); \
+            (a) += (sc) * qdot + (zp) * xsum; \
+        } while (0)
+        #else
         #define DOG(pk, sc, zp, b, a) \
             (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
                  + (sc * (float)(((pk) >> 4) & 0xFu)  + zp) * x[(b) + 1] \
@@ -95,16 +278,38 @@ extern "C" __global__ void HIPFIRE_FUSED_GATE_UP_KERNEL(
                  + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
                  + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
                  + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+        #endif
 
+        #if !HIPFIRE_HFQ4_STAGE_X32
         DOG(pk0, sc0, zp0, base, acc0);
         DOG(pk1, sc1, zp1, base + 256, acc1);
         DOG(pk2, sc2, zp2, base + 512, acc2);
         DOG(pk3, sc3, zp3, base + 768, acc3);
         #undef DOG
+        #endif
     }
+#endif
 
     // Tail groups must accumulate into acc[g % 4] — see
     // gemv_hfq4g256.gfx1100.hip for the full bug explanation.
+    #if HIPFIRE_HFQ4_DOT_REFORM
+    #define TAIL_DOG(pk, sc, zp, b, a) do { \
+        const float4 xa = *reinterpret_cast<const float4*>(x + (b)); \
+        const float4 xb = *reinterpret_cast<const float4*>(x + (b) + 4); \
+        const float q01 = (float)((pk) & 0xFu) * xa.x \
+                        + (float)(((pk) >> 4) & 0xFu) * xa.y; \
+        const float q23 = (float)(((pk) >> 8) & 0xFu) * xa.z \
+                        + (float)(((pk) >> 12) & 0xFu) * xa.w; \
+        const float q45 = (float)(((pk) >> 16) & 0xFu) * xb.x \
+                        + (float)(((pk) >> 20) & 0xFu) * xb.y; \
+        const float q67 = (float)(((pk) >> 24) & 0xFu) * xb.z \
+                        + (float)(((pk) >> 28) & 0xFu) * xb.w; \
+        const float qdot = (q01 + q23) + (q45 + q67); \
+        const float xsum = ((xa.x + xa.y) + (xa.z + xa.w)) \
+                         + ((xb.x + xb.y) + (xb.z + xb.w)); \
+        (a) += (sc) * qdot + (zp) * xsum; \
+    } while (0)
+    #else
     #define TAIL_DOG(pk, sc, zp, b, a) \
         (a) += (sc * (float)((pk) & 0xFu)        + zp) * x[(b)]     \
              + (sc * (float)(((pk) >> 4) & 0xFu)  + zp) * x[(b) + 1] \
@@ -114,6 +319,7 @@ extern "C" __global__ void HIPFIRE_FUSED_GATE_UP_KERNEL(
              + (sc * (float)(((pk) >> 20) & 0xFu) + zp) * x[(b) + 5] \
              + (sc * (float)(((pk) >> 24) & 0xFu) + zp) * x[(b) + 6] \
              + (sc * (float)(((pk) >> 28) & 0xFu) + zp) * x[(b) + 7]
+    #endif
 
     if (tail >= 1) {
         const int g = quads << 2;

--- a/kernels/src/fused_gate_up_hfq4g256_pair.gfx1100.hip
+++ b/kernels/src/fused_gate_up_hfq4g256_pair.gfx1100.hip
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+
+#ifndef HIPFIRE_FUSED_GATE_UP_PAIR_KERNEL
+#define HIPFIRE_FUSED_GATE_UP_PAIR_KERNEL fused_gate_up_hfq4g256_pair_gfx1100
+#endif
+
+#ifndef HIPFIRE_GATE_UP_PAIR2
+#define HIPFIRE_GATE_UP_PAIR2 0
+#endif
+
+// gfx1100 dense gate+up pairing experiment. One wave computes matching rows
+// from both matrices, so each eight-value activation slice is loaded once and
+// consumed by both projections. Weight traffic and each output's four-chain
+// accumulation order remain identical to fused_gate_up_hfq4g256.hip.
+//
+// The host admits this kernel only when gate_m == up_m. Grid=[gate_m], block=32.
+// Default OFF: Qwen3.6-27B MQ4 on a W7900 (ROCm 7.14, HIP/q8, graph off,
+// 8-token warmup + 2 s DPM settle + 64 timed tokens) measured 35.6/35.4
+// tok/s for the base kernel and 35.3/35.3 for this arm in A/B/B/A order
+// (-0.56% median throughput; +0.43% median p50 latency). The emitted object
+// is spill-free (44 VGPR / 23 SGPR), and a 65-token greedy trace was exact.
+// Keep this as a negative oracle: activation reuse is already cache-absorbed.
+
+__launch_bounds__(32, 16)
+extern "C" __global__ void HIPFIRE_FUSED_GATE_UP_PAIR_KERNEL(
+    const char* __restrict__ A_gate,
+    const char* __restrict__ A_up,
+    const float* __restrict__ x,
+    float* __restrict__ y_gate,
+    float* __restrict__ y_up,
+    int gate_m, int up_m, int K
+) {
+    const int row = blockIdx.x;
+    if (row >= gate_m || row >= up_m) return;
+    const int tid = threadIdx.x;
+
+    const int groups_per_row = K / 256;
+    const long long row_stride = (long long)groups_per_row * 136;
+    const char* gate_ptr = A_gate + (long long)row * row_stride;
+    const char* up_ptr = A_up + (long long)row * row_stride;
+    const int boff = tid * 4;
+#if HIPFIRE_GFX12_WEIGHT_BUFFER_LOADS
+    const auto gate_rsrc = HIPFIRE_WEIGHT_RSRC(gate_ptr);
+    const auto up_rsrc = HIPFIRE_WEIGHT_RSRC(up_ptr);
+#endif
+
+    float gacc0 = 0.0f, gacc1 = 0.0f, gacc2 = 0.0f, gacc3 = 0.0f;
+    float uacc0 = 0.0f, uacc1 = 0.0f, uacc2 = 0.0f, uacc3 = 0.0f;
+    const int quads = groups_per_row >> 2;
+    const int tail = groups_per_row & 3;
+
+    #define DOG_X8(sc, zp, pk, a, xa, xb) \
+        (a) += ((sc) * (float)((pk) & 0xFu)         + (zp)) * (xa).x \
+             + ((sc) * (float)(((pk) >> 4) & 0xFu)  + (zp)) * (xa).y \
+             + ((sc) * (float)(((pk) >> 8) & 0xFu)  + (zp)) * (xa).z \
+             + ((sc) * (float)(((pk) >> 12) & 0xFu) + (zp)) * (xa).w \
+             + ((sc) * (float)(((pk) >> 16) & 0xFu) + (zp)) * (xb).x \
+             + ((sc) * (float)(((pk) >> 20) & 0xFu) + (zp)) * (xb).y \
+             + ((sc) * (float)(((pk) >> 24) & 0xFu) + (zp)) * (xb).z \
+             + ((sc) * (float)(((pk) >> 28) & 0xFu) + (zp)) * (xb).w
+
+    // Limit the live range to one HFQ group. This keeps both four-chain
+    // accumulators resident without retaining a full four-group x tile.
+    #define PROCESS_GROUP(group_index, chain) do { \
+        const int group = (group_index); \
+        const int base = group * 256 + tid * 8; \
+        const float4 xa = *reinterpret_cast<const float4*>(x + base); \
+        const float4 xb = *reinterpret_cast<const float4*>(x + base + 4); \
+        const char* gg = gate_ptr + group * 136; \
+        float gsc = __builtin_bit_cast(float, \
+            HIPFIRE_WEIGHT_LOAD_PTR_U32(gate_rsrc, gg, group * 136)); \
+        float gzp = __builtin_bit_cast(float, \
+            HIPFIRE_WEIGHT_LOAD_PTR_U32(gate_rsrc, gg + 4, group * 136 + 4)); \
+        unsigned int gpk = HIPFIRE_WEIGHT_LOAD_PTR_U32( \
+            gate_rsrc, gg + 8 + boff, group * 136 + 8 + boff); \
+        DOG_X8(gsc, gzp, gpk, gacc##chain, xa, xb); \
+        const char* uu = up_ptr + group * 136; \
+        float usc = __builtin_bit_cast(float, \
+            HIPFIRE_WEIGHT_LOAD_PTR_U32(up_rsrc, uu, group * 136)); \
+        float uzp = __builtin_bit_cast(float, \
+            HIPFIRE_WEIGHT_LOAD_PTR_U32(up_rsrc, uu + 4, group * 136 + 4)); \
+        unsigned int upk = HIPFIRE_WEIGHT_LOAD_PTR_U32( \
+            up_rsrc, uu + 8 + boff, group * 136 + 8 + boff); \
+        DOG_X8(usc, uzp, upk, uacc##chain, xa, xb); \
+        asm volatile("" \
+            : "+v"(gacc0), "+v"(gacc1), "+v"(gacc2), "+v"(gacc3), \
+              "+v"(uacc0), "+v"(uacc1), "+v"(uacc2), "+v"(uacc3) \
+            : : "memory"); \
+    } while (0)
+
+#if HIPFIRE_GATE_UP_PAIR2
+    // Retain two groups of x and both weight streams at once. Pair1's single
+    // group live range cut VMEM concurrency in half; this restores a middle
+    // schedule without approaching the 96-VGPR gfx1100 occupancy ceiling.
+    #define PROCESS_GROUP_PAIR(group0, chain0, group1, chain1) do { \
+        const int ga = (group0); \
+        const int gb = (group1); \
+        const int ba = ga * 256 + tid * 8; \
+        const int bb = gb * 256 + tid * 8; \
+        const float4 xa0 = *reinterpret_cast<const float4*>(x + ba); \
+        const float4 xb0 = *reinterpret_cast<const float4*>(x + ba + 4); \
+        const float4 xa1 = *reinterpret_cast<const float4*>(x + bb); \
+        const float4 xb1 = *reinterpret_cast<const float4*>(x + bb + 4); \
+        const char* gg0 = gate_ptr + ga * 136; \
+        const char* gg1 = gate_ptr + gb * 136; \
+        const float gsc0 = __builtin_bit_cast(float, \
+            HIPFIRE_WEIGHT_LOAD_PTR_U32(gate_rsrc, gg0, ga * 136)); \
+        const float gzp0 = __builtin_bit_cast(float, \
+            HIPFIRE_WEIGHT_LOAD_PTR_U32(gate_rsrc, gg0 + 4, ga * 136 + 4)); \
+        const unsigned int gpk0 = HIPFIRE_WEIGHT_LOAD_PTR_U32( \
+            gate_rsrc, gg0 + 8 + boff, ga * 136 + 8 + boff); \
+        const float gsc1 = __builtin_bit_cast(float, \
+            HIPFIRE_WEIGHT_LOAD_PTR_U32(gate_rsrc, gg1, gb * 136)); \
+        const float gzp1 = __builtin_bit_cast(float, \
+            HIPFIRE_WEIGHT_LOAD_PTR_U32(gate_rsrc, gg1 + 4, gb * 136 + 4)); \
+        const unsigned int gpk1 = HIPFIRE_WEIGHT_LOAD_PTR_U32( \
+            gate_rsrc, gg1 + 8 + boff, gb * 136 + 8 + boff); \
+        const char* uu0 = up_ptr + ga * 136; \
+        const char* uu1 = up_ptr + gb * 136; \
+        const float usc0 = __builtin_bit_cast(float, \
+            HIPFIRE_WEIGHT_LOAD_PTR_U32(up_rsrc, uu0, ga * 136)); \
+        const float uzp0 = __builtin_bit_cast(float, \
+            HIPFIRE_WEIGHT_LOAD_PTR_U32(up_rsrc, uu0 + 4, ga * 136 + 4)); \
+        const unsigned int upk0 = HIPFIRE_WEIGHT_LOAD_PTR_U32( \
+            up_rsrc, uu0 + 8 + boff, ga * 136 + 8 + boff); \
+        const float usc1 = __builtin_bit_cast(float, \
+            HIPFIRE_WEIGHT_LOAD_PTR_U32(up_rsrc, uu1, gb * 136)); \
+        const float uzp1 = __builtin_bit_cast(float, \
+            HIPFIRE_WEIGHT_LOAD_PTR_U32(up_rsrc, uu1 + 4, gb * 136 + 4)); \
+        const unsigned int upk1 = HIPFIRE_WEIGHT_LOAD_PTR_U32( \
+            up_rsrc, uu1 + 8 + boff, gb * 136 + 8 + boff); \
+        DOG_X8(gsc0, gzp0, gpk0, gacc##chain0, xa0, xb0); \
+        DOG_X8(usc0, uzp0, upk0, uacc##chain0, xa0, xb0); \
+        DOG_X8(gsc1, gzp1, gpk1, gacc##chain1, xa1, xb1); \
+        DOG_X8(usc1, uzp1, upk1, uacc##chain1, xa1, xb1); \
+        asm volatile("" \
+            : "+v"(gacc0), "+v"(gacc1), "+v"(gacc2), "+v"(gacc3), \
+              "+v"(uacc0), "+v"(uacc1), "+v"(uacc2), "+v"(uacc3) \
+            : : "memory"); \
+    } while (0)
+
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        PROCESS_GROUP_PAIR(g, 0, g + 1, 1);
+        PROCESS_GROUP_PAIR(g + 2, 2, g + 3, 3);
+    }
+    #undef PROCESS_GROUP_PAIR
+#else
+    for (int q = 0; q < quads; q++) {
+        const int g = q << 2;
+        PROCESS_GROUP(g, 0);
+        PROCESS_GROUP(g + 1, 1);
+        PROCESS_GROUP(g + 2, 2);
+        PROCESS_GROUP(g + 3, 3);
+    }
+#endif
+    if (tail >= 1) {
+        PROCESS_GROUP(quads << 2, 0);
+    }
+    if (tail >= 2) {
+        PROCESS_GROUP((quads << 2) + 1, 1);
+    }
+    if (tail >= 3) {
+        PROCESS_GROUP((quads << 2) + 2, 2);
+    }
+    #undef PROCESS_GROUP
+    #undef DOG_X8
+
+    float gate = (gacc0 + gacc1) + (gacc2 + gacc3);
+    float up = (uacc0 + uacc1) + (uacc2 + uacc3);
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        gate += __shfl_down(gate, offset);
+        up += __shfl_down(up, offset);
+    }
+
+    if (tid == 0) {
+        y_gate[row] = gate;
+        y_up[row] = up;
+    }
+}

--- a/kernels/src/fused_rmsnorm_mq_rotate_awq_direct.gfx1100.hip
+++ b/kernels/src/fused_rmsnorm_mq_rotate_awq_direct.gfx1100.hip
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 HUSRCF
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+
+// gfx1100 AWQ direct path. Preserve the baseline's 256-thread RMS
+// reduction tree, IEEE divide, FWHT order, and output ABI, but do not stage the
+// full activation and normalized vector through LDS. The second x read should
+// hit cache; each FWHT wave instead consumes x/weight/AWQ directly in float4s.
+// Qwen3.6-27B K=5120 certification: +2.44% graph-on A/B/B/A, 14.859 ->
+// 9.116 us/launch, and exact tokens through a 1025-token greedy replay.
+//
+// Grid: [batch]. Block: [256]. LDS: 256 floats for the exact RMS tree.
+__launch_bounds__(256, 1)
+extern "C" __global__ void fused_rmsnorm_mq_rotate_awq(
+    const float* __restrict__ x,
+    const float* __restrict__ weight,
+    const float* __restrict__ awq_scale,
+    const float* __restrict__ signs1,
+    const float* __restrict__ signs2,
+    float* __restrict__ x_rot,
+    int K,
+    float eps
+) {
+    extern __shared__ float reduce[];
+
+    const int tid = threadIdx.x;
+    const int lane_id = tid & 31;
+    const int warp_id = tid >> 5;
+    const int num_warps = blockDim.x >> 5;
+    const long long batch_off = (long long)blockIdx.x * K;
+    const float* x_b = x + batch_off;
+    float* x_rot_b = x_rot + batch_off;
+
+    // Keep the baseline's scalar accumulation and descending-offset LDS tree.
+    float local_sum = 0.0f;
+    for (int i = tid; i < K; i += blockDim.x) {
+        const float v = x_b[i];
+        local_sum += v * v;
+    }
+    reduce[tid] = local_sum;
+    __syncthreads();
+    for (int s = blockDim.x >> 1; s > 0; s >>= 1) {
+        if (tid < s) reduce[tid] += reduce[tid + s];
+        __syncthreads();
+    }
+    const float rms = rsqrtf(reduce[0] / (float)K + eps);
+
+    const int groups_total = K / 256;
+    const int groups_per_warp = (groups_total + num_warps - 1) / num_warps;
+    const int warp_group_start = warp_id * groups_per_warp;
+    const int d0 = lane_id * 8;
+    const float4 s10 = *reinterpret_cast<const float4*>(signs1 + d0);
+    const float4 s11 = *reinterpret_cast<const float4*>(signs1 + d0 + 4);
+    const float4 s20 = *reinterpret_cast<const float4*>(signs2 + d0);
+    const float4 s21 = *reinterpret_cast<const float4*>(signs2 + d0 + 4);
+
+    for (int gi = 0; gi < groups_per_warp; gi++) {
+        const int group = warp_group_start + gi;
+        if (group >= groups_total) break;
+
+        const int base = group * 256 + d0;
+        const float4 x0 = *reinterpret_cast<const float4*>(x_b + base);
+        const float4 x1 = *reinterpret_cast<const float4*>(x_b + base + 4);
+        const float4 w0 = *reinterpret_cast<const float4*>(weight + base);
+        const float4 w1 = *reinterpret_cast<const float4*>(weight + base + 4);
+        const float4 a0 = *reinterpret_cast<const float4*>(awq_scale + base);
+        const float4 a1 = *reinterpret_cast<const float4*>(awq_scale + base + 4);
+
+        // Match the baseline expression and its IEEE division exactly:
+        // ((x * weight) * rms / awq_scale) * sign1.
+        float v0 = x0.x * w0.x * rms / a0.x * s10.x;
+        float v1 = x0.y * w0.y * rms / a0.y * s10.y;
+        float v2 = x0.z * w0.z * rms / a0.z * s10.z;
+        float v3 = x0.w * w0.w * rms / a0.w * s10.w;
+        float v4 = x1.x * w1.x * rms / a1.x * s11.x;
+        float v5 = x1.y * w1.y * rms / a1.y * s11.y;
+        float v6 = x1.z * w1.z * rms / a1.z * s11.z;
+        float v7 = x1.w * w1.w * rms / a1.w * s11.w;
+
+        float t;
+        t = v0; v0 = v0 + v1; v1 = t - v1;
+        t = v2; v2 = v2 + v3; v3 = t - v3;
+        t = v4; v4 = v4 + v5; v5 = t - v5;
+        t = v6; v6 = v6 + v7; v7 = t - v7;
+
+        t = v0; v0 = v0 + v2; v2 = t - v2;
+        t = v1; v1 = v1 + v3; v3 = t - v3;
+        t = v4; v4 = v4 + v6; v6 = t - v6;
+        t = v5; v5 = v5 + v7; v7 = t - v7;
+
+        t = v0; v0 = v0 + v4; v4 = t - v4;
+        t = v1; v1 = v1 + v5; v5 = t - v5;
+        t = v2; v2 = v2 + v6; v6 = t - v6;
+        t = v3; v3 = v3 + v7; v7 = t - v7;
+
+        #define HBFLY(v, pat, str) do { \
+            float _p = __int_as_float( \
+                __builtin_amdgcn_ds_swizzle(__float_as_int(v), (pat))); \
+            if (lane_id & (str)) { (v) = _p - (v); } \
+            else { (v) = (v) + _p; } \
+        } while (0)
+        #define HBFLY8(pat, str) \
+            HBFLY(v0,pat,str); HBFLY(v1,pat,str); \
+            HBFLY(v2,pat,str); HBFLY(v3,pat,str); \
+            HBFLY(v4,pat,str); HBFLY(v5,pat,str); \
+            HBFLY(v6,pat,str); HBFLY(v7,pat,str)
+
+        HBFLY8(0x041F, 1);
+        HBFLY8(0x081F, 2);
+        HBFLY8(0x101F, 4);
+        HBFLY8(0x201F, 8);
+        HBFLY8(0x401F, 16);
+        #undef HBFLY8
+        #undef HBFLY
+
+        const float scale = 0.0625f;
+        float4 out0;
+        float4 out1;
+        out0.x = v0 * scale * s20.x;
+        out0.y = v1 * scale * s20.y;
+        out0.z = v2 * scale * s20.z;
+        out0.w = v3 * scale * s20.w;
+        out1.x = v4 * scale * s21.x;
+        out1.y = v5 * scale * s21.y;
+        out1.z = v6 * scale * s21.z;
+        out1.w = v7 * scale * s21.w;
+        *reinterpret_cast<float4*>(x_rot_b + base) = out0;
+        *reinterpret_cast<float4*>(x_rot_b + base + 4) = out1;
+    }
+}

--- a/kernels/src/gemv_hfq4g256_residual.gfx1100.hip
+++ b/kernels/src/gemv_hfq4g256_residual.gfx1100.hip
@@ -74,6 +74,8 @@ extern "C" __global__ void HIPFIRE_RESIDUAL_KERNEL(
         // header/packed-weight stream, then give LLVM a load-free VALU burst.
         // This preserves one output row per wave (unlike the gfx12 dual-row
         // kernel) so gfx1100 keeps enough blocks to occupy all 96 CUs.
+        // Next-quad packed-only prefetch lowered VGPR 72->60 but cut graph-on
+        // Qwen3.6-27B decode 36.643->36.452 tok/s (-0.52%, 2026-08-18).
         const float4 x0a = *reinterpret_cast<const float4*>(x + base);
         const float4 x0b = *reinterpret_cast<const float4*>(x + base + 4);
         const float4 x1a = *reinterpret_cast<const float4*>(x + base + 256);

--- a/kernels/src/kv_cache_write_asym3_q8_pair.gfx1100.hip
+++ b/kernels/src/kv_cache_write_asym3_q8_pair.gfx1100.hip
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 HUSRCF
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+#include "turbo_common.h"
+#include "givens_common.h"
+
+__device__ __forceinline__ void givens_rot_inplace_asym3_pair(
+    float& a, float& b,
+    float c, float s)
+{
+    float a2 = a * c - b * s;
+    float b2 = a * s + b * c;
+    a = a2; b = b2;
+}
+
+// Exact heterogeneous-grid sibling of kv_cache_write_asym_k_givens3 plus
+// kv_cache_write_q8_0. The first n_kv_heads workgroups write rotated asym3 K;
+// the remaining n_kv_heads * (head_dim / 32) workgroups write Q8_0 V. Keeping
+// the original workgroup geometries preserves both quantizers' arithmetic and
+// only removes the launch boundary between the independent cache writes.
+extern "C" __global__ void kv_cache_write_asym3_q8_pair_gfx1100(
+    unsigned char* __restrict__ k_dst,
+    unsigned char* __restrict__ v_dst,
+    const float* __restrict__ k_src,
+    const float* __restrict__ v_src,
+    const int* __restrict__ pos_buf,
+    const float* __restrict__ cos_theta,
+    const float* __restrict__ sin_theta,
+    int n_kv_heads,
+    int head_dim
+) {
+    const int combined_gid = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int pos = pos_buf[0];
+
+    if (combined_gid < n_kv_heads) {
+        const int h = combined_gid;
+        const int nthreads = blockDim.x;
+        const int bytes_per_head = 4 + (head_dim * 3) / 8;
+        const int bytes_per_pos = n_kv_heads * bytes_per_head;
+
+        extern __shared__ float smem[];
+        float* x = smem;
+        float* scratch = smem + head_dim;
+
+        const float* src = k_src + h * head_dim;
+        unsigned char* out =
+            k_dst + (size_t)pos * bytes_per_pos + h * bytes_per_head;
+
+        for (int d = tid; d < head_dim; d += nthreads) x[d] = src[d];
+        __syncthreads();
+
+        float lsq = 0.0f;
+        for (int d = tid; d < head_dim; d += nthreads) lsq += x[d] * x[d];
+        scratch[tid] = lsq;
+        __syncthreads();
+        for (int s = 16; s > 0; s >>= 1) {
+            if (tid < s) scratch[tid] += scratch[tid + s];
+            __syncthreads();
+        }
+        float orig_norm = sqrtf(scratch[0]);
+        float inv_norm = (orig_norm > 1e-10f) ? 1.0f / orig_norm : 0.0f;
+
+        for (int d = tid; d < head_dim; d += nthreads) x[d] *= inv_norm;
+        __syncthreads();
+
+        const int d0 = tid * 8;
+        float v0 = x[d0 + 0], v1 = x[d0 + 1];
+        float v2 = x[d0 + 2], v3 = x[d0 + 3];
+        float v4 = x[d0 + 4], v5 = x[d0 + 5];
+        float v6 = x[d0 + 6], v7 = x[d0 + 7];
+
+        const int b0 = tid * 4;
+        givens_rot_inplace_asym3_pair(
+            v0, v1, cos_theta[b0 + 0], sin_theta[b0 + 0]);
+        givens_rot_inplace_asym3_pair(
+            v2, v3, cos_theta[b0 + 1], sin_theta[b0 + 1]);
+        givens_rot_inplace_asym3_pair(
+            v4, v5, cos_theta[b0 + 2], sin_theta[b0 + 2]);
+        givens_rot_inplace_asym3_pair(
+            v6, v7, cos_theta[b0 + 3], sin_theta[b0 + 3]);
+
+        int idx[8];
+        idx[0] = turbo_quantize_3bit_256(v0);
+        idx[1] = turbo_quantize_3bit_256(v1);
+        idx[2] = turbo_quantize_3bit_256(v2);
+        idx[3] = turbo_quantize_3bit_256(v3);
+        idx[4] = turbo_quantize_3bit_256(v4);
+        idx[5] = turbo_quantize_3bit_256(v5);
+        idx[6] = turbo_quantize_3bit_256(v6);
+        idx[7] = turbo_quantize_3bit_256(v7);
+
+        float local_rsq = 0.0f;
+        for (int i = 0; i < 8; i++)
+            local_rsq += TURBO_C3_256[idx[i]] * TURBO_C3_256[idx[i]];
+
+        scratch[tid] = local_rsq;
+        __syncthreads();
+        for (int s = 16; s > 0; s >>= 1) {
+            if (tid < s) scratch[tid] += scratch[tid + s];
+            __syncthreads();
+        }
+        float recon_norm = sqrtf(scratch[0]);
+        float cnorm =
+            (recon_norm > 1e-10f) ? orig_norm / recon_norm : orig_norm;
+        if (tid == 0) *(float*)out = cnorm;
+
+        unsigned int packed = 0;
+        for (int i = 0; i < 8; i++)
+            packed |= ((unsigned int)(idx[i] & 7)) << (i * 3);
+        unsigned char* base = out + 4 + tid * 3;
+        base[0] = (unsigned char)(packed & 0xFF);
+        base[1] = (unsigned char)((packed >> 8) & 0xFF);
+        base[2] = (unsigned char)((packed >> 16) & 0xFF);
+        return;
+    }
+
+    const int blocks_per_head = head_dim / 32;
+    const int total_blocks = n_kv_heads * blocks_per_head;
+    const int gid = combined_gid - n_kv_heads;
+    if (gid >= total_blocks) return;
+
+    const int head_idx = gid / blocks_per_head;
+    const int block_idx = gid % blocks_per_head;
+    const int elem_offset = head_idx * head_dim + block_idx * 32 + tid;
+
+    float val = v_src[elem_offset];
+    float amax = fabsf(val);
+    for (int offset = 16; offset > 0; offset >>= 1)
+        amax = fmaxf(amax, __shfl_xor(amax, offset));
+
+    float scale = amax / 127.0f;
+    float inv_scale = (amax > 0.0f) ? (127.0f / amax) : 0.0f;
+    int q = __float2int_rn(val * inv_scale);
+    q = max(-127, min(127, q));
+
+    unsigned char* out =
+        v_dst + (size_t)pos * total_blocks * 34 + gid * 34;
+    if (tid == 0) *((_Float16*)out) = (_Float16)scale;
+    out[2 + tid] = (unsigned char)(signed char)q;
+}


### PR DESCRIPTION
## Summary

Accelerate Qwen3.6-27B MQ4 autoregressive decode on gfx1100, then reduce DFlash sidecar memory and repeated attention work without changing target verification or acceptance policy.

- specialize the admitted gfx1100/Qwen3.6-27B decode shapes with staged dense gate+up activations, direct AWQ norm/rotation, compact DeltaNet Q/K preparation, fused full-attention preparation, and paired asym3-K/Q8-V cache writes;
- remove dead full-context K/V scratch and share disjoint attention/FFN residual storage;
- cache context K after RMSNorm + RoPE, so steady-state cycles rotate only newly projected rows instead of the full historical span;
- stage V into LDS in explicit 16-element chunks on gfx11 and gfx12, retaining a scalar tail for valid non-32-multiple head shapes such as head_dim=80.

The general decode freeze and the three DFlash changes are split into four independent commits. Experimental decode variants remain opt-in; promoted defaults are restricted by exact gfx1100 architecture and Qwen3.6-27B shapes. Persistent-FP16 DFlash K/V storage is deliberately left for a follow-up so this PR keeps the existing F32 cache/storage contract.

## Which crate(s) does this touch?

- [x] `kernels/` (HIP source)
- [x] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [x] `crates/hipfire-dispatch` (kernel family routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [x] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [x] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy`
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [x] docs / CI / scripts

## Performance evidence

Decode target: Qwen3.6-27B MQ4, greedy, batch 1. DFlash target/draft: Qwen3.6-27B MQ4 + `qwen36-27b-dflash-mq4.hfq`, Q8 target KV, block 16.

| Surface | Baseline | Candidate | Result |
|---|---:|---:|---:|
| W7900/gfx1100 AR, 1024-token decode | 35.05 tok/s | 37.45 tok/s | **+6.85%** |
| W7900/gfx1100 LongBench-v2 hard30 decode | 30.10 tok/s | 31.45 tok/s | **+4.49%** |
| R9700/gfx1201 LongBench-v2 hard30 decode | — | — | **−0.33% decode / +0.05% prefill** |
| gfx1100 DFlash attention micro, B=16/L=1120/HD=160 | 1.094 ms | 0.961 ms | **−12.1% time** |
| gfx1100 synchronized attention subphase | — | — | approximately **−15% time** |
| gfx1100 E2E, 1120-token context | 79.37 tok/s | 79.75 tok/s | **+0.48%** |
| gfx1100 E2E, 4397-token context | 29.68 tok/s | 29.88 tok/s | **+0.69%** |
| gfx1201 resident hot E2E, five measured rows | 116.20 tok/s | 116.46 tok/s | **+0.22%** |
| gfx1100 VRAM, ctx=2048 | 17,276 MiB | 17,260 MiB | **−16 MiB** |

Caching post-RoPE K reduces the measured concat/norm/RoPE portion from roughly 0.60–0.63 ms to 0.53–0.55 ms per cycle (about 11%). Its standalone E2E effect is neutral at these decode lengths; the measurable whole-path gain comes from the V-staging change. The smaller E2E gain relative to the attention microbenchmark is expected because target verification remains the dominant cost.

The gfx1201 result is intentionally described as neutral-to-positive rather than a broad speed claim. The five hot rows were 116.24/116.20/116.01/116.27/115.92 tok/s for scalar staging and 116.49/116.46/116.52/116.36/116.29 tok/s for vector staging.

The repository's locked gfx1100 speed baseline was recorded on different hardware and is not a valid W7900 gate: both clean `origin/beta` and this branch report roughly 141–143 tok/s against the locked 178 tok/s. Same-device alternating checks were near-neutral (beta 143.0/141.9/140.9; candidate 141.6/140.9/141.0), and the reversed final pair was candidate 141.0 followed by beta 140.9. This result is reported as telemetry rather than used as evidence for the shape-specific 27B speed claim above.

## Correctness evidence

- AR/LongBench ABBA: **240/240** runs completed without runtime errors; every baseline/candidate output was byte-identical within each host.
- gfx1100 DFlash attention CPU-reference matrix: **336 cases, 0 failures**, max abs diff `3.052e-5` (`1e-3` tolerance).
- gfx1201 generic-WMMA CPU-reference matrix: **112 cases, 0 failures**, max abs diff `3.052e-5` (`1e-3` tolerance), covering B={1,16,17,32}, L={1,127,128,13951,13952,13953,16384}, and head_dim={64,128,256} on the WMMA route.
- Isolated-cache E2E A/B produced identical token streams, cycle counts, accepted-token counts, and tau at both 1120 and 4397 prompt tokens on gfx1100.
- gfx1201 scalar/vector resident runs produced identical full token-stream hashes (`d2f7e22bfdaae1153bf8c58f72c512a5969592f733c3d29a49af2eb526725728`), 22 cycles, 105 accepted tokens, and tau=4.773 on every measured row.
- The ctx=2048 merge-sort smoke remained coherent and token-exact after the scratch and post-RoPE cache changes. Prompt MD5: `253c7ac50857fe6d0e10fb0d2c5e35c0`.
- The gfx1201 resident comparison used `benchmarks/prompts/coherence_lloyd_long.txt`, MD5 `f20bbc4f5b88ab5f7b44fe7c7da0e2e3`.
- A combined four-commit long-generation smoke at ctx=2048 produced coherent 1024-token outputs in both modes: AR 39.61 tok/s; DFlash 49.85 tok/s, 316 cycles, 709 accepted tokens, tau=2.244 (1.26x DFlash/AR).

## Test plan

- [ ] `./scripts/no-gpu-ci.sh` passes, or equivalent CI job is green
- [x] `cargo build --release --locked --workspace --features deltanet` clean
- [ ] `cargo test --lib --workspace --features deltanet` passes
- [ ] `python3 -m tools.change_gate run --base beta --md gate.md`
- [ ] If perf-relevant: `./scripts/speed-gate.sh` within ±2% of locked baselines
- [x] `cargo test --locked -p rdna-compute --lib` — 162 passed
- [x] `cargo build --release --locked --features deltanet -p hipfire-runtime --example dflash_spec_demo`
- [x] W7900 1024-token AR ABBA and two-host LongBench-v2 hard30 ABBA — 240/240 completed, byte-identical within host
- [x] gfx1100 and gfx1201 model-level generation, numeric parity, and matched performance runs described above
- [x] Combined four-commit gfx1100 attention CPU-reference matrix — 336/336 passed, max abs diff `3.052e-5`
- [x] Combined four-commit 1024-token AR/DFlash coherent-generation smoke

`python3 -m tools.change_gate run --base origin/beta` completed its locally runnable preflights. The affected unit routes and kernel-channel detection passed. The overall verdict is `incomplete`: six routes were unavailable because of missing local models or architecture, Redline lacked a prebuilt daemon, and the serve batteries rejected their inherited think-token/max-token combinations before model execution. `bind-thread` and `env-docs` fail identically in a clean detached `origin/beta` worktree, so they are inherited rather than introduced here. The speed route's locked 178 tok/s gfx1100 baseline is also from different hardware; the same-device beta/candidate telemetry is reported above.

<details><summary>change_gate telemetry</summary>

```text
verdict=incomplete
pass: detect.kernels-channel, unit.arch-qwen35, unit.diff-check,
      unit.hipfire-dispatch, unit.hipfire-runtime, unit.rdna-compute
inherited on clean origin/beta: shell.bind-thread, unit.env-docs
precondition failures: redline.capture and three serve batteries
blocked/not-run: six routes (missing local models or incompatible local arch)
speed telemetry on W7900: beta 140.9–143.0, candidate 140.9–141.6 tok/s
```

</details>

## Architecture-trait change?

No. This does not change the `Architecture` trait or dispatch routing.
