### PR TITLE
fix(quantize): gemma4 GGUF config + tensor-name translation

### DIFF
--- a/crates/hipfire-quantize/Cargo.toml
+++ b/crates/hipfire-quantize/Cargo.toml
@@ -32,6 +32,10 @@ tempfile = "3"
 # integration test lives in-module in reap_overlay.rs (it needs crate-internal
 # write_hfq / quantize_* access that a tests/ target can't reach).
 hipfire-runtime = { path = "../hipfire-runtime" }
+# Test-only: parse `config_json_from_gguf` output through the REAL gemma4
+# loader parser (Gemma4Config::from_metadata_json) — the config-emission /
+# loader-admission boundary is where the GGUF gemma4 gap sat.
+hipfire-arch-gemma4 = { path = "../hipfire-arch-gemma4" }
 # Test-only: the MQ*-G256-GL codebooks (GL_CB2/GL_CB3) and SoA group sizes are
 # duplicated between this encoder and the runtime (the kernels take the codebook
 # as scalar args; it is NOT stored in the .hfq). `gl_codebooks_match_runtime` /
@@ -39,7 +43,6 @@ hipfire-runtime = { path = "../hipfire-runtime" }
 # identical, so a drift becomes a red test instead of a silent accuracy loss.
 # dev-dependency only — the quantizer still builds and runs with no GPU/ROCm.
 rdna-compute = { path = "../rdna-compute" }
-
 # ---------------------------------------------------------------------------
 # Archived research probes.
 #

--- a/crates/hipfire-quantize/src/calibration.rs
+++ b/crates/hipfire-quantize/src/calibration.rs
@@ -107,7 +107,7 @@ pub(crate) fn is_gguf_input(p: &Path) -> bool {
 /// Returns None for tensors that don't have a known safetensors equivalent
 /// (we then keep them under their GGUF name; the future loader can decide
 /// what to do, or they're skipped).
-pub(crate) fn gguf_to_safetensors_name(gguf_name: &str) -> Option<String> {
+pub(crate) fn gguf_to_safetensors_name(gguf_name: &str, arch_str: &str) -> Option<String> {
     // Top-level tensors.
     match gguf_name {
         "token_embd.weight" => return Some("model.embed_tokens.weight".to_string()),
@@ -123,6 +123,35 @@ pub(crate) fn gguf_to_safetensors_name(gguf_name: &str) -> Option<String> {
         let slot_full = &rest[dot + 1..]; // "<slot>.weight"
                                           // Drop the trailing ".weight" so we can rewrite slots like "attn_q"→"self_attn.q_proj".
         let slot = slot_full.strip_suffix(".weight")?;
+        // Gemma 4 layers carry FOUR sandwich norms plus a per-layer scalar.
+        // The generic Llama slot map below assumes two norms and maps
+        // `ffn_norm` → post_attention_layernorm — correct for Llama, WRONG
+        // for gemma4 (that is the pre-FFN norm). The loader reads
+        // `{p}.layer_scalar` with NO `.weight` suffix (HF tensor name), so
+        // `layer_output_scale` needs an early return.
+        if arch_str == "gemma4" {
+            match slot {
+                "post_attention_norm" => {
+                    return Some(format!(
+                        "model.layers.{layer_idx}.post_attention_layernorm.weight"
+                    ));
+                }
+                "ffn_norm" => {
+                    return Some(format!(
+                        "model.layers.{layer_idx}.pre_feedforward_layernorm.weight"
+                    ));
+                }
+                "post_ffw_norm" => {
+                    return Some(format!(
+                        "model.layers.{layer_idx}.post_feedforward_layernorm.weight"
+                    ));
+                }
+                "layer_output_scale" => {
+                    return Some(format!("model.layers.{layer_idx}.layer_scalar"));
+                }
+                _ => {}
+            }
+        }
         let translated = match slot {
             "attn_norm" => "input_layernorm".to_string(),
             "ffn_norm" => "post_attention_layernorm".to_string(),
@@ -720,9 +749,219 @@ pub(crate) fn config_json_from_gguf(gguf: &gguf_input::GgufFile, arch_str: &str)
     if let Some(v) = head_dim {
         cfg.insert("head_dim".to_string(), serde_json::Value::from(v));
     }
+    if arch_str == "gemma4" {
+        apply_gemma4_fields(gguf, prefix, &mut cfg);
+    }
     cfg.insert("bos_token_id".to_string(), serde_json::Value::from(bos));
     cfg.insert("eos_token_id".to_string(), serde_json::Value::from(eos));
     serde_json::Value::Object(cfg)
+}
+
+/// Translate gemma4-specific GGUF metadata into the `text_config` fields the
+/// `hipfire-arch-gemma4` loader expects. The generic `config_json_from_gguf`
+/// path only reads Llama-style scalar keys; gemma4 stores its layout as arrays
+/// and dual sliding/full keys that the generic reads miss or misread:
+///
+/// - `attention.sliding_window_pattern` (bool array) -> `layer_types`
+///   (the loader hard-requires it; GGUF has no `layer_types` key).
+/// - `attention.head_count_kv` is an ARRAY (8 sliding / 1 full layers);
+///   the generic scalar read fails and falls back to n_heads. Split it into
+///   `num_key_value_heads` (sliding) / `num_global_key_value_heads` (full).
+/// - `attention.key_length` = 512 is the FULL head dim; sliding is
+///   `key_length_swa` = 256. Generic wrote key_length into `head_dim`.
+/// - Dual rope: `rope.freq_base_swa` (10k) vs `rope.freq_base` (1M) plus
+///   proportional partial rotary on full layers -> `rope_parameters`.
+/// - `attention_k_eq_v`: 12B-class checkpoints ship no `attn_v` tensor on
+///   full layers (V = pre-k_norm K). Detect from the tensor table.
+fn apply_gemma4_fields(
+    gguf: &gguf_input::GgufFile,
+    prefix: &str,
+    cfg: &mut serde_json::Map<String, serde_json::Value>,
+) {
+    let read_u = |k: &str| -> Option<u64> {
+        gguf.metadata.get(k).and_then(|v| match v {
+            gguf_input::MetaValue::U8(x) => Some(*x as u64),
+            gguf_input::MetaValue::I8(x) => Some(*x as u64),
+            gguf_input::MetaValue::U16(x) => Some(*x as u64),
+            gguf_input::MetaValue::I16(x) => Some(*x as u64),
+            gguf_input::MetaValue::U32(x) => Some(*x as u64),
+            gguf_input::MetaValue::I32(x) => Some(*x as u64),
+            gguf_input::MetaValue::U64(x) => Some(*x),
+            gguf_input::MetaValue::I64(x) => Some(*x as u64),
+            _ => None,
+        })
+    };
+    let read_f = |k: &str| -> Option<f64> {
+        gguf.metadata.get(k).and_then(|v| match v {
+            gguf_input::MetaValue::F32(x) => Some(*x as f64),
+            gguf_input::MetaValue::F64(x) => Some(*x),
+            _ => None,
+        })
+    };
+    let read_arr_u = |k: &str| -> Option<Vec<u64>> {
+        gguf.metadata.get(k).and_then(|v| match v {
+            gguf_input::MetaValue::Array(arr) => arr
+                .iter()
+                .map(|item| match item {
+                    gguf_input::MetaValue::U8(x) => Some(*x as u64),
+                    gguf_input::MetaValue::I8(x) => Some(*x as u64),
+                    gguf_input::MetaValue::U16(x) => Some(*x as u64),
+                    gguf_input::MetaValue::I16(x) => Some(*x as u64),
+                    gguf_input::MetaValue::U32(x) => Some(*x as u64),
+                    gguf_input::MetaValue::I32(x) => Some(*x as u64),
+                    gguf_input::MetaValue::U64(x) => Some(*x),
+                    gguf_input::MetaValue::I64(x) => Some(*x as u64),
+                    _ => None,
+                })
+                .collect::<Option<Vec<u64>>>(),
+            _ => None,
+        })
+    };
+    let ins_u = |cfg: &mut serde_json::Map<String, serde_json::Value>, k: &str, v: u64| {
+        cfg.insert(k.to_string(), serde_json::Value::from(v));
+    };
+    let ins_f = |cfg: &mut serde_json::Map<String, serde_json::Value>, k: &str, v: f64| {
+        cfg.insert(k.to_string(), serde_json::Value::from(v));
+    };
+
+    // ── layer_types from the sliding-window pattern (required by loader) ──
+    // GGUF: true = sliding, false = full (global). Loader strings:
+    // "sliding_attention" / "full_attention".
+    let pattern = gguf
+        .metadata
+        .get(&format!("{prefix}.attention.sliding_window_pattern"))
+        .and_then(|v| match v {
+            gguf_input::MetaValue::Array(arr) => arr
+                .iter()
+                .map(|item| match item {
+                    gguf_input::MetaValue::Bool(b) => Some(*b),
+                    _ => None,
+                })
+                .collect::<Option<Vec<bool>>>(),
+            _ => None,
+        });
+    let full_layer_indices: Vec<usize> = pattern
+        .as_ref()
+        .map(|p| {
+            p.iter()
+                .enumerate()
+                .filter(|(_, b)| !**b)
+                .map(|(i, _)| i)
+                .collect()
+        })
+        .unwrap_or_default();
+    if let Some(p) = &pattern {
+        let layer_types: Vec<&str> = p
+            .iter()
+            .map(|&b| {
+                if b {
+                    "sliding_attention"
+                } else {
+                    "full_attention"
+                }
+            })
+            .collect();
+        cfg.insert(
+            "layer_types".to_string(),
+            serde_json::Value::Array(
+                layer_types
+                    .into_iter()
+                    .map(serde_json::Value::from)
+                    .collect(),
+            ),
+        );
+    }
+
+    // ── KV heads: array form is per-layer (sliding/full differ) ──
+    let kv_arr = read_arr_u(&format!("{prefix}.attention.head_count_kv"));
+    match (&kv_arr, &pattern) {
+        (Some(arr), Some(p)) if arr.len() == p.len() && !arr.is_empty() => {
+            // Sliding value: first element at a sliding index (pattern true).
+            if let Some((_, &v)) = p.iter().zip(arr.iter()).find(|(&b, _)| b) {
+                ins_u(cfg, "num_key_value_heads", v);
+            }
+            // Full value: element at a full index (pattern false).
+            if let Some((_, &v)) = p.iter().zip(arr.iter()).find(|(&b, _)| !b) {
+                ins_u(cfg, "num_global_key_value_heads", v);
+            }
+        }
+        _ => {}
+    }
+
+    // ── Head dims: key_length is the FULL dim; key_length_swa is sliding ──
+    if let Some(v) = read_u(&format!("{prefix}.attention.key_length_swa")) {
+        ins_u(cfg, "head_dim", v);
+    }
+    if let Some(v) = read_u(&format!("{prefix}.attention.key_length")) {
+        ins_u(cfg, "global_head_dim", v);
+    }
+
+    // ── Simple scalar carries the generic path missed ──
+    if let Some(v) = read_u(&format!("{prefix}.attention.sliding_window")) {
+        ins_u(cfg, "sliding_window", v);
+    }
+    if let Some(v) = read_u(&format!("{prefix}.attention.shared_kv_layers")) {
+        ins_u(cfg, "num_kv_shared_layers", v);
+    }
+    if let Some(v) = read_u(&format!("{prefix}.embedding_length_per_layer_input")) {
+        ins_u(cfg, "hidden_size_per_layer_input", v);
+    }
+    if let Some(v) = read_f(&format!("{prefix}.final_logit_softcapping")) {
+        ins_f(cfg, "final_logit_softcapping", v);
+    }
+
+    // ── Dual rope parameters ──
+    // Sliding: default rope at freq_base_swa (10k). Full: proportional
+    // partial rotary at freq_base (1M). partial_rotary_factor has no GGUF
+    // key in the wild; 0.25 is the family constant (arch config documents
+    // it alongside the 1M full theta) — read the GGUF key if a exporter
+    // ever ships one.
+    let sliding_theta = read_f(&format!("{prefix}.rope.freq_base_swa"));
+    let full_theta = read_f(&format!("{prefix}.rope.freq_base"));
+    if sliding_theta.is_some() || full_theta.is_some() {
+        let partial = read_f(&format!("{prefix}.rope.partial_rotary_factor"));
+        let mut sliding = serde_json::Map::new();
+        if let Some(t) = sliding_theta {
+            sliding.insert("rope_theta".to_string(), serde_json::Value::from(t));
+        }
+        sliding.insert("rope_type".to_string(), serde_json::Value::from("default"));
+        let mut full = serde_json::Map::new();
+        if let Some(t) = full_theta {
+            full.insert("rope_theta".to_string(), serde_json::Value::from(t));
+        }
+        full.insert(
+            "rope_type".to_string(),
+            serde_json::Value::from("proportional"),
+        );
+        full.insert(
+            "partial_rotary_factor".to_string(),
+            serde_json::Value::from(partial.unwrap_or(0.25)),
+        );
+        let mut rp = serde_json::Map::new();
+        rp.insert(
+            "sliding_attention".to_string(),
+            serde_json::Value::Object(sliding),
+        );
+        rp.insert(
+            "full_attention".to_string(),
+            serde_json::Value::Object(full),
+        );
+        cfg.insert("rope_parameters".to_string(), serde_json::Value::Object(rp));
+    }
+
+    // ── attention_k_eq_v: no attn_v tensor on full layers (12B class) ──
+    if let Some(&first_full) = full_layer_indices.first() {
+        let has_v_on_full = gguf
+            .tensors
+            .iter()
+            .any(|t| t.name == format!("blk.{first_full}.attn_v.weight"));
+        if !has_v_on_full {
+            cfg.insert(
+                "attention_k_eq_v".to_string(),
+                serde_json::Value::from(true),
+            );
+        }
+    }
 }
 
 /// Translate the GGUF metadata HashMap into a JSON object that ends up in
@@ -756,5 +995,244 @@ pub(crate) fn mv_to_json(v: &gguf_input::MetaValue) -> serde_json::Value {
         // Tokenizer arrays (tokens, scores, merges, ...) can be huge —
         // serialize them as JSON arrays so the engine side can re-parse.
         MV::Array(arr) => serde_json::Value::Array(arr.iter().map(mv_to_json).collect()),
+    }
+}
+#[cfg(test)]
+mod gemma4_config_tests {
+    use crate::calibration::config_json_from_gguf;
+    use crate::gguf_input::{GgufFile, MetaValue, TensorInfo};
+    use std::collections::HashMap;
+
+    /// Metadata + tensor table mirroring the real gemma-4-12b GGUF layout
+    /// (48 layers, 5:1 sliding:full, per-layer kv array, dual rope, no
+    /// attn_v on full layers). Values taken from a production file.
+    fn gemma4_12b_gguf() -> GgufFile {
+        let mut m: HashMap<String, MetaValue> = HashMap::new();
+        let kv_arr: Vec<MetaValue> = (0..48)
+            .map(|i| MetaValue::U32(if i % 6 == 5 { 1 } else { 8 }))
+            .collect();
+        let pattern: Vec<MetaValue> = (0..48).map(|i| MetaValue::Bool(i % 6 != 5)).collect();
+        m.insert("gemma4.attention.head_count".into(), MetaValue::U32(16));
+        m.insert(
+            "gemma4.attention.head_count_kv".into(),
+            MetaValue::Array(kv_arr),
+        );
+        m.insert("gemma4.attention.key_length".into(), MetaValue::U32(512));
+        m.insert(
+            "gemma4.attention.key_length_swa".into(),
+            MetaValue::U32(256),
+        );
+        m.insert(
+            "gemma4.attention.layer_norm_rms_epsilon".into(),
+            MetaValue::F32(1e-6),
+        );
+        m.insert(
+            "gemma4.attention.shared_kv_layers".into(),
+            MetaValue::U32(0),
+        );
+        m.insert(
+            "gemma4.attention.sliding_window".into(),
+            MetaValue::U32(1024),
+        );
+        m.insert(
+            "gemma4.attention.sliding_window_pattern".into(),
+            MetaValue::Array(pattern),
+        );
+        m.insert("gemma4.block_count".into(), MetaValue::U32(48));
+        m.insert("gemma4.context_length".into(), MetaValue::U32(262144));
+        m.insert("gemma4.embedding_length".into(), MetaValue::U32(3840));
+        m.insert(
+            "gemma4.embedding_length_per_layer_input".into(),
+            MetaValue::U32(0),
+        );
+        m.insert("gemma4.feed_forward_length".into(), MetaValue::U32(15360));
+        m.insert(
+            "gemma4.final_logit_softcapping".into(),
+            MetaValue::F32(30.0),
+        );
+        m.insert("gemma4.rope.freq_base".into(), MetaValue::F64(1_000_000.0));
+        m.insert("gemma4.rope.freq_base_swa".into(), MetaValue::F64(10_000.0));
+        m.insert(
+            "general.architecture".into(),
+            MetaValue::String("gemma4".into()),
+        );
+
+        let mut tensors = vec![TensorInfo {
+            name: "token_embd.weight".into(),
+            shape: vec![3840, 262144],
+            ..fake_tensor()
+        }];
+        for i in 0..48 {
+            tensors.push(TensorInfo {
+                name: format!("blk.{i}.attn_k.weight"),
+                ..fake_tensor()
+            });
+            if i % 6 != 5 {
+                // v tensor only on sliding layers (12B k_eq_v layout).
+                tensors.push(TensorInfo {
+                    name: format!("blk.{i}.attn_v.weight"),
+                    ..fake_tensor()
+                });
+            }
+        }
+        GgufFile::for_tests(m, tensors).unwrap()
+    }
+
+    fn fake_tensor() -> TensorInfo {
+        TensorInfo {
+            name: String::new(),
+            shape: vec![1, 1],
+            offset: 0,
+            dtype: crate::gguf_input::GgmlType::F32,
+        }
+    }
+
+    #[test]
+    fn gemma4_gguf_config_has_layout_fields() {
+        let cfg = config_json_from_gguf(&gemma4_12b_gguf(), "gemma4");
+        let lt = cfg["layer_types"].as_array().unwrap();
+        assert_eq!(lt.len(), 48);
+        for (i, v) in lt.iter().enumerate() {
+            let expect = if i % 6 == 5 {
+                "full_attention"
+            } else {
+                "sliding_attention"
+            };
+            assert_eq!(v.as_str().unwrap(), expect, "layer {i}");
+        }
+        assert_eq!(cfg["num_key_value_heads"].as_u64(), Some(8));
+        assert_eq!(cfg["num_global_key_value_heads"].as_u64(), Some(1));
+        assert_eq!(cfg["head_dim"].as_u64(), Some(256));
+        assert_eq!(cfg["global_head_dim"].as_u64(), Some(512));
+        assert_eq!(cfg["sliding_window"].as_u64(), Some(1024));
+        assert_eq!(cfg["final_logit_softcapping"].as_f64(), Some(30.0));
+        assert_eq!(cfg["attention_k_eq_v"].as_bool(), Some(true));
+        let rp = &cfg["rope_parameters"];
+        assert_eq!(
+            rp["sliding_attention"]["rope_theta"].as_f64(),
+            Some(10_000.0)
+        );
+        assert_eq!(
+            rp["sliding_attention"]["rope_type"].as_str(),
+            Some("default")
+        );
+        assert_eq!(
+            rp["full_attention"]["rope_theta"].as_f64(),
+            Some(1_000_000.0)
+        );
+        assert_eq!(
+            rp["full_attention"]["rope_type"].as_str(),
+            Some("proportional")
+        );
+        assert_eq!(
+            rp["full_attention"]["partial_rotary_factor"].as_f64(),
+            Some(0.25)
+        );
+        // Generic fields still populated.
+        assert_eq!(cfg["hidden_size"].as_u64(), Some(3840));
+        assert_eq!(cfg["num_hidden_layers"].as_u64(), Some(48));
+        assert_eq!(cfg["num_attention_heads"].as_u64(), Some(16));
+        assert_eq!(cfg["intermediate_size"].as_u64(), Some(15360));
+        assert_eq!(cfg["vocab_size"].as_u64(), Some(262144));
+    }
+
+    #[test]
+    fn gemma4_gguf_config_is_admitted_by_loader_parser() {
+        let cfg = config_json_from_gguf(&gemma4_12b_gguf(), "gemma4");
+        let metadata_json = serde_json::to_string(&serde_json::json!({ "config": cfg })).unwrap();
+        let parsed = hipfire_arch_gemma4::config::Gemma4Config::from_metadata_json(&metadata_json)
+            .expect("loader parser must admit the generated config");
+        assert_eq!(parsed.n_layers, 48);
+        assert_eq!(parsed.n_full_layers(), 8);
+        assert_eq!(parsed.n_sliding_layers(), 40);
+        assert_eq!(parsed.sliding_head_dim, 256);
+        assert_eq!(parsed.full_head_dim, 512);
+        assert_eq!(parsed.sliding_n_kv_heads, 8);
+        assert_eq!(parsed.full_n_kv_heads, 1);
+        assert!(parsed.attention_k_eq_v);
+        assert_eq!(
+            parsed.layer_types[5],
+            hipfire_arch_gemma4::config::LayerType::Full
+        );
+        assert_eq!(
+            parsed.layer_types[0],
+            hipfire_arch_gemma4::config::LayerType::Sliding
+        );
+    }
+
+    #[test]
+    fn gemma4_with_attn_v_on_full_layers_is_not_k_eq_v() {
+        let mut gguf = gemma4_12b_gguf();
+        gguf.tensors.push(TensorInfo {
+            name: "blk.5.attn_v.weight".into(),
+            ..fake_tensor()
+        });
+        let cfg = config_json_from_gguf(&gguf, "gemma4");
+        assert!(cfg.get("attention_k_eq_v").is_none());
+    }
+
+    #[test]
+    fn non_gemma4_arch_is_untouched() {
+        let mut m: HashMap<String, MetaValue> = HashMap::new();
+        m.insert("llama.embedding_length".into(), MetaValue::U32(4096));
+        m.insert("llama.block_count".into(), MetaValue::U32(32));
+        m.insert("llama.attention.head_count".into(), MetaValue::U32(32));
+        m.insert("llama.attention.head_count_kv".into(), MetaValue::U32(8));
+        m.insert("llama.attention.key_length".into(), MetaValue::U32(128));
+        m.insert("llama.feed_forward_length".into(), MetaValue::U32(11008));
+        m.insert("llama.rope.freq_base".into(), MetaValue::F32(10000.0));
+        let gguf = GgufFile::for_tests(m, vec![]).unwrap();
+        let cfg = config_json_from_gguf(&gguf, "llama");
+        assert!(cfg.get("layer_types").is_none());
+        assert!(cfg.get("rope_parameters").is_none());
+        assert!(cfg.get("attention_k_eq_v").is_none());
+        assert_eq!(cfg["num_key_value_heads"].as_u64(), Some(8));
+        assert_eq!(cfg["head_dim"].as_u64(), Some(128));
+    }
+}
+
+#[cfg(test)]
+mod gemma4_name_translation_tests {
+    use crate::calibration::gguf_to_safetensors_name;
+
+    #[test]
+    fn gemma4_sandwich_norms_map_to_loader_names() {
+        let f = |slot: &str| {
+            gguf_to_safetensors_name(&format!("blk.7.{slot}.weight"), "gemma4").unwrap()
+        };
+        assert_eq!(f("attn_norm"), "model.layers.7.input_layernorm.weight");
+        assert_eq!(
+            f("post_attention_norm"),
+            "model.layers.7.post_attention_layernorm.weight"
+        );
+        assert_eq!(
+            f("ffn_norm"),
+            "model.layers.7.pre_feedforward_layernorm.weight"
+        );
+        assert_eq!(
+            f("post_ffw_norm"),
+            "model.layers.7.post_feedforward_layernorm.weight"
+        );
+        // Loader reads `{p}.layer_scalar` with NO `.weight` suffix.
+        assert_eq!(f("layer_output_scale"), "model.layers.7.layer_scalar");
+        // Generic slots unchanged.
+        assert_eq!(f("attn_q"), "model.layers.7.self_attn.q_proj.weight");
+        assert_eq!(f("ffn_down"), "model.layers.7.mlp.down_proj.weight");
+    }
+
+    #[test]
+    fn llama_ffn_norm_still_maps_to_post_attention() {
+        // The two-norm Llama layout must be byte-identical to before the
+        // gemma4 arm existed — ffn_norm IS post_attention_layernorm there.
+        assert_eq!(
+            gguf_to_safetensors_name("blk.3.ffn_norm.weight", "llama").unwrap(),
+            "model.layers.3.post_attention_layernorm.weight"
+        );
+        // Gemma-4-only slots do not exist in Llama files; translation of an
+        // unexpected slot passes through untouched (no gemma4 arm taken).
+        assert_eq!(
+            gguf_to_safetensors_name("blk.3.post_ffw_norm.weight", "llama").unwrap(),
+            "model.layers.3.post_ffw_norm.weight"
+        );
     }
 }

--- a/crates/hipfire-quantize/src/gguf_input.rs
+++ b/crates/hipfire-quantize/src/gguf_input.rs
@@ -165,6 +165,26 @@ pub struct GgufFile {
 }
 
 impl GgufFile {
+    /// Test-only: metadata + tensor-table view with no backing file. The
+    /// mmap is a zero-length map of an empty temp file (memmap2 handles
+    /// zero-length files); config translation reads only `metadata` and
+    /// `tensors`.
+    #[cfg(test)]
+    pub fn for_tests(
+        metadata: HashMap<String, MetaValue>,
+        tensors: Vec<TensorInfo>,
+    ) -> io::Result<Self> {
+        let file = tempfile::tempfile()?;
+        let mmap = unsafe { Mmap::map(&file)? };
+        Ok(Self {
+            version: 3,
+            metadata,
+            tensors,
+            tensor_data_offset: 0,
+            mmap,
+        })
+    }
+
     pub fn open(path: &Path) -> io::Result<Self> {
         let file = File::open(path)?;
         let mmap = unsafe { Mmap::map(&file)? };

--- a/crates/hipfire-quantize/src/pipeline_gguf.rs
+++ b/crates/hipfire-quantize/src/pipeline_gguf.rs
@@ -355,8 +355,8 @@ pub(crate) fn run_gguf_pipeline(
         let mut map = HashMap::new();
         let mut counts = [0u32; 4];
         for info in &gguf.tensors {
-            let out_name =
-                gguf_to_safetensors_name(&info.name).unwrap_or_else(|| info.name.clone());
+            let out_name = gguf_to_safetensors_name(&info.name, &arch_str)
+                .unwrap_or_else(|| info.name.clone());
             let level = kmap_resolve_mode(&out_name, n_layers, is_moe, kmap_mode);
             match level {
                 QuantLevel::F16 => counts[0] += 1,
@@ -410,7 +410,8 @@ pub(crate) fn run_gguf_pipeline(
         // Translate to the safetensors-style name `hipfire_runtime::hfq::load_weights_hfq`
         // expects. If we don't have a translation, keep the original name —
         // the future loader can ignore unknown tensors.
-        let out_name = gguf_to_safetensors_name(&info.name).unwrap_or_else(|| info.name.clone());
+        let out_name =
+            gguf_to_safetensors_name(&info.name, &arch_str).unwrap_or_else(|| info.name.clone());
 
         let kmap_level = kmap.get(&out_name).copied().unwrap_or(QuantLevel::Base);
 


### PR DESCRIPTION
## Summary

GGUF -> HFQ quantization of gemma4 models produced unloadable artifacts.
`hipfire run` failed with `load failed: gemma4: missing layer_types array`.
The safetensors path (the one exercised in #439) is unaffected: HF
`config.json` and HF tensor names carry through verbatim. The GGUF path
goes through two generic Llama-assumed translation layers that were never
gemma4-aware.

LLM Disclosure: Yes, used GLM-5.3 to help along

## Fix

Two translation gaps, both gated on `arch_str == "gemma4"` (byte-identical
path for every other arch, regression-tested):

1. `config_json_from_gguf` (calibration.rs): gemma4 stores its layout as
   arrays and dual SWA/full keys the scalar reader misses or misreads.
   Added a gemma4 arm that emits:
   - `layer_types` from `attention.sliding_window_pattern` (bool array;
     GGUF has no `layer_types` key, loader hard-requires it)
   - `num_key_value_heads` / `num_global_key_value_heads` from the
     per-layer `head_count_kv` array (8 sliding / 1 full; scalar read
     silently fell back to n_heads)
   - `head_dim` = `key_length_swa` (256) and `global_head_dim` =
     `key_length` (512); the generic path wrote the full 512 into both
   - `rope_parameters` from `freq_base_swa` / `freq_base` (10k default
     sliding, 1M proportional + partial_rotary_factor 0.25 on full)
   - `attention_k_eq_v: true` when full layers ship no `attn_v` tensor
     (12B-class checkpoints; detected from the tensor table)
   - `sliding_window`, `num_kv_shared_layers`,
     `hidden_size_per_layer_input`, `final_logit_softcapping`

2. `gguf_to_safetensors_name` (calibration.rs): the Llama slot map
   assumed two norms per layer; gemma4 has four sandwich norms + a
   per-layer scalar. Without this, `ffn_norm` landed in
   `post_attention_layernorm` (wrong weights), `pre_feedforward_layernorm`
   was never emitted (guaranteed load failure), and `layer_output_scale`
   never became `layer_scalar` (loader reads it without a `.weight`
   suffix).

Tests parse the generated config through the real loader parser
(`Gemma4Config::from_metadata_json`, added as a dev-dependency of
hipfire-quantize) using metadata + tensor tables mirroring the production
gemma-4-12b GGUF.

Stacks on #612 (Windows build fix, cherry-picked so this branch compiles
on Windows; drop that commit if #612 merges first).

## Testing

- `cargo test -p hipfire-quantize gemma4`: 6 tests pass (layout fields,
  loader-parser admission, k_eq_v both ways, name translation, llama
  regression)
- Full crate suite: 117 pass; `glimmer_self_attn_*` and
  `sp4_overlay_to_sp3_load_end_to_end` fail/flake, both reproduce on
  clean master (order/env-dependent, pre-existing)
- End-to-end: `gemma-4-12b-it-heretic-BF16.gguf` (BF16, 23.8 GB) ->
  `--format hf4` -> loads and generates coherently on gfx1100
  (`HIPFIRE_GEMMA4_GRAPH=0`, see below), e.g. correct
  `def reverse_string(text): return text[::-1]` with explanation

Out of scope, found while testing: gemma4 hipGraph decode emits token
soup on gfx1100 with default `HIPFIRE_GEMMA4_GRAPH=1` (attractor
signature as documented in #439); eager path is byte-coherent. Will file
a separate issue.