### PR TITLE
fix(windows): daemon discovery, diag compiler probe, and quantize build

### DIFF
--- a/crates/hipfire-cli/src/main.rs
+++ b/crates/hipfire-cli/src/main.rs
@@ -4849,7 +4849,7 @@ fn diag_command(paths: &Paths, output: OutputArgs) -> Result<()> {
                 "path": root.display().to_string(),
                 "device_compiler": hipfire_config::rocm::DEVICE_COMPILERS
                     .iter()
-                    .find(|name| root.join("bin").join(name).is_file()),
+                    .find_map(|name| hipfire_config::rocm::tool_from_selected_root(root, name)),
                 "hip_headers": hipfire_config::rocm::is_complete_root(root),
                 "hip_runtime": hipfire_config::rocm::runtime_library(root)
                     .map(|p| p.display().to_string()),
@@ -5104,13 +5104,20 @@ pub(crate) fn find_daemon(paths: &Paths) -> Option<PathBuf> {
         }
     }
     let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target");
-    [
-        paths.root.join("bin/daemon"),
-        workspace.join("release/daemon"),
-        workspace.join("debug/daemon"),
-    ]
-    .into_iter()
-    .find(|path| path.is_file())
+    // Windows ships the daemon as `daemon.exe`; probe both spellings so a
+    // source-tree build (target/release/daemon.exe) and an install
+    // (~/.hipfire/bin/daemon.exe) are found without HIPFIRE_DAEMON_BIN.
+    #[cfg(windows)]
+    const DAEMON_NAMES: &[&str] = &["daemon.exe", "daemon"];
+    #[cfg(not(windows))]
+    const DAEMON_NAMES: &[&str] = &["daemon"];
+    let mut candidates = Vec::new();
+    for name in DAEMON_NAMES {
+        candidates.push(paths.root.join("bin").join(name));
+        candidates.push(workspace.join("release").join(name));
+        candidates.push(workspace.join("debug").join(name));
+    }
+    candidates.into_iter().find(|path| path.is_file())
 }
 
 pub(crate) fn request_f64(

--- a/crates/hipfire-cli/src/main.rs
+++ b/crates/hipfire-cli/src/main.rs
@@ -5104,15 +5104,30 @@ pub(crate) fn find_daemon(paths: &Paths) -> Option<PathBuf> {
         }
     }
     let workspace = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../target");
-    // Windows ships the daemon as `daemon.exe`; probe both spellings so a
-    // source-tree build (target/release/daemon.exe) and an install
-    // (~/.hipfire/bin/daemon.exe) are found without HIPFIRE_DAEMON_BIN.
-    #[cfg(windows)]
-    const DAEMON_NAMES: &[&str] = &["daemon.exe", "daemon"];
-    #[cfg(not(windows))]
-    const DAEMON_NAMES: &[&str] = &["daemon"];
+    find_daemon_in(paths, &workspace, cfg!(windows))
+}
+
+/// Daemon binary name candidates, most preferred first.
+///
+/// Windows ships the daemon as `daemon.exe`; ELF platforms ship an
+/// extensionless `daemon`. The bare spelling is kept as a fallback so a
+/// future extensionless shim still wins. `windows` is a pure parameter
+/// (mirroring `hipfire_config::rocm::tool_filename_candidates`) so the
+/// policy is unit-testable on any host without process-global env.
+fn daemon_bin_names(windows: bool) -> &'static [&'static str] {
+    if windows {
+        &["daemon.exe", "daemon"]
+    } else {
+        &["daemon"]
+    }
+}
+
+/// Candidate lookup shared by [`find_daemon`] and its platform-shaped tests:
+/// probe the install root (`~/.hipfire/bin/`) and the source-tree target dir
+/// (`release/`, then `debug/`), in that order, for each candidate name.
+fn find_daemon_in(paths: &Paths, workspace: &std::path::Path, windows: bool) -> Option<PathBuf> {
     let mut candidates = Vec::new();
-    for name in DAEMON_NAMES {
+    for name in daemon_bin_names(windows) {
         candidates.push(paths.root.join("bin").join(name));
         candidates.push(workspace.join("release").join(name));
         candidates.push(workspace.join("debug").join(name));
@@ -5431,6 +5446,80 @@ mod tests {
             .unwrap()
             .iter()
             .any(|model| model.path == fs::canonicalize(&nested).unwrap()));
+        fs::remove_dir_all(&paths.root).unwrap();
+    }
+
+    #[test]
+    fn daemon_discovery_prefers_windows_exe_spelling() {
+        // Windows-shaped policy (runs on any host, like the rocm.rs HIPCC
+        // suffix tests): daemon.exe is probed before the bare name so an
+        // install or source-tree build is found on Windows.
+        assert_eq!(daemon_bin_names(true), &["daemon.exe", "daemon"]);
+        assert_eq!(daemon_bin_names(false), &["daemon"]);
+    }
+
+    #[test]
+    fn find_daemon_discovers_daemon_exe_under_windows_shaped_policy() {
+        // Only the .exe spelling exists — exactly the Windows install layout.
+        let paths = test_paths("daemon-exe");
+        let bin = paths.root.join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        fs::write(bin.join("daemon.exe"), b"").unwrap();
+        let workspace = paths.root.join("target");
+        fs::create_dir_all(&workspace).unwrap();
+        assert_eq!(
+            find_daemon_in(&paths, &workspace, true),
+            Some(bin.join("daemon.exe"))
+        );
+        fs::remove_dir_all(&paths.root).unwrap();
+    }
+
+    #[test]
+    fn find_daemon_windows_policy_accepts_extensionless_shim() {
+        // The bare spelling stays a fallback on Windows for a future shim.
+        let paths = test_paths("daemon-shim");
+        let bin = paths.root.join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        fs::write(bin.join("daemon"), b"").unwrap();
+        let workspace = paths.root.join("target");
+        fs::create_dir_all(&workspace).unwrap();
+        assert_eq!(
+            find_daemon_in(&paths, &workspace, true),
+            Some(bin.join("daemon"))
+        );
+        fs::remove_dir_all(&paths.root).unwrap();
+    }
+
+    #[test]
+    fn find_daemon_prefers_install_dir_over_source_tree() {
+        // Install root (~/.hipfire/bin) wins over the source-tree target dir
+        // even when both carry a candidate (real host: Windows + dev build).
+        let paths = test_paths("daemon-install-vs-target");
+        let bin = paths.root.join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        fs::write(bin.join("daemon.exe"), b"install").unwrap();
+        let workspace = paths.root.join("target");
+        fs::create_dir_all(workspace.join("release")).unwrap();
+        fs::write(workspace.join("release").join("daemon.exe"), b"dev").unwrap();
+        assert_eq!(
+            find_daemon_in(&paths, &workspace, true),
+            Some(bin.join("daemon.exe"))
+        );
+        fs::remove_dir_all(&paths.root).unwrap();
+    }
+
+    #[test]
+    fn find_daemon_falls_back_to_bare_spelling_for_unix_shaped_policy() {
+        // Unix-shaped policy: only the extensionless daemon is probed.
+        let paths = test_paths("daemon-bare");
+        let release = paths.root.join("target").join("release");
+        fs::create_dir_all(&release).unwrap();
+        fs::write(release.join("daemon"), b"").unwrap();
+        let workspace = paths.root.join("target");
+        assert_eq!(
+            find_daemon_in(&paths, &workspace, false),
+            Some(release.join("daemon"))
+        );
         fs::remove_dir_all(&paths.root).unwrap();
     }
 

--- a/crates/hipfire-config/src/rocm.rs
+++ b/crates/hipfire-config/src/rocm.rs
@@ -946,7 +946,12 @@ fn path_tool(name: &str) -> Option<PathBuf> {
 
 /// Kept separate so tests can prove the strict selected-root behavior without
 /// mutating process-global environment variables.
-fn tool_from_selected_root(root: &Path, name: &str) -> Option<PathBuf> {
+///
+/// Public because diagnostics (`hipfire-cli diag`) need the same
+/// host-suffix-aware lookup: on Windows the HIP SDK installs `hipcc.bat` /
+/// `hipcc.exe`, and probing the bare name would report a coherent SDK as
+/// missing its compiler.
+pub fn tool_from_selected_root(root: &Path, name: &str) -> Option<PathBuf> {
     first_tool_in_dir(&root.join("bin"), name, cfg!(windows))
 }
 

--- a/crates/hipfire-quantize/src/hessian_io.rs
+++ b/crates/hipfire-quantize/src/hessian_io.rs
@@ -20,7 +20,7 @@
 //! `get(tensor_name_without_dot_weight_suffix, 0)` per MQ4G256 tensor.
 
 use byteorder::{ByteOrder, LittleEndian};
-use memmap2::{Advice, Mmap};
+use memmap2::Mmap;
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
@@ -154,11 +154,12 @@ impl HessianSidecar {
         let file = File::open(path)?;
         let mmap = unsafe { Mmap::map(&file)? };
         // Hint sequential access: the quantizer walks tensor-by-tensor.
+        // `memmap2::Advice` only exists on unix; on other platforms the hint
+        // is a no-op and the call is compiled out entirely.
         #[cfg(unix)]
         {
-            mmap.advise(Advice::Sequential).ok();
+            mmap.advise(memmap2::Advice::Sequential).ok();
         }
-        let _ = Advice::Sequential; // silence unused on non-unix
 
         if mmap.len() < HEADER_SIZE {
             return Err(HessianError::TruncatedFile {

--- a/crates/hipfire-quantize/src/hfqm.rs
+++ b/crates/hipfire-quantize/src/hfqm.rs
@@ -17,7 +17,7 @@
 //!   payloads: concatenated tensor bytes in index order from data_offset.
 
 use byteorder::{ByteOrder, LittleEndian};
-use memmap2::{Advice, Mmap};
+use memmap2::Mmap;
 use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
@@ -234,11 +234,13 @@ impl HfqmPackage {
     pub fn open(path: &Path) -> Result<Self, HfqmError> {
         let file = File::open(path)?;
         let mmap = unsafe { Mmap::map(&file)? };
+        // Hint sequential access: the quantizer walks tensor-by-tensor.
+        // `memmap2::Advice` only exists on unix; on other platforms the hint
+        // is a no-op and the call is compiled out entirely.
         #[cfg(unix)]
         {
-            mmap.advise(Advice::Sequential).ok();
+            mmap.advise(memmap2::Advice::Sequential).ok();
         }
-        let _ = Advice::Sequential;
 
         if mmap.len() < HEADER_SIZE {
             return Err(HfqmError::TruncatedFile {

--- a/scripts/serve_harness.py
+++ b/scripts/serve_harness.py
@@ -586,7 +586,7 @@ def _kill_serve():
     pgid = _serve_pgid
     if pgid is None and _serve_proc is not None:
         pgid = _serve_proc.pid
-    if pgid is not None:
+    if pgid is not None and hasattr(os, "killpg"):
         # rocprof must observe a normal target shutdown to flush its CSV trace.
         # The default remains the historical exact/fast SIGKILL cleanup; this
         # opt-in is developer tooling for HIPFIRE_DAEMON_BIN wrappers such as
@@ -626,6 +626,13 @@ def _kill_serve():
                         _serve_proc.kill()
                     except Exception:
                         pass
+    elif _serve_proc is not None:
+        # Windows: process groups are POSIX-only (os.killpg does not exist);
+        # kill the direct child and let its daemon child exit with it.
+        try:
+            _serve_proc.kill()
+        except Exception:
+            pass
     _serve_proc = None
     _serve_pgid = None
     _clear_pid_file()
@@ -633,10 +640,11 @@ def _kill_serve():
 
 def _native_cli():
     """Resolve the Rust control-plane binary."""
+    exe = ".exe" if os.name == "nt" else ""
     candidates = [
         os.environ.get("HIPFIRE_CLI_BIN"),
-        os.path.join(REPO, "target", "release", "hipfire"),
-        os.path.expanduser("~/.hipfire/bin/hipfire"),
+        os.path.join(REPO, "target", "release", f"hipfire{exe}"),
+        os.path.expanduser(f"~/.hipfire/bin/hipfire{exe}"),
         shutil.which("hipfire"),
     ]
     for candidate in candidates:
@@ -1914,7 +1922,9 @@ def spawn_serve(cfg, home, log):
     # process comm → the CLI's reapOrphans `pkill -x <name>` stays scoped to THIS
     # instance). HIPFIRE_DAEMON_NAME/ID pass through from os.environ untouched.
     env = dict(os.environ, HOME=home, HIP_VISIBLE_DEVICES=os.environ.get("HIP_VISIBLE_DEVICES","0"),
-               HIPFIRE_DAEMON_BIN=os.environ.get("HIPFIRE_DAEMON_BIN", os.path.join(REPO, "target/release/daemon")),
+               HIPFIRE_DAEMON_BIN=os.environ.get(
+                   "HIPFIRE_DAEMON_BIN",
+                   os.path.join(REPO, "target", "release", "daemon" + (".exe" if os.name == "nt" else ""))),
                HIPFIRE_KV_MODE=cfg["kv"], HIPFIRE_CASK_OFF="1", HIPFIRE_MODEL=cfg["model"])
     if cfg["mtp"] == "on":
         env.update(HIPFIRE_QWEN_MTP="1", HIPFIRE_MTP_SAMPLED="1")
@@ -2105,10 +2115,11 @@ def _tool_result_feedback(tool_call_id, content, feedback_shape=None, name=None)
 
 def _daemon_binary_md5():
     """Return (md5_hex, path) for the daemon binary per AGENTS.md discipline."""
-    cand = os.environ.get("HIPFIRE_DAEMON_BIN") or os.path.join(REPO, "target/release/daemon")
+    exe = ".exe" if os.name == "nt" else ""
+    cand = os.environ.get("HIPFIRE_DAEMON_BIN") or os.path.join(REPO, "target", "release", f"daemon{exe}")
     # Fallback to HIPFIRE_CLI_BIN if daemon not found
     if not os.path.exists(cand):
-        alt = os.environ.get("HIPFIRE_CLI_BIN") or os.path.join(REPO, "target/release/hipfire")
+        alt = os.environ.get("HIPFIRE_CLI_BIN") or os.path.join(REPO, "target", "release", f"hipfire{exe}")
         if os.path.exists(alt):
             cand = alt
     try:


### PR DESCRIPTION
find_daemon only probed the bare daemon name, so on Windows every run/serve/diag failed with 'daemon binary not found'; probe daemon.exe first and keep the bare spelling as a fallback shim. diag checked bin/hipcc bare and always reported the compiler MISSING on Windows — route it through the host-suffix-aware rocm::tool_from_selected_root (now pub). quantize imported memmap2::Advice unconditionally although it only exists on unix, breaking the Windows build with E0432; call it fully-qualified inside the cfg(unix) block.

## Summary

Windows is a documented platform (AMD HIP SDK for Windows), but the CLI could not discover `daemon.exe` (every run/serve/diag failed), `hipfire diag` falsely reported a complete SDK as missing its compiler, and `hipfire-quantize` did not compile at all — all invisible to the ubuntu-only CI. This PR fixes those (touching `crates/hipfire-cli`, `crates/hipfire-config`, `crates/hipfire-quantize`), adds platform-shaped unit tests locking in the daemon discovery policy, and fixes `scripts/serve_harness.py` so the serve battery can actually run and tear down on Windows. Verified end-to-end on Windows 11 + RX 7900 XTX (gfx1100) + HIP SDK 7.1: kernel precompile 60/60, `qwen3.8:27b` GPU inference, and the full 5-turn serve battery green.

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [ ] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [ ] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template — touch only when refining the new-arch reference)
- [x] `crates/hipfire-quantize` (`hessian_io.rs`: unix-only `memmap2::Advice` import broke the Windows build)
- [x] examples / daemon (`crates/hipfire-cli`: `find_daemon` daemon.exe discovery + diag device-compiler probe + platform-shaped unit tests)
- [x] docs / CI / scripts (`scripts/serve_harness.py`: Windows native-binary resolution + POSIX-only `os.killpg` teardown)

Note: `crates/hipfire-cli` and `crates/hipfire-config` are not in the checkbox list. The config change is `rocm::tool_from_selected_root` made `pub` — a host-suffix-aware tool lookup (`hipcc.bat/.cmd/.exe/.com`) reused by the diag path.

## Test plan

- [x] `cargo build --release -p hipfire-daemon -p hipfire-cli -p hipfire-quantize` clean on Windows (stable-x86_64-pc-windows-msvc)
- [x] New platform-shaped unit tests, run on Windows and written to pass on any host: `daemon_discovery_prefers_windows_exe_spelling`, `find_daemon_discovers_daemon_exe_under_windows_shaped_policy`, `find_daemon_windows_policy_accepts_extensionless_shim`, `find_daemon_prefers_install_dir_over_source_tree`, `find_daemon_falls_back_to_bare_spelling_for_unix_shaped_policy` — 11/11 daemon-related tests pass
- [x] GPU verification on the repro host: `daemon.exe --precompile` 60/60 gfx1100 kernels; `hipfire run qwen3.5:0.8b` and `qwen3.8:27b` generate correctly
- [x] `hipfire diag` now reports `compiler: D:\AMD\HIP\7.1\bin\hipcc.bat  headers: yes  runtime: D:\AMD\HIP\7.1\bin\amdhip64_7.dll`, live probe `HIP GPU: gfx1100`
- [x] Serve battery (manual, route-equivalent args, on Windows): 5/5 turns, `empty=0 attractor=0 retrieval_miss=0`, avg prefill 2169 tok/s, avg decode 178 tok/s, clean exit 0
- [ ] `./scripts/no-gpu-ci.sh` passes, or equivalent CI job is green — not run on the Windows host; relies on CI
- [ ] `cargo build --release --workspace --features deltanet` clean — only the touched binaries were built locally; full workspace build relies on CI
- [ ] `cargo test --lib --workspace --features deltanet` passes — not run on the Windows host; relies on CI
- [ ] **Change gate run and telemetry pasted below.** `python3 -m tools.change_gate plan --base beta`
      shows what your diff actually owes and what it costs; `run --md gate.md` executes it and emits the
      report. The gate selects routes from the diff, so an unrelated change does not owe a model battery.
- [ ] If perf-relevant: `./scripts/speed-gate.sh` within ±2% of locked baselines — not perf-relevant (probe/discovery-only changes)
- [ ] Any route reported `blocked` (absent model, wrong arch) is **acknowledged below**, not ignored —
      a blocked route makes the gate verdict `incomplete`, which is not a pass.

<details><summary>change_gate telemetry</summary>

Plan (`python3 -m tools.change_gate plan --base beta`, working tree `80a572c8..9e8ee658`, dirty):

```
### Routes RUN
| route                 | status  |
| --------------------- | ------- |
| unit.env-docs         | planned |
| unit.hipfire-cli      | planned |
| unit.hipfire-config   | planned |
| unit.hipfire-quantize | planned |
| unit.no-gpu-control   | planned |

### Routes NOT RUN
| route                   | reason                                          |
| ----------------------- | ----------------------------------------------- |
| serve.battery.qwen35-4b | blocked_model: missing model(s): qwen3.5-4b.mq4 |

plan: 5 selected, 1 not_run, est_minutes=3.8, verdict=incomplete
```

Run (after pulling `qwen3.5:4b` into the models dir; host gfx1100 / ROCm 7.1.51803 / `HIPFIRE_MODELS_DIR=K:\llm\mq4`):

```
**change_gate: FAIL**

host gfx=`gfx1100` rocm=`7.1.51803` models_dir=`K:\llm\mq4` · `80a572c8..9e8ee658` dirty · est=6.8min actual=46.3s

### Routes RUN
| route                   | status | duration |
| ----------------------- | ------ | -------- |
| serve.battery.qwen35-4b | fail   | 0.2s     |
| unit.env-docs           | fail   | 0.6s     |
| unit.hipfire-cli        | fail   | 8.8s     |
| unit.hipfire-config     | fail   | 0.4s     |
| unit.hipfire-quantize   | fail   | 26.9s    |
| unit.no-gpu-control     | fail   | 8.8s     |
```

**Route-by-route acknowledgment (all pre-existing / platform-environment, none caused by this diff):**

- `serve.battery.qwen35-4b`: the canned route args (`--thinking med --max-tokens 180`) trip the harness think-only guard (`180 <= med cap 2048`) before any daemon spawns — deterministic pure-python logic, identical on Linux with this harness. Run manually with route-equivalent args (`--thinking off`, plus `--kv-backend contiguous` because the `qwen3.5:4b` tag policy selects the VMM backend, which the Windows HIP driver cannot service at decode — known issue 2): **5/5 turns green, exit 0** (`turns=5 runaway=1 empty=0 attractor=0 retrieval_miss=0 avg_prefill=2169.1tok/s avg_decode=177.9tok/s`).
- `unit.env-docs`: `scripts/check-env-docs.py` lists env vars used in code but missing from docs (`HIPFIRE_Q8_CLASSES`, `HIPFIRE_FIXED_TIER`, `HIPFIRE_E8_IMATRIX`, `HIPFIRE_GLIMMER_CTX_CAP`, …) — docs debt present on base master, untouched by this diff.
- `unit.hipfire-cli` / `unit.no-gpu-control`: 144 passed / 6 failed — all pre-existing Windows-environment failures, none near the changed code: `setup::tests::pin_cargo_forces_source_target_dir`; `tests::nested_model_discovery_matches_native_registry_layout` (`fs::canonicalize` returns `\\?\`-prefixed paths on Windows, breaking the equality assertion); `tests::update_*` (5 git-integration tests).
- `unit.hipfire-config`: 60 passed / 3 failed — `install_guidance_lists_artifacts_and_amd_selector` hardcodes the Linux artifact message (`libamdhip64, libhsa-runtime64` vs the Windows text), plus two `canonicalize`-based root-resolution tests.
- `unit.hipfire-quantize`: 112 passed / 1 failed — `reap_overlay::integ::sp4_overlay_to_sp3_load_end_to_end` (model-load integration, env-dependent).

The changed surfaces are green: all daemon-discovery tests (including the 5 new ones) pass, and the serve battery passes with route-equivalent args.

</details>

Route selection is defined in [`tools/change_gate/routes.py`](../tools/change_gate/routes.py) and route
policy in [`docs/VALIDATION.md`](../docs/VALIDATION.md). The retired `scripts/coherence-gate*.sh`
batteries are **not** acceptance evidence and no longer exist in-tree. Adding coverage means adding a
`Route` + `Rule` there, not resurrecting a fixed battery.

## Architecture-trait change?

No. The `Architecture` trait surface in `crates/hipfire-runtime/src/arch.rs` is untouched.

## Known open issues (out of scope, documented for follow-ups)

1. **GGUF → HFQ conversion is broken for Qwen3.5/3.6/3.8 hybrid architectures (all platforms)**: `hipfire-quantize`'s `config_json_from_gguf` does not emit `layer_types` (nor `linear_*`/`ssm.*` fields). The GGUF metadata keys `qwen35.full_attention_interval` / `qwen35.ssm.*` are ignored, so converted artifacts load as all-FullAttention and panic with `tensor not found: layers.0.self_attn.q_proj.weight`. Official registry `.mq4` files are unaffected (converted from safetensors with a complete config.json).
2. **VMM KV backend fails at decode on the Windows driver** (`hipMemSetAccess: invalid argument`); `kv_backend=contiguous` is required. Note the registry tag policy for `qwen3.5:4b` selects VMM — on Windows the harness/gate battery must pass `--kv-backend contiguous`.
3. **The daemon JIT needs the vcvars environment** (`INCLUDE`/`LIB`); first run from a plain shell fails because clang cannot find the MSVC headers. A documentation note for Windows prerequisites would help.
4. **serve_harness teardown on Windows kills only the CLI, not the daemon child** (no process groups); the daemon normally exits with its parent, but a straggler may briefly remain — `hipfire stop --force` / `~/.hipfire/daemon.pid` cleans it.
