### PR TITLE
Fix hipfire-quantize compilation on Windows

### DIFF
--- a/crates/hipfire-quantize/src/hessian_io.rs
+++ b/crates/hipfire-quantize/src/hessian_io.rs
@@ -20,7 +20,9 @@
 //! `get(tensor_name_without_dot_weight_suffix, 0)` per MQ4G256 tensor.
 
 use byteorder::{ByteOrder, LittleEndian};
-use memmap2::{Advice, Mmap};
+#[cfg(unix)]
+use memmap2::Advice;
+use memmap2::Mmap;
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
@@ -36,8 +38,15 @@ pub enum HessianError {
     Io(std::io::Error),
     InvalidMagic([u8; 4]),
     UnsupportedVersion(u32),
-    TruncatedFile { needed: usize, have: usize },
-    NegativeDiagonal { tensor: String, index: usize, value: f32 },
+    TruncatedFile {
+        needed: usize,
+        have: usize,
+    },
+    NegativeDiagonal {
+        tensor: String,
+        index: usize,
+        value: f32,
+    },
     UnknownDtype(u32),
 }
 
@@ -46,7 +55,11 @@ impl std::fmt::Display for HessianError {
         match self {
             HessianError::Io(e) => write!(f, "I/O error: {e}"),
             HessianError::InvalidMagic(m) => {
-                write!(f, "invalid HFHS magic: got {m:?}, expected {:?}", HFHS_MAGIC)
+                write!(
+                    f,
+                    "invalid HFHS magic: got {m:?}, expected {:?}",
+                    HFHS_MAGIC
+                )
             }
             HessianError::UnsupportedVersion(v) => {
                 write!(f, "unsupported HFHS version {v}, this build understands v{HFHS_VERSION_SUPPORTED}")
@@ -54,7 +67,11 @@ impl std::fmt::Display for HessianError {
             HessianError::TruncatedFile { needed, have } => {
                 write!(f, "HFHS truncated: needed {needed} bytes, file is {have}")
             }
-            HessianError::NegativeDiagonal { tensor, index, value } => write!(
+            HessianError::NegativeDiagonal {
+                tensor,
+                index,
+                value,
+            } => write!(
                 f,
                 "Hessian for tensor {tensor:?} has negative diagonal H[{index},{index}] = {value} \
                  (should be ≥0 by PSD construction; likely FP corruption — fall back to plain MQ4)"
@@ -112,7 +129,11 @@ impl<'a> HessianRef<'a> {
 
     /// Read the `[i, j]` entry as f64. O(1).
     pub fn at(&self, i: usize, j: usize) -> f64 {
-        debug_assert!(i < self.k && j < self.k, "out of bounds: H[{i},{j}] K={}", self.k);
+        debug_assert!(
+            i < self.k && j < self.k,
+            "out of bounds: H[{i},{j}] K={}",
+            self.k
+        );
         let off = (i * self.k + j) * self.dtype.size_bytes();
         match self.dtype {
             HessianDtype::F32 => LittleEndian::read_f32(&self.bytes[off..off + 4]) as f64,
@@ -123,7 +144,7 @@ impl<'a> HessianRef<'a> {
 
 /// Per-tensor record layout (computed at open, points into the mmap).
 struct TensorEntry {
-    name_offset: usize,    // byte offset of the name string in mmap
+    name_offset: usize, // byte offset of the name string in mmap
     name_len: usize,
     expert_idx: u32,
     k: usize,
@@ -158,7 +179,6 @@ impl HessianSidecar {
         {
             mmap.advise(Advice::Sequential).ok();
         }
-        let _ = Advice::Sequential; // silence unused on non-unix
 
         if mmap.len() < HEADER_SIZE {
             return Err(HessianError::TruncatedFile {
@@ -183,7 +203,10 @@ impl HessianSidecar {
         let mut pos = HEADER_SIZE;
         for _ in 0..n_tensors {
             if pos + 4 > mmap.len() {
-                return Err(HessianError::TruncatedFile { needed: pos + 4, have: mmap.len() });
+                return Err(HessianError::TruncatedFile {
+                    needed: pos + 4,
+                    have: mmap.len(),
+                });
             }
             let name_len = LittleEndian::read_u32(&mmap[pos..pos + 4]) as usize;
             pos += 4;
@@ -195,7 +218,7 @@ impl HessianSidecar {
             }
             let name_offset = pos;
             let name = std::str::from_utf8(&mmap[pos..pos + name_len])
-                .map_err(|_| HessianError::InvalidMagic([0; 4]))?  // reuse for UTF-8 failure
+                .map_err(|_| HessianError::InvalidMagic([0; 4]))? // reuse for UTF-8 failure
                 .to_string();
             pos += name_len;
             let expert_idx = LittleEndian::read_u32(&mmap[pos..pos + 4]);
@@ -249,8 +272,10 @@ impl HessianSidecar {
         // than alternative gymnastics for this rare-call path.
         let entry = self.index.get(&(name.to_string(), expert_idx))?;
         Some(HessianRef {
-            name: std::str::from_utf8(&self.mmap[entry.name_offset..entry.name_offset + entry.name_len])
-                .ok()?,
+            name: std::str::from_utf8(
+                &self.mmap[entry.name_offset..entry.name_offset + entry.name_len],
+            )
+            .ok()?,
             expert_idx: entry.expert_idx,
             k: entry.k,
             dtype: entry.dtype,
@@ -262,8 +287,10 @@ impl HessianSidecar {
     /// symmetry / PSD check at start of quantize) and debug dumps.
     pub fn tensors(&self) -> impl Iterator<Item = HessianRef<'_>> + '_ {
         self.index.values().map(|entry| HessianRef {
-            name: std::str::from_utf8(&self.mmap[entry.name_offset..entry.name_offset + entry.name_len])
-                .unwrap_or(""),
+            name: std::str::from_utf8(
+                &self.mmap[entry.name_offset..entry.name_offset + entry.name_len],
+            )
+            .unwrap_or(""),
             expert_idx: entry.expert_idx,
             k: entry.k,
             dtype: entry.dtype,
@@ -345,17 +372,17 @@ mod tests {
 
         // Header
         f.write_all(b"HFHS").unwrap();
-        f.write_all(&1u32.to_le_bytes()).unwrap();      // version
-        f.write_all(&2u64.to_le_bytes()).unwrap();      // n_tensors
-        f.write_all(&0u64.to_le_bytes()).unwrap();      // reserved
+        f.write_all(&1u32.to_le_bytes()).unwrap(); // version
+        f.write_all(&2u64.to_le_bytes()).unwrap(); // n_tensors
+        f.write_all(&0u64.to_le_bytes()).unwrap(); // reserved
 
         // Tensor 1: "tA", expert_idx=0, K=2, FP32, H = [[1.0, 0.5], [0.5, 2.0]]
         let name1 = b"tA";
         f.write_all(&(name1.len() as u32).to_le_bytes()).unwrap();
         f.write_all(name1).unwrap();
-        f.write_all(&0u32.to_le_bytes()).unwrap();      // expert_idx
-        f.write_all(&2u32.to_le_bytes()).unwrap();      // K
-        f.write_all(&1u32.to_le_bytes()).unwrap();      // dtype = F32
+        f.write_all(&0u32.to_le_bytes()).unwrap(); // expert_idx
+        f.write_all(&2u32.to_le_bytes()).unwrap(); // K
+        f.write_all(&1u32.to_le_bytes()).unwrap(); // dtype = F32
         for v in [1.0_f32, 0.5_f32, 0.5_f32, 2.0_f32] {
             f.write_all(&v.to_le_bytes()).unwrap();
         }
@@ -364,9 +391,9 @@ mod tests {
         let name2 = b"tB";
         f.write_all(&(name2.len() as u32).to_le_bytes()).unwrap();
         f.write_all(name2).unwrap();
-        f.write_all(&3u32.to_le_bytes()).unwrap();      // expert_idx
-        f.write_all(&2u32.to_le_bytes()).unwrap();      // K
-        f.write_all(&2u32.to_le_bytes()).unwrap();      // dtype = F64
+        f.write_all(&3u32.to_le_bytes()).unwrap(); // expert_idx
+        f.write_all(&2u32.to_le_bytes()).unwrap(); // K
+        f.write_all(&2u32.to_le_bytes()).unwrap(); // dtype = F64
         for v in [3.0_f64, 1.0_f64, 1.0_f64, 4.0_f64] {
             f.write_all(&v.to_le_bytes()).unwrap();
         }
@@ -459,7 +486,10 @@ mod tests {
     fn python_fixture_hfhs_roundtrip() {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
         path.push("reference_gptq/fixtures/smoke.hfhs");
-        assert!(path.is_file(), "missing fixture {path:?}; run reference_gptq/make_fixtures.py");
+        assert!(
+            path.is_file(),
+            "missing fixture {path:?}; run reference_gptq/make_fixtures.py"
+        );
         let sc = HessianSidecar::open(&path).expect("open python HFHS fixture");
         assert_eq!(sc.n_tensors(), 2);
 
@@ -471,7 +501,9 @@ mod tests {
         assert_eq!(t0.at(1, 0), 0.25);
         assert_eq!(t0.at(1, 1), 2.0);
 
-        let t1 = sc.get("model.layers.1.mlp.down_proj", 3).expect("down_proj expert 3");
+        let t1 = sc
+            .get("model.layers.1.mlp.down_proj", 3)
+            .expect("down_proj expert 3");
         assert_eq!(t1.k, 3);
         assert_eq!(t1.dtype, HessianDtype::F32);
         assert!((t1.at(0, 0) - 3.0).abs() < 1e-6);


### PR DESCRIPTION
## Summary

`hipfire-quantize` fails to compile on Windows because `memmap2::Advice` is exported unix-only (memmap2 0.9, `#[cfg(unix)]`), but `hessian_io.rs` imports it unconditionally:

```
error[E0432]: unresolved import `memmap2::Advice`
  --> crates/hipfire-quantize/src/hessian_io.rs:23:15
```

This also breaks the documented whole-workspace build (`cargo build --release --workspace`) on Windows.

## Fix

- Gate the `Advice` import behind `#[cfg(unix)]`.
- Drop the stray `let _ = Advice::Sequential;` lint-silencer; it referenced the broken import and is unnecessary once the import is gated.

The `mmap.advise(...)` call was already `#[cfg(unix)]`-gated, so there is no behavior change on unix. On Windows the sequential-access hint is simply skipped; `Mmap::map` itself is fully supported there. The remaining diff churn in the file is `rustfmt` output required by the changed-file fmt gate.

## Testing

- Windows 11, `x86_64-pc-windows-msvc`, rustc 1.97.1, memmap2 0.9.11:
  - before: `cargo build --release -p hipfire-quantize` -> E0432
  - after: builds clean; `hipfire-quantize --help` runs
- `cargo clippy -p hipfire-quantize`: no warnings in the changed file (crate's other warnings pre-exist on all platforms)
- Whole workspace now completes on Windows with no `--exclude`

LLM Disclosure: Yes, used GLM-5.3 to help along