### PR TITLE
fix(scripts): close unterminated quote that broke serve_concurrency_gate.sh parsing

### DIFF
--- a/scripts/serve_concurrency_gate.sh
+++ b/scripts/serve_concurrency_gate.sh
@@ -70,7 +70,7 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 [ -f "$MODEL" ] || fail "model not found: $MODEL"
 [ -x "$ROOT/target/release/hipfire" ] || fail "build first: cargo build --release -p hipfire-cli"
 DAEMON="$ROOT/target/release/daemon"
-[ -x "$DAEMON" ] || fail "build first: cargo build --release -p hipfire-daemon
+[ -x "$DAEMON" ] || fail "build first: cargo build --release -p hipfire-daemon"
 
 if ss -ltn 2>/dev/null | grep -q ":$PORT "; then
   fail "port $PORT already in use"


### PR DESCRIPTION
## Summary

`fe031717` (daemon crate move) left `fail "build first: cargo build --release -p hipfire-daemon` without its closing quote, so bash fails to parse the entire script (`syntax error near unexpected token '('`, reported at line 174 inside the python heredoc) and the gate exits 2 before ever starting a server. One-character fix; `bash -n scripts/serve_concurrency_gate.sh` is clean after.

Side note, not addressed here: the gate also needs `bc` on PATH (absent on NixOS by default) — flagging in case a POSIX-arithmetic rewrite is preferred over the dependency.

## Which crate(s) does this touch?

- [x] docs / CI / scripts

## Test plan

- [x] `bash -n scripts/serve_concurrency_gate.sh` clean (was: syntax error, exit 2)
- [x] Gate parses and runs end-to-end again
- [x] Change gate run and telemetry pasted below

<details><summary>change_gate telemetry</summary>

```
**change_gate: PASS**

host gfx=`gfx1100` rocm=`6.18.37` models_dir=`/home/alpineq/.hipfire/models` · `80a572c824dcbbcdddac1cc5f6d1a7e91d7c4dd6`..`f76d3c3f1953c7c7c67b8d4baa680441fa7f0c6e` dirty · est=0.0min actual=0.0s

### Routes RUN
| route | status | duration |
| ----- | ------ | -------- |
| —     | —      | —        |

### Routes NOT RUN
| route | reason |
| ----- | ------ |
| —     | —      |

_Blocked or excluded routes mean coverage is incomplete — this report is not an admission that unrun surfaces are safe._
```

</details>
