### PR TITLE
perf(loader): UMA-gated eviction + parallel warmer + zero-copy uploads — 2-3.4x faster dense loads, ~6x faster A3B MoE loads on dGPUs; fix sequential sampler seed

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35/load.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35/load.rs
@@ -2946,6 +2946,22 @@ fn contiguous_tensor_span<'a>(hfq: &'a HfqFile, names: &[&str], stride: usize) -
     hfq.data_range(first.data_offset, expect - first.data_offset)
 }
 
+/// Memoized [`HfqFile::mostly_page_cached`] — the probe maps + mincores the
+/// whole multi-GB model file (~0.4 s), far too expensive to run per layer.
+fn model_pages_resident(hfq: &HfqFile) -> bool {
+    use std::sync::atomic::{AtomicU8, Ordering};
+    static CACHED: AtomicU8 = AtomicU8::new(0); // 0 unknown, 1 resident, 2 not
+    match CACHED.load(Ordering::Relaxed) {
+        1 => true,
+        2 => false,
+        _ => {
+            let resident = hfq.mostly_page_cached();
+            CACHED.store(if resident { 1 } else { 2 }, Ordering::Relaxed);
+            resident
+        }
+    }
+}
+
 fn try_load_packed_mq4_experts(
     hfq: &HfqFile,
     gpu: &mut Gpu,
@@ -3022,7 +3038,7 @@ fn try_load_packed_mq4_experts(
     // an evicted cache soft-faults serially inside the copy loop (~0.25 GB/s
     // off disk), while the parallel-pread fallback reads with multiple lanes.
     let zero_copy_ok =
-        matches!((gate_up_contig, down_contig), (Some(_), Some(_))) && hfq.mostly_page_cached();
+        matches!((gate_up_contig, down_contig), (Some(_), Some(_))) && model_pages_resident(hfq);
     let (gate_up_host, down_host) = if zero_copy_ok {
         let (Some(gu), Some(dn)) = (gate_up_contig, down_contig) else {
             unreachable!("zero_copy_ok implies both spans resolved");

--- a/crates/hipfire-arch-qwen35/src/qwen35/load.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35/load.rs
@@ -2946,22 +2946,6 @@ fn contiguous_tensor_span<'a>(hfq: &'a HfqFile, names: &[&str], stride: usize) -
     hfq.data_range(first.data_offset, expect - first.data_offset)
 }
 
-/// Memoized [`HfqFile::mostly_page_cached`] — the probe maps + mincores the
-/// whole multi-GB model file (~0.4 s), far too expensive to run per layer.
-fn model_pages_resident(hfq: &HfqFile) -> bool {
-    use std::sync::atomic::{AtomicU8, Ordering};
-    static CACHED: AtomicU8 = AtomicU8::new(0); // 0 unknown, 1 resident, 2 not
-    match CACHED.load(Ordering::Relaxed) {
-        1 => true,
-        2 => false,
-        _ => {
-            let resident = hfq.mostly_page_cached();
-            CACHED.store(if resident { 1 } else { 2 }, Ordering::Relaxed);
-            resident
-        }
-    }
-}
-
 fn try_load_packed_mq4_experts(
     hfq: &HfqFile,
     gpu: &mut Gpu,
@@ -3037,8 +3021,8 @@ fn try_load_packed_mq4_experts(
     // Zero-copy only pays when pages are resident: a borrowed-slice H2D from
     // an evicted cache soft-faults serially inside the copy loop (~0.25 GB/s
     // off disk), while the parallel-pread fallback reads with multiple lanes.
-    let zero_copy_ok =
-        matches!((gate_up_contig, down_contig), (Some(_), Some(_))) && model_pages_resident(hfq);
+    let zero_copy_ok = matches!((gate_up_contig, down_contig), (Some(_), Some(_)))
+        && hfq.mostly_page_cached_memo();
     let (gate_up_host, down_host) = if zero_copy_ok {
         let (Some(gu), Some(dn)) = (gate_up_contig, down_contig) else {
             unreachable!("zero_copy_ok implies both spans resolved");

--- a/crates/hipfire-arch-qwen35/src/qwen35/load.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35/load.rs
@@ -98,6 +98,28 @@ fn qwen35_tensor_data_vec<'a>(
     None
 }
 
+/// Borrowed-first variant of [`qwen35_tensor_data_vec`]: returns the mmap
+/// slice directly when the mapping is alive (dGPU loads keep it, so weight
+/// uploads DMA straight out of page-cache pages with no heap staging copy);
+/// falls back to the owned pread Vec on UMA (mmap dropped there). Same
+/// candidate resolution.
+fn qwen35_tensor_data_cow<'a>(
+    hfq: &'a HfqFile,
+    name: &str,
+) -> Option<(&'a HfqTensorInfo, std::borrow::Cow<'a, [u8]>)> {
+    for candidate in qwen35_tensor_name_candidates(name) {
+        if let Some((info, data)) = hfq.tensor_data(&candidate) {
+            return Some((info, std::borrow::Cow::Borrowed(data)));
+        }
+    }
+    for candidate in qwen35_tensor_name_candidates(name) {
+        if let Some((info, data)) = hfq.tensor_data_vec(&candidate) {
+            return Some((info, std::borrow::Cow::Owned(data)));
+        }
+    }
+    None
+}
+
 fn load_norm_weight(
     hfq: &HfqFile,
     gpu: &mut Gpu,
@@ -813,12 +835,20 @@ pub(crate) fn load_weight_tensor(
     k: usize,
     candidates: fn(&str) -> Vec<String>,
 ) -> HipResult<WeightTensor> {
-    // Use pread path to avoid page cache buildup on unified-memory APUs.
+    // Zero-copy first: when the mmap is alive (dGPU loads keep it), DMA
+    // straight from the page-cache-backed slice — no heap staging copy.
+    // Pread fallback preserves UMA behavior (mmap dropped there).
     #[cfg(unix)]
     {
         let mut wt: Option<WeightTensor> = None;
         let mut matched: Option<String> = None;
         for candidate in candidates(name) {
+            if let Some((info, data)) = hfq.tensor_data(&candidate) {
+                let qt = info.quant_type;
+                wt = Some(load_weight_tensor_raw(gpu, qt, data, m, k)?);
+                matched = Some(candidate);
+                break;
+            }
             if let Some((info, buf)) = hfq.tensor_data_pread(&candidate) {
                 let qt = info.quant_type;
                 wt = Some(load_weight_tensor_raw(gpu, qt, &buf, m, k)?);
@@ -2441,8 +2471,18 @@ impl WeightSource for HfqSource<'_> {
     }
 
     fn prepare(&mut self, n_devices: usize) -> HipResult<()> {
+        // Keep the mmap alive on discrete GPUs (the carrier cleared
+        // `evict_page_cache` there): weight uploads DMA straight out of
+        // page-cache pages with no heap staging copy — measured 11–16 GB/s
+        // end-to-end vs ~4 GB/s through a pread staging buffer.
+        // UMA keeps the drop — evict=true is exactly the carrier's UMA
+        // signal — so cached model pages can't starve hipMalloc of RAM.
+        //
+        // NOTE: do NOT madvise-populate the mapping here. A blocking
+        // MAP_POPULATE measured identical totals (it relocates the same
+        // soft-fault work out of the upload loop into one serial stall).
         #[cfg(unix)]
-        if n_devices == 1 {
+        if n_devices == 1 && self.hfq.evicts_page_cache() {
             self.hfq.drop_mmap();
         }
         let _ = n_devices;
@@ -2463,7 +2503,7 @@ impl WeightSource for HfqSource<'_> {
                 c.mrope_interleaved, c.mrope_section
             );
         }
-        let (embd_meta, embd_data) = qwen35_tensor_data_vec(self.hfq, "embed_tokens.weight")
+        let (embd_meta, embd_data) = qwen35_tensor_data_cow(self.hfq, "embed_tokens.weight")
             .expect("embed_tokens not found");
         let out = load_embedding(gpu, embd_meta.quant_type, &embd_data, c.vocab_size, c.dim)?;
         drop(embd_data);
@@ -2497,11 +2537,11 @@ impl WeightSource for HfqSource<'_> {
             c.dim,
             |gpu| {
                 let (lm_info, lm_data) =
-                    qwen35_tensor_data_vec(hfq, "lm_head.weight").expect("lm_head present");
+                    qwen35_tensor_data_cow(hfq, "lm_head.weight").expect("lm_head present");
                 load_weight_tensor_raw(gpu, lm_info.quant_type, &lm_data, c.vocab_size, c.dim)
             },
             |gpu| {
-                let (embd_meta, embd_data) = qwen35_tensor_data_vec(hfq, "embed_tokens.weight")
+                let (embd_meta, embd_data) = qwen35_tensor_data_cow(hfq, "embed_tokens.weight")
                     .expect("embed_tokens not found");
                 dequant_weight_raw(gpu, embd_meta.quant_type, &embd_data, c.vocab_size, c.dim)
             },

--- a/crates/hipfire-arch-qwen35/src/qwen35/load.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35/load.rs
@@ -2431,6 +2431,9 @@ pub fn load_weights(
     devices: &mut [Gpu],
     layout: &Layout,
 ) -> HipResult<Qwen35Weights> {
+    use std::sync::atomic::Ordering;
+    use std::time::Instant;
+    let t_sweep = Instant::now();
     let LoadedWeights {
         token_embd,
         embd_format,
@@ -2439,6 +2442,12 @@ pub fn load_weights(
         layers,
         lm_head_aliases_embd,
     } = rt_load_weights(source, devices, layout)?;
+    eprintln!(
+        "  weight sweep: {} ms (packed-expert host-read {} ms, H2D {} ms)",
+        t_sweep.elapsed().as_millis(),
+        PACKED_READ_MS.load(Ordering::Relaxed),
+        PACKED_UPLOAD_MS.load(Ordering::Relaxed),
+    );
     Ok(Qwen35Weights {
         token_embd,
         embd_format,
@@ -2469,7 +2478,6 @@ impl WeightSource for HfqSource<'_> {
     fn n_layers(&self) -> usize {
         self.c.n_layers
     }
-
     fn prepare(&mut self, n_devices: usize) -> HipResult<()> {
         // Keep the mmap alive on discrete GPUs (the carrier cleared
         // `evict_page_cache` there): weight uploads DMA straight out of
@@ -2898,6 +2906,46 @@ fn packed_mq4_experts_supported(gpu: &Gpu) -> bool {
 /// preserving one `WeightTensor` view and one device pointer-table entry per
 /// expert. Returns `None` for every non-uniform/non-MQ4 layout so mixed tiers,
 /// ParoQuant, paged experts, and EP streaming retain their literal behavior.
+
+/// Host-side byte source for a packed blob: either a borrowed mmap slice
+enum HostBlob<'a> {
+    Borrowed(&'a [u8]),
+    Owned(Vec<u8>),
+}
+
+impl AsRef<[u8]> for HostBlob<'_> {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::Borrowed(s) => s,
+            Self::Owned(v) => v,
+        }
+    }
+}
+
+/// Cumulative packed-expert sweep timings for the current model load, in ms.
+static PACKED_READ_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+static PACKED_UPLOAD_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Verify that `names[0..n]` are uniform-`stride` tensors laid out back-to-back
+/// in file order, and return the single borrowed mmap slice covering all of
+/// them. Returns `None` on any gap, overlap, stride mismatch, dropped mmap
+/// (UMA), or attached overlay.
+fn contiguous_tensor_span<'a>(hfq: &'a HfqFile, names: &[&str], stride: usize) -> Option<&'a [u8]> {
+    if names.is_empty() || hfq.has_overlay() {
+        return None;
+    }
+    let first = hfq.find_tensor_info(names[0])?;
+    let mut expect = first.data_offset;
+    for name in names {
+        let info = hfq.find_tensor_info(name)?;
+        if info.data_offset != expect || info.data_size != stride {
+            return None;
+        }
+        expect = info.data_offset.checked_add(info.data_size)?;
+    }
+    hfq.data_range(first.data_offset, expect - first.data_offset)
+}
+
 fn try_load_packed_mq4_experts(
     hfq: &HfqFile,
     gpu: &mut Gpu,
@@ -2906,6 +2954,8 @@ fn try_load_packed_mq4_experts(
     mi: usize,
     dim: usize,
 ) -> HipResult<Option<(Vec<ExpertWeights>, PackedExpertOwners)>> {
+    use std::sync::atomic::Ordering;
+    use std::time::Instant;
     if expert_ids.is_empty() {
         return Ok(None);
     }
@@ -2956,12 +3006,34 @@ fn try_load_packed_mq4_experts(
 
     let gate_up_stride = gate_up_stride.expect("non-empty packed MQ4 expert list");
     let down_stride = down_stride.expect("non-empty packed MQ4 expert list");
-    let (gate_up_host, down_host) = if hfq.has_overlay() {
+    // Zero-copy fast path: when every expert's tensor lies contiguous in-file
+    // (expert 0's gate_up ends exactly where expert 1's begins, etc.) and the
+    // mmap is alive (dGPU, no overlay), upload both blobs straight from the
+    // page cache — no pread staging Vec, no heap copy. Measured dominant cost
+    // of A3B MoE loads otherwise: 512 pread segments per blob into a fresh
+    // heap buffer, then a second copy into hipMalloc'd VRAM.
+    let gate_up_names: Vec<&str> = specs.iter().map(|s| s.gate_up_name.as_str()).collect();
+    let down_names: Vec<&str> = specs.iter().map(|s| s.down_name.as_str()).collect();
+    let gate_up_contig = contiguous_tensor_span(hfq, &gate_up_names, gate_up_stride);
+    let down_contig = contiguous_tensor_span(hfq, &down_names, down_stride);
+
+    let t_read = Instant::now();
+    // Zero-copy only pays when pages are resident: a borrowed-slice H2D from
+    // an evicted cache soft-faults serially inside the copy loop (~0.25 GB/s
+    // off disk), while the parallel-pread fallback reads with multiple lanes.
+    let zero_copy_ok =
+        matches!((gate_up_contig, down_contig), (Some(_), Some(_))) && hfq.mostly_page_cached();
+    let (gate_up_host, down_host) = if zero_copy_ok {
+        let (Some(gu), Some(dn)) = (gate_up_contig, down_contig) else {
+            unreachable!("zero_copy_ok implies both spans resolved");
+        };
+        (HostBlob::Borrowed(gu), HostBlob::Borrowed(dn))
+    } else if hfq.has_overlay() {
         // Overlay offsets belong to a second file; retain the overlay-aware
         // serial path exactly rather than crossing files in reader workers.
-        let mut gate_up_host = Vec::with_capacity(gate_up_stride * specs.len());
-        let mut down_host = Vec::with_capacity(down_stride * specs.len());
-        for spec in &specs {
+        let mut gate_up_host = vec![0u8; gate_up_stride * specs.len()];
+        let mut down_host = vec![0u8; down_stride * specs.len()];
+        for (slot, spec) in specs.iter().enumerate() {
             {
                 let (_, bytes) = hfq.tensor_data_pread(&spec.gate_up_name).ok_or_else(|| {
                     HipError::new(
@@ -2982,7 +3054,8 @@ fn try_load_packed_mq4_experts(
                         ),
                     ));
                 }
-                gate_up_host.extend_from_slice(&bytes);
+                gate_up_host[slot * gate_up_stride..(slot + 1) * gate_up_stride]
+                    .copy_from_slice(&bytes);
             }
             {
                 let (_, bytes) = hfq.tensor_data_pread(&spec.down_name).ok_or_else(|| {
@@ -3001,10 +3074,10 @@ fn try_load_packed_mq4_experts(
                         ),
                     ));
                 }
-                down_host.extend_from_slice(&bytes);
+                down_host[slot * down_stride..(slot + 1) * down_stride].copy_from_slice(&bytes);
             }
         }
-        (gate_up_host, down_host)
+        (HostBlob::Owned(gate_up_host), HostBlob::Owned(down_host))
     } else {
         let jobs = [
             HfqReadJob::packed(
@@ -3024,14 +3097,18 @@ fn try_load_packed_mq4_experts(
             .map_err(|e| HipError::new(0, &format!("qwen35: parallel packed expert read: {e}")))?
             .into_iter();
         (
-            results.next().expect("two packed MQ4 jobs").data,
-            results.next().expect("two packed MQ4 jobs").data,
+            HostBlob::Owned(results.next().expect("two packed MQ4 jobs").data),
+            HostBlob::Owned(results.next().expect("two packed MQ4 jobs").data),
         )
     };
+    let trace = std::env::var_os("HIPFIRE_LOAD_TRACE").is_some();
+    let zero_copy =
+        matches!(gate_up_host, HostBlob::Borrowed(_)) && matches!(down_host, HostBlob::Borrowed(_));
+    let t_upload = Instant::now();
 
-    let gate_up_owner = gpu.upload_raw(&gate_up_host, &[specs.len(), gate_up_stride])?;
+    let gate_up_owner = gpu.upload_raw(gate_up_host.as_ref(), &[specs.len(), gate_up_stride])?;
     drop(gate_up_host);
-    let down_owner = match gpu.upload_raw(&down_host, &[specs.len(), down_stride]) {
+    let down_owner = match gpu.upload_raw(down_host.as_ref(), &[specs.len(), down_stride]) {
         Ok(owner) => owner,
         Err(error) => {
             let _ = gpu.free_tensor(gate_up_owner);
@@ -3039,6 +3116,15 @@ fn try_load_packed_mq4_experts(
         }
     };
     drop(down_host);
+    let upload_ms = t_upload.elapsed().as_millis() as u64;
+    let read_ms = t_read.elapsed().as_millis() as u64 - upload_ms;
+    PACKED_READ_MS.fetch_add(read_ms, Ordering::Relaxed);
+    PACKED_UPLOAD_MS.fetch_add(upload_ms, Ordering::Relaxed);
+    if trace {
+        eprintln!(
+            "  [load-trace] packed experts: host-read {read_ms} ms, H2D {upload_ms} ms, zero-copy={zero_copy}"
+        );
+    }
 
     let mut experts = Vec::with_capacity(specs.len());
     for (slot, spec) in specs.iter().enumerate() {

--- a/crates/hipfire-loader/src/carriers.rs
+++ b/crates/hipfire-loader/src/carriers.rs
@@ -269,6 +269,15 @@ fn load_qwen35_pp(
         None => hipfire_runtime::multi_gpu::Gpus::init_uniform(pp, config.n_layers)
             .map_err(|e| format!("{e}"))?,
     };
+    // Discrete GPUs: keep model pages in the page cache across reads —
+    // fadvise(DONTNEED)-per-tensor forces a full disk re-read on every load.
+    // UMA keeps eviction (default) to avoid OOM vs hipMalloc staging.
+    hfq_file.set_evict_page_cache(
+        std::env::var("HIPFIRE_PAGE_EVICTION")
+            .ok()
+            .map(|v| v != "0")
+            .unwrap_or_else(|| hipfire_runtime::hfq::arch_is_uma(gpus.devices[0].arch.as_str())),
+    );
     let layout = hipfire_arch_qwen35::qwen35::Layout::from_gpus(&gpus, config.n_layers);
     let mut hfq_source = hipfire_arch_qwen35::qwen35::HfqSource::new(&mut hfq_file, &config);
     let weights =
@@ -491,6 +500,19 @@ impl Carrier for Qwen35Carrier {
                 if ctx.pp > 1 {
                     return load_qwen35_pp(hfq_file, meta, ctx);
                 }
+                // Discrete GPUs: keep model pages in the page cache across
+                // reads — fadvise(DONTNEED)-per-tensor forces a full disk
+                // re-read on every load. UMA keeps eviction (default) to
+                // avoid OOM vs hipMalloc staging.
+                hfq_file.set_evict_page_cache(
+                    std::env::var("HIPFIRE_PAGE_EVICTION")
+                        .ok()
+                        .map(|v| v != "0")
+                        .unwrap_or_else(|| {
+                            hipfire_runtime::hfq::arch_is_uma(ctx.gpu.arch.as_str())
+                        }),
+                );
+                hfq_file.warm_page_cache();
 
                 // ── pp=1 path (single-GPU) ────────────────────
                 let physical_cap = ctx.cask.physical_cap(ctx.max_seq)?;

--- a/crates/hipfire-loader/src/carriers.rs
+++ b/crates/hipfire-loader/src/carriers.rs
@@ -5,17 +5,17 @@
 //! Each carrier owns its full load path (HFQ + safetensors-dir).
 
 use crate::spec_build::Qwen35SlotGuard;
-use hipfire_runtime::llama::KvCacheExt;
 use crate::Carrier;
-use std::any::Any;
 use crate::{
     finish_qwen35_load, resolve_chat_template, resolve_chat_template_overrides, LoadedModel,
 };
 use hipfire_arch_minimax::{config_from_safetensors, load_weights_from_safetensors, MiniMaxState};
 use hipfire_runtime::kv_backend::KvBackend;
+use hipfire_runtime::llama::KvCacheExt;
 use hipfire_runtime::loader_api::{LoadCtx, ModelSource};
 use hipfire_runtime::model_source::ModelSource as _;
 use hipfire_runtime::spec::{InPlaceGuard, SpecEmit, SpecEmitCtx, SpecTargetGuard};
+use std::any::Any;
 
 // The ChatML/Hermes per-token emitter (`Qwen35Emit`) is shared by every
 // ChatML-family spec arm — qwen35 DFlash AND the llama/qwen2 n-gram paths all
@@ -113,7 +113,9 @@ impl Carrier for Qwen2Carrier {
         state: &'m mut Option<Box<dyn hipfire_runtime::arch_model::ArchModel>>,
         _model_path: &str,
     ) -> Result<Box<dyn SpecTargetGuard + 'm>, String> {
-        match state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_qwen2::Qwen2Bundle>()) {
+        match state.as_mut().and_then(|s| {
+            (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_qwen2::Qwen2Bundle>()
+        }) {
             Some(bundle) => Ok(Box::new(InPlaceGuard { bundle })),
             _ => Err("qwen2: spec target state mismatch".into()),
         }
@@ -276,7 +278,7 @@ fn load_qwen35_pp(
         std::env::var("HIPFIRE_PAGE_EVICTION")
             .ok()
             .map(|v| v != "0")
-            .unwrap_or_else(|| hipfire_runtime::hfq::arch_is_uma(gpus.devices[0].arch.as_str())),
+            .unwrap_or_else(|| gpus.devices[0].is_uma()),
     );
     let _hfq_cache_warmer = hfq_file.start_cache_warmup();
     let layout = hipfire_arch_qwen35::qwen35::Layout::from_gpus(&gpus, config.n_layers);
@@ -509,9 +511,7 @@ impl Carrier for Qwen35Carrier {
                     std::env::var("HIPFIRE_PAGE_EVICTION")
                         .ok()
                         .map(|v| v != "0")
-                        .unwrap_or_else(|| {
-                            hipfire_runtime::hfq::arch_is_uma(ctx.gpu.arch.as_str())
-                        }),
+                        .unwrap_or_else(|| ctx.gpu.is_uma()),
                 );
                 let _hfq_cache_warmer = hfq_file.start_cache_warmup();
 
@@ -715,7 +715,9 @@ impl Carrier for LlamaCarrier {
         state: &'m mut Option<Box<dyn hipfire_runtime::arch_model::ArchModel>>,
         _model_path: &str,
     ) -> Result<Box<dyn SpecTargetGuard + 'm>, String> {
-        match state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_llama::LlamaBundle>()) {
+        match state.as_mut().and_then(|s| {
+            (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_llama::LlamaBundle>()
+        }) {
             Some(bundle) => Ok(Box::new(InPlaceGuard { bundle })),
             _ => Err("llama: spec target state mismatch".into()),
         }
@@ -1053,7 +1055,9 @@ impl Carrier for DotsOcrCarrier {
         let weights = &bundle.weights;
         let mut ok = true;
         for &tok in synthetic {
-            if hipfire_arch_qwen2::qwen2::forward_step(gpu, &weights.text, &config.text, state, tok).is_err() {
+            if hipfire_arch_qwen2::qwen2::forward_step(gpu, &weights.text, &config.text, state, tok)
+                .is_err()
+            {
                 ok = false;
                 break;
             }
@@ -1113,9 +1117,14 @@ impl Carrier for Deepseek4Carrier {
         state: &'m mut Option<Box<dyn hipfire_runtime::arch_model::ArchModel>>,
         _model_path: &str,
     ) -> Result<Box<dyn SpecTargetGuard + 'm>, String> {
-        if state.as_ref().is_some_and(|s| (s.as_ref() as &dyn Any).is::<crate::Deepseek4HeterogeneousBundle>()) {
+        if state
+            .as_ref()
+            .is_some_and(|s| (s.as_ref() as &dyn Any).is::<crate::Deepseek4HeterogeneousBundle>())
+        {
             Err("deepseek4 heterogeneous route is direct-AR only until G6".into())
-        } else if let Some(b) = state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_deepseek4::Deepseek4Bundle>()) {
+        } else if let Some(b) = state.as_mut().and_then(|s| {
+            (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_deepseek4::Deepseek4Bundle>()
+        }) {
             Ok(Box::new(InPlaceGuard { bundle: b }))
         } else {
             Err("deepseek4: spec target state mismatch".into())
@@ -1155,8 +1164,18 @@ impl Carrier for Deepseek4Carrier {
         n: usize,
         _prefill_err: &mut Option<String>,
     ) -> Option<bool> {
-        let b = m.state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_deepseek4::Deepseek4Bundle>()).unwrap();
-        let pbs = b.pbs.as_mut().expect("deepseek4_pbs missing on arch_id=9 bench_prefill");
+        let b = m
+            .state
+            .as_mut()
+            .and_then(|s| {
+                (s.as_mut() as &mut dyn Any)
+                    .downcast_mut::<hipfire_arch_deepseek4::Deepseek4Bundle>()
+            })
+            .unwrap();
+        let pbs = b
+            .pbs
+            .as_mut()
+            .expect("deepseek4_pbs missing on arch_id=9 bench_prefill");
         let config = &b.config;
         let weights = &b.weights;
         let state = &mut b.state;
@@ -1194,9 +1213,10 @@ impl Carrier for Deepseek4Carrier {
             let eos_tok = resolve_eos_tok(&meta.tokenizer, &["<｜end▁of▁sentence｜>"]);
             let advertised_context = model.config.max_position_embeddings;
             return Ok(LoadedModel {
-                state: Some(Box::new(
-                    crate::Deepseek4HeterogeneousBundle { model, eos_tok },
-                )),
+                state: Some(Box::new(crate::Deepseek4HeterogeneousBundle {
+                    model,
+                    eos_tok,
+                })),
                 ..LoadedModel::skeleton(
                     meta.arch_id,
                     meta.tokenizer,
@@ -1313,7 +1333,10 @@ impl Carrier for MinimaxCarrier {
         state: &'m mut Option<Box<dyn hipfire_runtime::arch_model::ArchModel>>,
         _model_path: &str,
     ) -> Result<Box<dyn SpecTargetGuard + 'm>, String> {
-        match state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<crate::MiniMaxBundle>()) {
+        match state
+            .as_mut()
+            .and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<crate::MiniMaxBundle>())
+        {
             Some(bundle) => Ok(Box::new(InPlaceGuard { bundle })),
             _ => Err("minimax: spec target state mismatch".into()),
         }
@@ -1358,7 +1381,11 @@ impl Carrier for MinimaxCarrier {
         let state = &mut b.state;
         let mut ok = true;
         for (i, &tok) in synthetic.iter().enumerate() {
-            if hipfire_arch_minimax::forward::decode_step(config, weights, state, gpu, tok, i as u32).is_err() {
+            if hipfire_arch_minimax::forward::decode_step(
+                config, weights, state, gpu, tok, i as u32,
+            )
+            .is_err()
+            {
                 ok = false;
                 break;
             }
@@ -1413,7 +1440,10 @@ impl Carrier for Lfm2MoeCarrier {
         state: &'m mut Option<Box<dyn hipfire_runtime::arch_model::ArchModel>>,
         _model_path: &str,
     ) -> Result<Box<dyn SpecTargetGuard + 'm>, String> {
-        match state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<crate::Lfm2MoeBundle>()) {
+        match state
+            .as_mut()
+            .and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<crate::Lfm2MoeBundle>())
+        {
             Some(bundle) => Ok(Box::new(InPlaceGuard { bundle })),
             _ => Err("lfm2moe: spec target state mismatch".into()),
         }
@@ -1458,7 +1488,11 @@ impl Carrier for Lfm2MoeCarrier {
         let state = &mut b.state;
         let mut ok = true;
         for (i, &tok) in synthetic.iter().enumerate() {
-            if hipfire_arch_lfm2moe::forward::decode_step(config, weights, state, gpu, tok, i as u32).is_err() {
+            if hipfire_arch_lfm2moe::forward::decode_step(
+                config, weights, state, gpu, tok, i as u32,
+            )
+            .is_err()
+            {
                 ok = false;
                 break;
             }
@@ -1516,7 +1550,10 @@ impl Carrier for Cohere2MoeCarrier {
         state: &'m mut Option<Box<dyn hipfire_runtime::arch_model::ArchModel>>,
         _model_path: &str,
     ) -> Result<Box<dyn SpecTargetGuard + 'm>, String> {
-        match state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<crate::Cohere2MoeBundle>()) {
+        match state
+            .as_mut()
+            .and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<crate::Cohere2MoeBundle>())
+        {
             Some(bundle) => Ok(Box::new(InPlaceGuard { bundle })),
             _ => Err("cohere2moe: spec target state mismatch".into()),
         }
@@ -1564,13 +1601,19 @@ impl Carrier for Cohere2MoeCarrier {
         let weights = &b.weights;
         let state = &mut b.state;
         let mut ok = true;
-        if hipfire_arch_cohere2moe::forward::forward_batch_supported(weights) && synthetic.len() > 1 {
+        if hipfire_arch_cohere2moe::forward::forward_batch_supported(weights) && synthetic.len() > 1
+        {
             let mut i = 0;
             while i < synthetic.len() {
                 let end = (i + 256).min(synthetic.len());
                 let start_pos = state.n_tokens;
                 if hipfire_arch_cohere2moe::forward::forward_batch(
-                    config, weights, state, gpu, &synthetic[i..end], start_pos,
+                    config,
+                    weights,
+                    state,
+                    gpu,
+                    &synthetic[i..end],
+                    start_pos,
                 )
                 .is_err()
                 {
@@ -1581,7 +1624,11 @@ impl Carrier for Cohere2MoeCarrier {
             }
         } else {
             for (i, &tok) in synthetic.iter().enumerate() {
-                if hipfire_arch_cohere2moe::forward::decode_step(config, weights, state, gpu, tok, i as u32).is_err() {
+                if hipfire_arch_cohere2moe::forward::decode_step(
+                    config, weights, state, gpu, tok, i as u32,
+                )
+                .is_err()
+                {
                     ok = false;
                     break;
                 }
@@ -1695,7 +1742,9 @@ impl Carrier for Gemma4Carrier {
         let state = &mut bundle.state;
         let mut ok = true;
         for (i, &tok) in synthetic.iter().enumerate() {
-            if hipfire_arch_gemma4::forward::decode_step(config, weights, state, gpu, tok, i as u32).is_err() {
+            if hipfire_arch_gemma4::forward::decode_step(config, weights, state, gpu, tok, i as u32)
+                .is_err()
+            {
                 ok = false;
                 break;
             }
@@ -2013,9 +2062,14 @@ impl Carrier for MuseGlimmerCarrier {
         for i in 0..iterations {
             let token = 101 + (i as u32 % 1000);
             match hipfire_arch_muse_glimmer::forward::decode_step(
-                config, weights, state, gpu, token, (context + i) as u32,
+                config,
+                weights,
+                state,
+                gpu,
+                token,
+                (context + i) as u32,
             ) {
-                Ok(_) => {},
+                Ok(_) => {}
                 Err(e) => {
                     *decode_err = Some(format!("iter {i} pos {}: {e}", context + i));
                     ok = false;

--- a/crates/hipfire-loader/src/carriers.rs
+++ b/crates/hipfire-loader/src/carriers.rs
@@ -278,6 +278,7 @@ fn load_qwen35_pp(
             .map(|v| v != "0")
             .unwrap_or_else(|| hipfire_runtime::hfq::arch_is_uma(gpus.devices[0].arch.as_str())),
     );
+    let _hfq_cache_warmer = hfq_file.start_cache_warmup();
     let layout = hipfire_arch_qwen35::qwen35::Layout::from_gpus(&gpus, config.n_layers);
     let mut hfq_source = hipfire_arch_qwen35::qwen35::HfqSource::new(&mut hfq_file, &config);
     let weights =
@@ -512,7 +513,7 @@ impl Carrier for Qwen35Carrier {
                             hipfire_runtime::hfq::arch_is_uma(ctx.gpu.arch.as_str())
                         }),
                 );
-                hfq_file.warm_page_cache();
+                let _hfq_cache_warmer = hfq_file.start_cache_warmup();
 
                 // ── pp=1 path (single-GPU) ────────────────────
                 let physical_cap = ctx.cask.physical_cap(ctx.max_seq)?;

--- a/crates/hipfire-quantize/src/model_filter.rs
+++ b/crates/hipfire-quantize/src/model_filter.rs
@@ -207,8 +207,6 @@ pub(crate) fn q8_class_of(name: &str) -> Option<&'static str> {
         Some("router")
     } else if name.contains("linear_attn.out_proj") || name.contains("ssm_out") {
         Some("ssm_out")
-    } else if name.contains("mlp.shared_expert.") {
-        Some("shared_expert")
     } else if name.contains("self_attn")
         || name.contains("attn_q")
         || name.contains("attn_k")

--- a/crates/hipfire-quantize/src/model_filter.rs
+++ b/crates/hipfire-quantize/src/model_filter.rs
@@ -207,6 +207,8 @@ pub(crate) fn q8_class_of(name: &str) -> Option<&'static str> {
         Some("router")
     } else if name.contains("linear_attn.out_proj") || name.contains("ssm_out") {
         Some("ssm_out")
+    } else if name.contains("mlp.shared_expert.") {
+        Some("shared_expert")
     } else if name.contains("self_attn")
         || name.contains("attn_q")
         || name.contains("attn_k")

--- a/crates/hipfire-runtime/Cargo.toml
+++ b/crates/hipfire-runtime/Cargo.toml
@@ -625,3 +625,11 @@ required-features = ["lab"]
 [[example]]
 name = "wmma_fa_spike"
 required-features = ["lab"]
+
+[[example]]
+name = "h2d_microbench"
+required-features = ["deltanet"]
+
+[[example]]
+name = "h2d_mmap_bench"
+required-features = ["deltanet"]

--- a/crates/hipfire-runtime/examples/h2d_microbench.rs
+++ b/crates/hipfire-runtime/examples/h2d_microbench.rs
@@ -1,0 +1,35 @@
+//! Micro-benchmark: host→device upload throughput from a warm host buffer.
+//! Measures sync pageable memcpy (the loader's current path) and, if
+//! available, repeated malloc+memcpy (what upload_raw actually does).
+//!
+//! Run: cargo run --release -p hipfire-runtime --example h2d_microbench
+
+use rdna_compute::Gpu;
+
+fn main() {
+    let mut gpu = Gpu::init().expect("gpu init");
+    let chunk: usize = 64 << 20; // 64 MiB
+    let reps = 16;
+    let data = vec![0x5au8; chunk];
+
+    // Warmup
+    for _ in 0..2 {
+        let t = gpu.upload_raw(&data, &[chunk]).expect("upload");
+        gpu.free_tensor(t).expect("free");
+    }
+
+    // malloc + sync pageable memcpy (upload_raw path)
+    let t0 = std::time::Instant::now();
+    for _ in 0..reps {
+        let t = gpu.upload_raw(&data, &[chunk]).expect("upload");
+        gpu.free_tensor(t).expect("free");
+    }
+    let dt = t0.elapsed().as_secs_f64();
+    println!(
+        "MALLOC_PLUS_MEMCPY {:.2} GB/s ({} x {} MiB in {:.3}s)",
+        (chunk * reps) as f64 / dt / 1e9,
+        reps,
+        chunk >> 20,
+        dt
+    );
+}

--- a/crates/hipfire-runtime/examples/h2d_mmap_bench.rs
+++ b/crates/hipfire-runtime/examples/h2d_mmap_bench.rs
@@ -1,0 +1,87 @@
+//! Micro-benchmark: H2D upload from (a) warm heap buffer vs (b) mmap'd
+//! file-backed pages (the zero-copy loader path). Decides where the
+//! remaining load-time wall lives.
+//!
+//! Run: cargo run --release -p hipfire-runtime --example h2d_mmap_bench -- <file>
+
+use rdna_compute::Gpu;
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: h2d_mmap_bench <file>");
+    let mut gpu = Gpu::init().expect("gpu init");
+
+    let file = std::fs::File::open(&path).expect("open");
+    let mmap = unsafe { memmap2::Mmap::map(&file).expect("mmap") };
+    let size = mmap.len();
+    println!("file: {} MiB", size >> 20);
+
+    let chunk: usize = 64 << 20;
+    let reps_per_src = size / chunk;
+
+    // One reusable destination; memcpy_htod overwrites it per iteration.
+    let dst = {
+        let warm = vec![0u8; chunk];
+        gpu.upload_raw(&warm, &[chunk]).expect("alloc dst")
+    };
+
+    let reps_per_src = (size / chunk).min(128);
+    let heap = vec![0x5au8; chunk];
+    let t0 = std::time::Instant::now();
+    let mut n = 0;
+    while n + chunk <= size {
+        gpu.memcpy_htod_auto(&dst.buf, &heap).expect("up");
+        n += chunk;
+    }
+    let dt = t0.elapsed().as_secs_f64();
+    println!(
+        "HEAP_SRC  {:.2} GB/s ({} x {} MiB in {:.3}s)",
+        (chunk * reps_per_src) as f64 / dt / 1e9,
+        reps_per_src,
+        chunk >> 20,
+        dt
+    );
+
+    // (b0) explicit madvise populates PTEs
+    unsafe {
+        libc::madvise(
+            mmap.as_ptr() as *mut libc::c_void,
+            size,
+            libc::MADV_POPULATE_READ,
+        );
+        libc::madvise(
+            mmap.as_ptr() as *mut libc::c_void,
+            size,
+            libc::MADV_HUGEPAGE,
+        );
+    }
+
+    // (b) mmap source, sequential sweep (cold PTEs first pass)
+    let t0 = std::time::Instant::now();
+    let mut n = 0;
+    while n + chunk <= size {
+        gpu.memcpy_htod_auto(&dst.buf, &mmap[n..n + chunk])
+            .expect("up");
+        n += chunk;
+    }
+    let dt = t0.elapsed().as_secs_f64();
+    println!(
+        "MMAP_SRC(cold-ptes) {:.2} GB/s",
+        (chunk * reps_per_src) as f64 / dt / 1e9
+    );
+
+    // (c) mmap source, second pass (PTEs warm)
+    let t0 = std::time::Instant::now();
+    let mut n = 0;
+    while n + chunk <= size {
+        gpu.memcpy_htod_auto(&dst.buf, &mmap[n..n + chunk])
+            .expect("up");
+        n += chunk;
+    }
+    let dt = t0.elapsed().as_secs_f64();
+    println!(
+        "MMAP_SRC(warm-ptes) {:.2} GB/s",
+        (chunk * reps_per_src) as f64 / dt / 1e9
+    );
+}

--- a/crates/hipfire-runtime/examples/h2d_mmap_bench.rs
+++ b/crates/hipfire-runtime/examples/h2d_mmap_bench.rs
@@ -1,6 +1,20 @@
-//! Micro-benchmark: H2D upload from (a) warm heap buffer vs (b) mmap'd
+//! Micro-benchmark: H2D upload from (a) a warm heap buffer vs (b/c/d) mmap'd
 //! file-backed pages (the zero-copy loader path). Decides where the
 //! remaining load-time wall lives.
+//!
+//! Phases:
+//! - `HEAP_SRC`      — 64 MiB warm heap chunks (the old staging-copy path's
+//!                     best case).
+//! - `MMAP_COLD`     — first sweep over a freshly-dropped mapping: pages are
+//!                     NOT resident and PTEs absent, so every chunk pays disk
+//!                     read + soft fault + H2D. The honest cold-start number.
+//! - `MMAP_WARM_PTE` — second sweep, everything resident with PTEs installed.
+//!                     The steady-state zero-copy number.
+//! - `MMAP_POPULATE` — sweep after `MADV_POPULATE_READ`; isolates any
+//!                     remaining per-chunk fault cost by removing it.
+//!
+//! Byte accounting: every phase counts its own completed iterations inside
+//! its own timing window and reports bytes actually transferred.
 //!
 //! Run: cargo run --release -p hipfire-runtime --example h2d_mmap_bench -- <file>
 
@@ -12,76 +26,92 @@ fn main() {
         .expect("usage: h2d_mmap_bench <file>");
     let mut gpu = Gpu::init().expect("gpu init");
 
-    let file = std::fs::File::open(&path).expect("open");
-    let mmap = unsafe { memmap2::Mmap::map(&file).expect("mmap") };
-    let size = mmap.len();
+    let size = std::fs::metadata(&path).expect("stat").len() as usize;
     println!("file: {} MiB", size >> 20);
 
     let chunk: usize = 64 << 20;
-    let reps_per_src = size / chunk;
+    if size < chunk {
+        eprintln!("file smaller than one {chunk} MiB chunk; nothing to measure");
+        return;
+    }
 
-    // One reusable destination; memcpy_htod overwrites it per iteration.
+    // One reusable destination; each upload overwrites it in full.
     let dst = {
         let warm = vec![0u8; chunk];
         gpu.upload_raw(&warm, &[chunk]).expect("alloc dst")
     };
 
-    let reps_per_src = (size / chunk).min(128);
+    // (a) heap source — the old staging-copy path.
     let heap = vec![0x5au8; chunk];
+    let mut reps = 0usize;
     let t0 = std::time::Instant::now();
-    let mut n = 0;
-    while n + chunk <= size {
+    while reps * chunk < size {
         gpu.memcpy_htod_auto(&dst.buf, &heap).expect("up");
-        n += chunk;
+        reps += 1;
     }
-    let dt = t0.elapsed().as_secs_f64();
-    println!(
-        "HEAP_SRC  {:.2} GB/s ({} x {} MiB in {:.3}s)",
-        (chunk * reps_per_src) as f64 / dt / 1e9,
-        reps_per_src,
-        chunk >> 20,
-        dt
-    );
+    report("HEAP_SRC     ", reps * chunk, t0.elapsed());
 
-    // (b0) explicit madvise populates PTEs
+    let file = std::fs::File::open(&path).expect("open");
+
+    // (b) COLD: drop resident pages for this inode BEFORE mapping, then map
+    // fresh so PTEs are absent too. `posix_fadvise(DONTNEED)` is only honored
+    // while the file is NOT mmap'd, which is why the drop runs on the plain
+    // handle before `Mmap::map`.
+    {
+        use std::os::unix::io::AsRawFd;
+        let fd = file.as_raw_fd();
+        let rc = unsafe { libc::posix_fadvise(fd, 0, size as _, libc::POSIX_FADV_DONTNEED) };
+        if rc != 0 {
+            eprintln!("warn: fadvise DONTNEED failed (rc={rc}); MMAP_COLD may be partially warm");
+        }
+    }
+    let mmap = unsafe { memmap2::Mmap::map(&file).expect("mmap") };
+    let (reps, dt) = sweep_mmap(&gpu, &dst, &mmap, chunk);
+    report("MMAP_COLD    ", reps * chunk, dt);
+
+    // (c) WARM PTEs: second sweep, pages resident + PTEs installed by (b).
+    let (reps, dt) = sweep_mmap(&gpu, &dst, &mmap, chunk);
+    report("MMAP_WARM_PTE", reps * chunk, dt);
+
+    // (d) POPULATE_READ then sweep: pre-faults everything up front, so the
+    // sweep itself carries zero fault cost. Delta vs (c) shows how much of
+    // even the "warm" pass was still fault handling.
     unsafe {
         libc::madvise(
             mmap.as_ptr() as *mut libc::c_void,
-            size,
+            mmap.len(),
             libc::MADV_POPULATE_READ,
         );
-        libc::madvise(
-            mmap.as_ptr() as *mut libc::c_void,
-            size,
-            libc::MADV_HUGEPAGE,
-        );
     }
+    let (reps, dt) = sweep_mmap(&gpu, &dst, &mmap, chunk);
+    report("MMAP_POPULATE", reps * chunk, dt);
+}
 
-    // (b) mmap source, sequential sweep (cold PTEs first pass)
+/// Sequential full-file sweep through the GPU copy engine, timed inside.
+/// Returns completed chunk transfers and elapsed time so callers report
+/// exact byte counts for exactly the measured window.
+fn sweep_mmap(
+    gpu: &Gpu,
+    dst: &rdna_compute::GpuTensor,
+    mmap: &[u8],
+    chunk: usize,
+) -> (usize, std::time::Duration) {
+    let mut n = 0usize;
     let t0 = std::time::Instant::now();
-    let mut n = 0;
-    while n + chunk <= size {
+    while n + chunk <= mmap.len() {
         gpu.memcpy_htod_auto(&dst.buf, &mmap[n..n + chunk])
             .expect("up");
         n += chunk;
     }
-    let dt = t0.elapsed().as_secs_f64();
-    println!(
-        "MMAP_SRC(cold-ptes) {:.2} GB/s",
-        (chunk * reps_per_src) as f64 / dt / 1e9
-    );
+    let dt = t0.elapsed();
+    (n / chunk, dt)
+}
 
-    // (c) mmap source, second pass (PTEs warm)
-    let t0 = std::time::Instant::now();
-    let mut n = 0;
-    while n + chunk <= size {
-        gpu.memcpy_htod_auto(&dst.buf, &mmap[n..n + chunk])
-            .expect("up");
-        n += chunk;
-    }
-    let dt = t0.elapsed().as_secs_f64();
+fn report(label: &str, bytes: usize, dt: std::time::Duration) {
     println!(
-        "MMAP_SRC(warm-ptes) {:.2} GB/s",
-        (chunk * reps_per_src) as f64 / dt / 1e9
+        "{label} {:8.2} GB/s ({} x 64 MiB in {:.3}s)",
+        bytes as f64 / dt.as_secs_f64() / 1e9,
+        bytes >> 26,
+        dt.as_secs_f64()
     );
 }

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -51,33 +51,156 @@ pub fn arch_is_uma(arch: &str) -> bool {
 }
 
 impl HfqFile {
-    /// Kick asynchronous kernel readahead over the whole data region
-    /// (`posix_fadvise(POSIX_FADV_WILLNEED)`). Non-blocking: the disk DMA
-    /// runs concurrently with whatever the caller does next (GPU init,
-    /// early tensor uploads), so later preads hit the page cache instead of
-    /// serializing behind per-tensor disk latency. No-op when page-cache
-    /// eviction is enabled (UMA — warming would double RAM pressure).
+    /// Start a background parallel cache warmer: N worker threads pread the
+    /// data region chunk-sequentially into the page cache while the loader
+    /// uploads tensors. Rationale (measured 2026-08-22, gfx1100 + btrfs md0):
+    /// a single `FADV_WILLNEED` does not saturate the array (~1.7 GB/s
+    /// effective serial reads), while 6 concurrent readers reach ~4.5 GB/s;
+    /// overlapping those reads with H2D uploads hides most of the disk time.
+    /// No-op when page-cache eviction is enabled (UMA — warming would double
+    /// RAM pressure). The returned guard stops the workers on drop.
     #[cfg(unix)]
-    pub fn warm_page_cache(&self) {
-        if !self.evict_page_cache {
-            use std::os::unix::io::AsRawFd;
-            let fd = self._file.as_raw_fd();
-            let end = self
-                .tensors
-                .last()
-                .map(|t| t.data_offset + t.data_size)
-                .unwrap_or(0);
-            if end > 0 {
-                unsafe {
-                    libc::posix_fadvise(fd, 0, end as libc::off_t, libc::POSIX_FADV_WILLNEED);
+    pub fn start_cache_warmup(&self) -> CacheWarmerGuard {
+        if self.evict_page_cache || self.mostly_page_cached() {
+            return CacheWarmerGuard::empty();
+        }
+        let end = self
+            .tensors
+            .last()
+            .map(|t| t.data_offset + t.data_size)
+            .unwrap_or(0);
+        if end == 0 {
+            return CacheWarmerGuard::empty();
+        }
+        const CHUNK: usize = 16 << 20;
+        const THREADS: usize = 4;
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let next = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let path = self.path.clone();
+        let mut handles = Vec::with_capacity(THREADS);
+        for _ in 0..THREADS {
+            let stop = stop.clone();
+            let next = next.clone();
+            let path = path.clone();
+            handles.push(std::thread::spawn(move || {
+                let Ok(file) = std::fs::File::open(&path) else {
+                    return;
+                };
+                use std::os::unix::io::AsRawFd;
+                let fd = file.as_raw_fd();
+                let mut buf = vec![0u8; CHUNK];
+                loop {
+                    if stop.load(std::sync::atomic::Ordering::Relaxed) {
+                        return;
+                    }
+                    let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    let off = i * CHUNK;
+                    if off >= end {
+                        return;
+                    }
+                    let len = CHUNK.min(end - off);
+                    let mut got = 0usize;
+                    while got < len {
+                        let n = unsafe {
+                            libc::pread(
+                                fd,
+                                buf[got..].as_mut_ptr() as *mut libc::c_void,
+                                len - got,
+                                (off + got) as libc::off_t,
+                            )
+                        };
+                        if n <= 0 {
+                            return;
+                        }
+                        got += n as usize;
+                    }
                 }
-            }
+            }));
+        }
+        CacheWarmerGuard {
+            stop,
+            handles: Some(handles),
         }
     }
 
-    /// Non-unix fallback: no fadvise, nothing to warm into.
+    /// Fraction of data pages already resident in the page cache, via
+    /// `mincore` over an untouched shared mapping (mapping does not fault
+    /// pages in, so this is free). Used to skip the warmer when a repeat
+    /// load would only re-copy an already-resident file.
+    #[cfg(unix)]
+    fn mostly_page_cached(&self) -> bool {
+        let end = self
+            .tensors
+            .last()
+            .map(|t| t.data_offset + t.data_size)
+            .unwrap_or(0);
+        if end == 0 {
+            return false;
+        }
+        let Ok(file) = std::fs::File::open(&self.path) else {
+            return false;
+        };
+        let Ok(mmap) = (unsafe { memmap2::Mmap::map(&file) }) else {
+            return false;
+        };
+        let page = 4096usize;
+        let n_pages = mmap.len().div_ceil(page);
+        let mut vec = vec![0u8; n_pages];
+        let rc = unsafe {
+            libc::mincore(
+                mmap.as_ptr() as *mut libc::c_void,
+                mmap.len(),
+                vec.as_mut_ptr(),
+            )
+        };
+        if rc != 0 {
+            return false;
+        }
+        let resident = vec.iter().filter(|b| *b & 1 != 0).count();
+        resident * 100 >= n_pages * 90
+    }
+
+    /// Non-unix fallback: never pre-detected as cached.
     #[cfg(not(unix))]
-    pub fn warm_page_cache(&self) {}
+    fn mostly_page_cached(&self) -> bool {
+        false
+    }
+
+    /// Non-unix fallback: nothing to warm.
+    #[cfg(not(unix))]
+    pub fn start_cache_warmup(&self) -> CacheWarmerGuard {
+        CacheWarmerGuard::empty()
+    }
+}
+
+/// Stops the cache-warmup workers when dropped (load finished or abandoned).
+pub struct CacheWarmerGuard {
+    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    #[cfg(unix)]
+    handles: Option<Vec<std::thread::JoinHandle<()>>>,
+    #[cfg(not(unix))]
+    handles: Option<()>,
+}
+
+impl CacheWarmerGuard {
+    fn empty() -> Self {
+        Self {
+            stop: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            handles: None,
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for CacheWarmerGuard {
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Some(handles) = self.handles.take() {
+            for h in handles {
+                let _ = h.join();
+            }
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -160,6 +160,25 @@ impl HfqFile {
         resident * 100 >= n_pages * 90
     }
 
+    /// [`Self::mostly_page_cached`] memoized per file instance. The probe
+    /// maps + mincores the whole multi-GB file (~0.4 s on an 18.8 GB model),
+    /// so callers inside a layer sweep must not re-run it per layer — but the
+    /// answer belongs to THIS file: a process-global memo goes stale when the
+    /// daemon swaps models (a warm model A would make a cold model B take the
+    /// zero-copy path and soft-fault serially at ~0.25 GB/s).
+    #[cfg(unix)]
+    pub fn mostly_page_cached_memo(&self) -> bool {
+        match self.pages_resident_memo.get() {
+            1 => true,
+            2 => false,
+            _ => {
+                let resident = self.mostly_page_cached();
+                self.pages_resident_memo.set(if resident { 1 } else { 2 });
+                resident
+            }
+        }
+    }
+
     /// Non-unix fallback: never pre-detected as cached.
     #[cfg(not(unix))]
     fn mostly_page_cached(&self) -> bool {
@@ -289,6 +308,11 @@ pub struct HfqFile {
     /// 2026-08-22 on gfx1100: fadvise-per-tensor forces a full disk re-read
     /// of the model on every load (~1.3 GB/s effective vs multi-GB/s cache).
     evict_page_cache: bool,
+    /// Memoized result of [`Self::mostly_page_cached`] for THIS file:
+    /// 0 = not probed, 1 = resident, 2 = not resident. Per-instance (not a
+    /// process global) so loading a second model in the same daemon probes
+    /// its own file instead of inheriting the previous model's answer.
+    pages_resident_memo: std::cell::Cell<u8>,
     /// Optional overlay HFQ whose tensors shadow this file's by name (the
     /// REAP load-time splice, SP3). When `Some`, every tensor read method
     /// consults the overlay first and falls back to the base. When `None`
@@ -591,6 +615,7 @@ impl HfqFile {
             tensor_map,
             pread_buf: std::cell::RefCell::new(Vec::new()),
             evict_page_cache: true,
+            pages_resident_memo: std::cell::Cell::new(0),
             overlay: None,
         };
 
@@ -870,10 +895,10 @@ impl HfqFile {
         }
         let idx = self.resolve_idx(name)?;
         let info = &self.tensors[idx];
-        debug_assert!(
-            self.mmap.is_some(),
-            "tensor_data() called after drop_mmap() — use tensor_data_vec() or tensor_data_pread() instead (tensor: {name})"
-        );
+        // NOTE: `self.mmap` may legitimately be None here — UMA loads drop the
+        // mapping in prepare() and callers probe tensor_data() first, falling
+        // back to tensor_data_vec()/tensor_data_pread() on None. Do NOT
+        // assert-fail debug builds on that expected path.
         let mmap = self.mmap.as_ref()?;
         Some((
             info,

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -73,7 +73,12 @@ impl HfqFile {
             return CacheWarmerGuard::empty();
         }
         const CHUNK: usize = 16 << 20;
-        const THREADS: usize = 4;
+        // Measured 2026-08-23 on gfx1100 + btrfs md0, time-to-99%-resident for
+        // a 5.3 GB mq4 after drop_caches: 4 threads 3.69 GB/s, 8 threads
+        // 4.58 GB/s, 12 threads 5.00 GB/s (plateau = array sequential
+        // ceiling). 8 captures most of the win without a small army of
+        // threads competing with the upload thread.
+        const THREADS: usize = 8;
         let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
         let next = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let path = self.path.clone();

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -42,6 +42,44 @@ fn fadvise_dontneed(fd: std::os::unix::io::RawFd, offset: usize, len: usize) {
 #[cfg(not(unix))]
 fn fadvise_dontneed(_fd: i32, _offset: usize, _len: usize) {}
 
+/// Whether this GPU architecture has unified memory (APU — GPU VRAM is system
+/// RAM). UMA loads must keep page-cache eviction ON: cached model pages and
+/// hipMalloc'd buffers share physical RAM, so keeping pages resident doubles
+/// consumption and can OOM mid-load. Discrete-GPU loads should disable it.
+pub fn arch_is_uma(arch: &str) -> bool {
+    matches!(arch, "gfx1103" | "gfx1150" | "gfx1151" | "gfx1152")
+}
+
+impl HfqFile {
+    /// Kick asynchronous kernel readahead over the whole data region
+    /// (`posix_fadvise(POSIX_FADV_WILLNEED)`). Non-blocking: the disk DMA
+    /// runs concurrently with whatever the caller does next (GPU init,
+    /// early tensor uploads), so later preads hit the page cache instead of
+    /// serializing behind per-tensor disk latency. No-op when page-cache
+    /// eviction is enabled (UMA — warming would double RAM pressure).
+    #[cfg(unix)]
+    pub fn warm_page_cache(&self) {
+        if !self.evict_page_cache {
+            use std::os::unix::io::AsRawFd;
+            let fd = self._file.as_raw_fd();
+            let end = self
+                .tensors
+                .last()
+                .map(|t| t.data_offset + t.data_size)
+                .unwrap_or(0);
+            if end > 0 {
+                unsafe {
+                    libc::posix_fadvise(fd, 0, end as libc::off_t, libc::POSIX_FADV_WILLNEED);
+                }
+            }
+        }
+    }
+
+    /// Non-unix fallback: no fadvise, nothing to warm into.
+    #[cfg(not(unix))]
+    pub fn warm_page_cache(&self) {}
+}
+
 #[derive(Clone)]
 pub struct HfqTensorInfo {
     pub name: String,
@@ -119,6 +157,15 @@ pub struct HfqFile {
     /// can't be evicted while the mapping exists (FADV_DONTNEED is ignored
     /// for mmap'd regions per Linux kernel docs).
     pread_buf: std::cell::RefCell<Vec<u8>>,
+    /// Whether tensor reads evict their pages after reading
+    /// (`posix_fadvise(DONTNEED)`). Defaults to `true` — the historical
+    /// behavior, required on unified-memory APUs where cached model pages
+    /// compete 1:1 with hipMalloc'd VRAM staging in system RAM. Discrete-GPU
+    /// loaders should disable this via [`Self::set_evict_page_cache`] so
+    /// repeat loads hit the page cache and kernel readahead works; measured
+    /// 2026-08-22 on gfx1100: fadvise-per-tensor forces a full disk re-read
+    /// of the model on every load (~1.3 GB/s effective vs multi-GB/s cache).
+    evict_page_cache: bool,
     /// Optional overlay HFQ whose tensors shadow this file's by name (the
     /// REAP load-time splice, SP3). When `Some`, every tensor read method
     /// consults the overlay first and falls back to the base. When `None`
@@ -411,7 +458,6 @@ impl HfqFile {
             });
             cumulative_offset += data_size;
         }
-
         let me = Self {
             _file: file,
             path: path.to_path_buf(),
@@ -421,6 +467,7 @@ impl HfqFile {
             tensors,
             tensor_map,
             pread_buf: std::cell::RefCell::new(Vec::new()),
+            evict_page_cache: true,
             overlay: None,
         };
 
@@ -458,6 +505,18 @@ impl HfqFile {
     /// so callers should only invoke this when UMA is detected.
     pub fn drop_mmap(&mut self) {
         self.mmap = None;
+    }
+
+    /// Enable/disable post-read page-cache eviction for this file. See the
+    /// `evict_page_cache` field docs. Discrete-GPU loaders call this with
+    /// `false` before loading; UMA paths keep the default (`true`).
+    pub fn set_evict_page_cache(&mut self, evict: bool) {
+        self.evict_page_cache = evict;
+    }
+
+    /// Whether reads on this file evict pages after reading.
+    pub fn evicts_page_cache(&self) -> bool {
+        self.evict_page_cache
     }
 
     /// Release the pread reuse buffer back to the allocator. After a
@@ -742,8 +801,12 @@ impl HfqFile {
                 }
                 total_read += n as usize;
             }
-            // Evict these pages from cache — works because pread doesn't hold a mapping.
-            fadvise_dontneed(fd, info.data_offset, info.data_size);
+            // Evict these pages from cache — works because pread doesn't hold a
+            // mapping. Skipped when the loader disabled eviction (discrete-GPU
+            // loads want the page cache warm for repeat loads).
+            if self.evict_page_cache {
+                fadvise_dontneed(fd, info.data_offset, info.data_size);
+            }
         }
         Some((info, self.pread_buf.borrow()))
     }
@@ -802,7 +865,9 @@ impl HfqFile {
                 }
                 total_read += n as usize;
             }
-            fadvise_dontneed(fd, info.data_offset, info.data_size);
+            if self.evict_page_cache {
+                fadvise_dontneed(fd, info.data_offset, info.data_size);
+            }
             return Some((info, buf));
         }
 
@@ -822,7 +887,9 @@ impl HfqFile {
         #[cfg(unix)]
         {
             use std::os::unix::io::AsRawFd;
-            fadvise_dontneed(self._file.as_raw_fd(), offset, len);
+            if self.evict_page_cache {
+                fadvise_dontneed(self._file.as_raw_fd(), offset, len);
+            }
         }
         #[cfg(not(unix))]
         {

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -128,7 +128,7 @@ impl HfqFile {
     /// pages in, so this is free). Used to skip the warmer when a repeat
     /// load would only re-copy an already-resident file.
     #[cfg(unix)]
-    fn mostly_page_cached(&self) -> bool {
+    pub fn mostly_page_cached(&self) -> bool {
         let end = self
             .tensors
             .last()
@@ -1002,6 +1002,25 @@ impl HfqFile {
                 mmap[info.data_offset..info.data_offset + info.data_size].to_vec(),
             ))
         }
+    }
+
+    /// Borrowed mmap byte range `[offset, offset+len)`. Zero-copy accessor for
+    /// callers that verified a set of tensors is contiguous in-file (via
+    /// `find_tensor_info` offsets) and want one slice covering all of them —
+    /// e.g. packed-expert blob uploads straight from the page cache.
+    ///
+    /// Returns `None` when the mapping was dropped (UMA / post-`drop_mmap`) or
+    /// when an overlay is attached (a range may span two files). Bounds-checked.
+    pub fn data_range(&self, offset: usize, len: usize) -> Option<&[u8]> {
+        if self.overlay.is_some() {
+            return None;
+        }
+        let mmap = self.mmap.as_ref()?;
+        let end = offset.checked_add(len)?;
+        if end > mmap.len() {
+            return None;
+        }
+        Some(&mmap[offset..end])
     }
 
     /// Release page cache for a byte range. Only works if the range is NOT mmap'd.

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -42,14 +42,6 @@ fn fadvise_dontneed(fd: std::os::unix::io::RawFd, offset: usize, len: usize) {
 #[cfg(not(unix))]
 fn fadvise_dontneed(_fd: i32, _offset: usize, _len: usize) {}
 
-/// Whether this GPU architecture has unified memory (APU — GPU VRAM is system
-/// RAM). UMA loads must keep page-cache eviction ON: cached model pages and
-/// hipMalloc'd buffers share physical RAM, so keeping pages resident doubles
-/// consumption and can OOM mid-load. Discrete-GPU loads should disable it.
-pub fn arch_is_uma(arch: &str) -> bool {
-    matches!(arch, "gfx1103" | "gfx1150" | "gfx1151" | "gfx1152")
-}
-
 impl HfqFile {
     /// Start a background parallel cache warmer: N worker threads pread the
     /// data region chunk-sequentially into the page cache while the loader
@@ -87,40 +79,52 @@ impl HfqFile {
             let stop = stop.clone();
             let next = next.clone();
             let path = path.clone();
-            handles.push(std::thread::spawn(move || {
-                let Ok(file) = std::fs::File::open(&path) else {
-                    return;
-                };
-                use std::os::unix::io::AsRawFd;
-                let fd = file.as_raw_fd();
-                let mut buf = vec![0u8; CHUNK];
-                loop {
-                    if stop.load(std::sync::atomic::Ordering::Relaxed) {
+            // Fallible spawn: under thread exhaustion (RLIMIT_NPROC, cgroup
+            // pids.max) `thread::spawn` would panic mid-load and kill the
+            // daemon. Degrade instead — fewer warmers only costs disk
+            // bandwidth; zero means the upload proceeds unwarmed.
+            match std::thread::Builder::new()
+                .name("hfq-cache-warmer".into())
+                .spawn(move || {
+                    let Ok(file) = std::fs::File::open(&path) else {
                         return;
-                    }
-                    let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    let off = i * CHUNK;
-                    if off >= end {
-                        return;
-                    }
-                    let len = CHUNK.min(end - off);
-                    let mut got = 0usize;
-                    while got < len {
-                        let n = unsafe {
-                            libc::pread(
-                                fd,
-                                buf[got..].as_mut_ptr() as *mut libc::c_void,
-                                len - got,
-                                (off + got) as libc::off_t,
-                            )
-                        };
-                        if n <= 0 {
+                    };
+                    use std::os::unix::io::AsRawFd;
+                    let fd = file.as_raw_fd();
+                    let mut buf = vec![0u8; CHUNK];
+                    loop {
+                        if stop.load(std::sync::atomic::Ordering::Relaxed) {
                             return;
                         }
-                        got += n as usize;
+                        let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let off = i * CHUNK;
+                        if off >= end {
+                            return;
+                        }
+                        let len = CHUNK.min(end - off);
+                        let mut got = 0usize;
+                        while got < len {
+                            let n = unsafe {
+                                libc::pread(
+                                    fd,
+                                    buf[got..].as_mut_ptr() as *mut libc::c_void,
+                                    len - got,
+                                    (off + got) as libc::off_t,
+                                )
+                            };
+                            if n <= 0 {
+                                return;
+                            }
+                            got += n as usize;
+                        }
                     }
-                }
-            }));
+                }) {
+                Ok(handle) => handles.push(handle),
+                Err(_) => break,
+            }
+        }
+        if handles.is_empty() {
+            return CacheWarmerGuard::empty();
         }
         CacheWarmerGuard {
             stop,
@@ -182,6 +186,13 @@ impl HfqFile {
                 resident
             }
         }
+    }
+
+    /// Non-unix fallback: no mincore probe available; never pre-detected as
+    /// cached (callers fall back to the pread path).
+    #[cfg(not(unix))]
+    pub fn mostly_page_cached_memo(&self) -> bool {
+        false
     }
 
     /// Non-unix fallback: never pre-detected as cached.

--- a/crates/hipfire-runtime/src/hfq_parallel.rs
+++ b/crates/hipfire-runtime/src/hfq_parallel.rs
@@ -124,13 +124,17 @@ pub fn read_hfq_jobs_ordered(hfq: &HfqFile, jobs: &[HfqReadJob]) -> io::Result<V
             "parallel HFQ reads do not cross attached overlay files",
         ));
     }
-    read_jobs_from_path(hfq.path(), jobs, HFQ_READER_LANES)
+    // Honor the model's page-cache policy: on discrete GPUs the carrier keeps
+    // pages resident across loads (fadvise(DONTNEED) here would force a full
+    // disk re-read on every restart); UMA / opt-in eviction keeps dropping.
+    read_jobs_from_path(hfq.path(), jobs, HFQ_READER_LANES, hfq.evicts_page_cache())
 }
 
 fn read_jobs_from_path(
     path: &Path,
     jobs: &[HfqReadJob],
     lanes: usize,
+    evict_page_cache: bool,
 ) -> io::Result<Vec<HfqReadResult>> {
     if jobs.is_empty() {
         return Ok(Vec::new());
@@ -173,7 +177,7 @@ fn read_jobs_from_path(
                     if index >= jobs.len() {
                         break;
                     }
-                    let result = read_job(&file, &jobs[index]);
+                    let result = read_job(&file, &jobs[index], evict_page_cache);
                     slots.lock().expect("HFQ result slots poisoned")[index] = Some(result);
                 }
             });
@@ -195,7 +199,7 @@ fn read_jobs_from_path(
     Ok(ordered)
 }
 
-fn read_job(file: &File, job: &HfqReadJob) -> io::Result<HfqReadResult> {
+fn read_job(file: &File, job: &HfqReadJob, evict_page_cache: bool) -> io::Result<HfqReadResult> {
     let mut data = vec![0u8; job.output_len];
     for segment in &job.segments {
         let end = segment
@@ -207,7 +211,9 @@ fn read_job(file: &File, job: &HfqReadJob) -> io::Result<HfqReadResult> {
             &mut data[segment.destination_offset..end],
             segment.source_offset as u64,
         )?;
-        advise_dontneed(file, segment.source_offset, segment.len);
+        if evict_page_cache {
+            advise_dontneed(file, segment.source_offset, segment.len);
+        }
     }
     Ok(HfqReadResult {
         label: job.label.clone(),
@@ -303,7 +309,7 @@ mod tests {
             job("third", &[(40, 3), (60, 5), (120, 8)]),
             job("fourth", &[(8, 8)]),
         ];
-        let results = read_jobs_from_path(source.path(), &jobs, 4).unwrap();
+        let results = read_jobs_from_path(source.path(), &jobs, 4, false).unwrap();
         assert_eq!(results[0].label, "first");
         assert_eq!(results[0].data, [&bytes[16..24], &bytes[0..4]].concat());
         assert_eq!(results[1].label, "second");
@@ -322,7 +328,8 @@ mod tests {
         let mut source = tempfile::NamedTempFile::new().unwrap();
         source.write_all(&[1, 2, 3, 4]).unwrap();
         source.flush().unwrap();
-        let error = read_jobs_from_path(source.path(), &[job("short", &[(2, 8)])], 1).unwrap_err();
+        let error =
+            read_jobs_from_path(source.path(), &[job("short", &[(2, 8)])], 1, false).unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
     }
 }

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -41,6 +41,16 @@ pub const LLOYD_MQ3_GROUP_BYTES: usize = 112;
 /// docs/plans/mq-lloyd-batched-prefill-followup.md).
 pub const LLOYD_MQ4_GROUP_BYTES: usize = 160;
 
+/// HIP `hipDeviceAttribute_t` ordinal for `hipDeviceAttributeIntegrated`
+/// ("Device is integrated GPU"). Pinned by enumerating the CUDA-compatible
+/// block in the local `hip_runtime_api.h`; the same enumeration reproduces
+/// the repo's existing pins (`HIP_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT` =
+/// 63 in `profiler.rs`). Ordinals HAVE shifted between ROCm releases before
+/// (`ReservedSharedMemPerBlock` was inserted ahead of
+/// `MaxSharedMemoryPerBlock`, moving it 74 → 75), so re-verify on any ROCm
+/// bump — see [`Gpu::is_uma`], the only consumer.
+const HIP_DEVICE_ATTRIBUTE_INTEGRATED: i32 = 16;
+
 // ── MQ*-GL ("global Lloyd") format constants ────────────────────────────
 //
 // GL = one codebook shared by the whole tensor plus a per-block fp16 scale,
@@ -905,6 +915,31 @@ impl Gpu {
     pub fn slots_decode_graph(&self) -> bool {
         // bind_thread: skip — pure flag read, touches no device state.
         self.flags.slots_decode_graph
+    }
+
+    /// Whether this device is an APU with unified memory (its "VRAM" is
+    /// system RAM). Queried live via
+    /// `hipDeviceGetAttribute(hipDeviceAttributeIntegrated)` instead of an
+    /// arch-string table: APUs and dGPUs share gfx IP across generations, so
+    /// name-based classification drifts every product refresh (gfx1151 is an
+    /// APU while gfx1201 with the same IP family era is not, etc).
+    ///
+    /// Query failure returns `true`, the conservative answer for page-cache
+    /// policy: assuming UMA on a dGPU only costs load speed (eviction is the
+    /// historical behavior), while assuming dGPU on a real APU keeps model
+    /// pages resident next to hipMalloc staging and can OOM the load.
+    // bind_thread: skip — pure device-property query; reads static device
+    // info, touches no stream or per-thread HIP context.
+    pub fn is_uma(&self) -> bool {
+        // bind_thread: skip — pure device-property query; reads static
+        // device info, touches no stream or per-thread HIP context.
+        match self
+            .hip
+            .get_device_attribute(HIP_DEVICE_ATTRIBUTE_INTEGRATED, self.device_id)
+        {
+            Ok(v) => v != 0,
+            Err(_) => true,
+        }
     }
 
     /// Install a real stream if launches are still going to the null stream.
@@ -2519,12 +2554,14 @@ impl Gpu {
     /// Together with `self.graphs.capture_blobs.len()`, this must agree for
     /// any body — see the `Gpu` type-level invariant doc.
     pub fn recorded_launch_count(&self) -> usize {
+        // bind_thread: skip — reads the recorded replay tape, no HIP calls.
         self.replay.recorded_launches().len()
     }
 
     /// Returns the number of HipGraph kernarg blobs captured.
     /// See `recorded_launch_count` and the `Gpu` invariant.
     pub fn graph_blob_count(&self) -> usize {
+        // bind_thread: skip — reads a captured-graph counter, no HIP calls.
         self.graphs.capture_blobs.len()
     }
 
@@ -2533,6 +2570,8 @@ impl Gpu {
     /// separate captures of the same body, passing the other count).
     /// A mismatch indicates a helper bypassed the replay recorder.
     pub fn debug_assert_tape_parity(&self, other_blob_count: Option<usize>) {
+        // bind_thread: skip — pure comparison of the two local tapes above;
+        // no HIP calls.
         let replay_len = self.recorded_launch_count();
         let graph_len = other_blob_count.unwrap_or_else(|| self.graph_blob_count());
         debug_assert_eq!(
@@ -3166,6 +3205,8 @@ impl Gpu {
         n: usize,
         k: usize,
     ) {
+        // bind_thread: skip — early-returns unless a capture is active, and
+        // capture paths run on an already-bound forward thread.
         if self.active_capture.is_none() {
             return;
         }

--- a/scripts/audit_load_ab.py
+++ b/scripts/audit_load_ab.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Interleaved model-load A/B with page-residency probes and stderr capture.
+
+Audits perf/model-load-time: runs master/branch daemons alternately (fresh
+process + fresh HOME each run), records spawn->loaded wall time, captures
+loader stderr traces, and mincore-probes model page residency before/between
+runs. Caller must hold the /home/ghazni/gpu-coord lock.
+"""
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import threading
+import time
+import ctypes
+import os
+
+
+libc = ctypes.CDLL("libc.so.6", use_errno=True)
+libc.mmap.restype = ctypes.c_void_p
+libc.mmap.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int,
+                      ctypes.c_int, ctypes.c_int, ctypes.c_long]
+libc.mincore.argtypes = [ctypes.c_void_p, ctypes.c_size_t,
+                         ctypes.POINTER(ctypes.c_ubyte)]
+
+PROT_READ = 0x1
+MAP_PRIVATE = 0x02
+
+
+def residency_pct(path):
+    fd = os.open(path, os.O_RDONLY)
+    try:
+        size = os.fstat(fd).st_size
+        addr = libc.mmap(None, ctypes.c_size_t(size),
+                         ctypes.c_int(PROT_READ), ctypes.c_int(MAP_PRIVATE),
+                         ctypes.c_int(fd), ctypes.c_long(0))
+        if addr in (None, ctypes.c_void_p(-1).value):
+            return -1.0
+        page = 4096
+        n = (size + page - 1) // page
+        vec = (ctypes.c_ubyte * n)()
+        rc = libc.mincore(ctypes.c_void_p(addr), ctypes.c_size_t(size), vec)
+        libc.munmap(ctypes.c_void_p(addr), ctypes.c_size_t(size))
+        if rc != 0:
+            return -1.0
+        res = sum(1 for b in vec if b & 1)
+        return res * 100.0 / n
+    finally:
+        os.close(fd)
+
+
+def one_run(daemon, model, home_dir):
+    env = dict(os.environ)
+    env["HOME"] = home_dir
+    proc = subprocess.Popen(
+        [daemon], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE, text=True, env=env,
+    )
+    errbuf = []
+
+    def drain():
+        for line in proc.stderr:
+            errbuf.append(line)
+
+    t = threading.Thread(target=drain, daemon=True)
+    t.start()
+    try:
+        t0 = time.perf_counter()
+        proc.stdin.write(json.dumps(
+            {"type": "load", "model": model,
+             "params": {"max_seq": 4096}}) + "\n")
+        proc.stdin.flush()
+        while True:
+            line = proc.stdout.readline()
+            if not line:
+                raise RuntimeError("daemon exited before loaded; stderr:\n"
+                                   + "".join(errbuf[-30:]))
+            try:
+                obj = json.loads(line.strip())
+            except json.JSONDecodeError:
+                continue
+            if obj.get("type") == "loaded":
+                return time.perf_counter() - t0, errbuf
+            if obj.get("type") == "error":
+                raise RuntimeError("load error: " + line[:400])
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def trace_lines(errs):
+    return [l.strip() for l in errs
+            if "sweep" in l or "load-trace" in l or "warmer" in l
+            or "evict" in l.lower()]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--master", required=True)
+    ap.add_argument("--branch", required=True)
+    ap.add_argument("--runs", type=int, default=4)
+    args = ap.parse_args()
+
+    homes = {"master": "/tmp/hm-master", "branch": "/tmp/hm-branch"}
+    results = {"master": [], "branch": []}
+    print(f"residency before: {residency_pct(args.model):.0f}%", flush=True)
+    for i in range(args.runs):
+        for arm, daemon in (("master", args.master), ("branch", args.branch)):
+            dt, errs = one_run(daemon, args.model, homes[arm])
+            results[arm].append(dt)
+            tr = trace_lines(errs)
+            print(f"run{i} {arm}: {dt*1000:7.1f} ms  "
+                  f"trace={tr[-1] if tr else '-'}", flush=True)
+            print(f"      residency after {arm}: "
+                  f"{residency_pct(args.model):.0f}%", flush=True)
+    for arm in ("master", "branch"):
+        xs = [x * 1000 for x in results[arm]]
+        print(f"{arm.upper()}: median={statistics.median(xs):.1f} ms "
+              f"samples={[round(x, 1) for x in xs]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_parity_check.py
+++ b/scripts/audit_parity_check.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Greedy-decode parity check between two hipfire daemon binaries.
+
+Speaks the daemon stdin/stdout protocol directly:
+  {"type":"load","model":...,"params":{"max_seq":...}}
+  {"type":"generate","id":...,"attempt_id":N,"prompt":...,"temperature":0,"max_tokens":...}
+
+Used by the perf/model-load-time audit to prove the loader rework
+(zero-copy mmap uploads, page-cache policy change) produces byte-identical
+greedy output vs master. Run under /home/ghazni/gpu-coord gpu-ctl only.
+"""
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+import time
+
+
+def sha(b):
+    return hashlib.sha256(b.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def run_daemon(daemon_bin, model, prompts, max_tokens, home):
+    env = {"HOME": home, "PATH": "/usr/bin:/bin:/usr/local/bin"}
+    proc = subprocess.Popen(
+        [daemon_bin], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE, text=True, env=env,
+    )
+    out = {}
+    try:
+        proc.stdin.write(json.dumps(
+            {"type": "load", "model": model, "params": {"max_seq": 4096}}) + "\n")
+        proc.stdin.flush()
+        t0 = time.perf_counter()
+        while True:
+            line = proc.stdout.readline()
+            if not line:
+                err = proc.stderr.read()
+                raise RuntimeError(f"daemon died during load:\n{err[-2000:]}")
+            try:
+                obj = json.loads(line.strip())
+            except json.JSONDecodeError:
+                continue
+            if obj.get("type") == "loaded":
+                print(f"  load-to-ready: {(time.perf_counter()-t0)*1000:.0f} ms",
+                      file=sys.stderr)
+                break
+            if obj.get("type") == "error":
+                raise RuntimeError(f"load error: {line[:400]}")
+        for i, p in enumerate(prompts):
+            pid = f"p{i}"
+            req = json.dumps({
+                "type": "generate", "id": pid, "attempt_id": i + 1, "prompt": p,
+                "temperature": 0, "max_tokens": max_tokens})
+            proc.stdin.write(req + "\n")
+            proc.stdin.flush()
+            text = []
+            while True:
+                line = proc.stdout.readline()
+                if not line:
+                    raise RuntimeError(f"daemon died during generate {pid}")
+                try:
+                    obj = json.loads(line.strip())
+                except json.JSONDecodeError:
+                    continue
+                t = obj.get("type")
+                if t == "token" and obj.get("id") == pid:
+                    text.append(obj.get("text") or obj.get("token") or "")
+                elif t in ("finish", "done", "finished") and obj.get("id") == pid:
+                    break
+                elif t == "error" and obj.get("id") == pid:
+                    text.append(f"<<ERROR: {obj.get('message')}>>")
+                    break
+            out[p] = "".join(text)
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--daemon", required=True)
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--prompt-file", action="append", required=True)
+    ap.add_argument("--max-tokens", type=int, default=640)
+    ap.add_argument("--home", required=True)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    prompts = []
+    for pf in args.prompt_file:
+        with open(pf, "rb") as f:
+            raw = f.read()
+        print(f"prompt {pf}: md5={hashlib.md5(raw).hexdigest()} bytes={len(raw)}",
+              file=sys.stderr)
+        prompts.append(raw.decode("utf-8"))
+
+    res = run_daemon(args.daemon, args.model, prompts, args.max_tokens, args.home)
+    with open(args.out, "w") as f:
+        for p, txt in res.items():
+            f.write(f"=== md5(prompt)={sha(p)} ===\n{txt}\n")
+            print(f"  output sha256[:16]={sha(txt)} chars={len(txt)}",
+                  file=sys.stderr)
+    print(args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/audit_swap_memo.py
+++ b/scripts/audit_swap_memo.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Model-swap residency-memo probe for perf/model-load-time audit.
+
+Loads models sequentially in ONE daemon process to exercise the process-global
+`model_pages_resident` memo in qwen35/load.rs. Sequence:
+  1. load A twice  -> second load sees A resident, memo := true
+  2. load B (not pre-warmed) -> memo still says true (stale) if bug present
+Compares step-2 timing/trace against a fresh-process load of B where the memo
+starts unset and the correct per-file probe runs.
+"""
+import json
+import subprocess
+import sys
+import threading
+import time
+
+
+def spawn(daemon):
+    env = {"HOME": "/tmp/hm-swap", "PATH": "/usr/bin:/bin"}
+    p = subprocess.Popen([daemon], stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                         text=True, env=env)
+    errs = []
+    threading.Thread(target=lambda: [errs.append(l) for l in p.stderr],
+                     daemon=True).start()
+    return p, errs
+
+
+def load(p, model):
+    t0 = time.perf_counter()
+    p.stdin.write(json.dumps(
+        {"type": "load", "model": model, "params": {"max_seq": 2048}}) + "\n")
+    p.stdin.flush()
+    while True:
+        line = p.stdout.readline()
+        if not line:
+            raise RuntimeError("daemon died: " + "".join(errs[-20:] if errs else []))
+        try:
+            o = json.loads(line.strip())
+        except json.JSONDecodeError:
+            continue
+        if o.get("type") == "loaded":
+            return time.perf_counter() - t0
+        if o.get("type") == "error":
+            raise RuntimeError("load error: " + line[:300])
+
+
+def main():
+    daemon = sys.argv[1]
+    a = sys.argv[2]   # small model, gets warmed
+    b = sys.argv[3]   # big model, never loaded before in this process
+
+    p, errs = spawn(daemon)
+    try:
+        print(f"swap1  A={a.split('/')[-1]}: {load(p, a)*1000:.0f} ms")
+        print(f"swap2  A again (warm):   {load(p, a)*1000:.0f} ms")
+        print(f"swap3  B first-in-proc:  {load(p, b)*1000:.0f} ms")
+    finally:
+        p.terminate()
+    # fresh-process control for B
+    p2, _ = spawn(daemon)
+    try:
+        print(f"fresh  B new-process:    {load(p2, b)*1000:.0f} ms")
+    finally:
+        p2.terminate()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_model_load.py
+++ b/scripts/bench_model_load.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Model-load wall-clock benchmark: hipfire daemon vs llama.cpp (ROCmFPX).
+
+Measures one thing per engine and reports medians of identical windows:
+
+  hipfire : daemon process spawn → {"type":"loaded"} protocol response.
+            Includes process init + GPU context + full weight upload.
+  rocmfpx : process spawn → engine-reported `load time` (print_timings),
+            cross-checked with wall-clock to end-of-load log line.
+
+GPU access MUST be serialized externally through /home/ghazni/gpu-coord/
+(e.g. gpu-ctl run ... -- python3 scripts/bench_model_load.py ...).
+This script never touches the lock itself so the caller owns acquisition.
+
+Usage:
+  python3 scripts/bench_model_load.py hipfire  --model M.hfq --runs 5 [--daemon PATH]
+  python3 scripts/bench_model_load.py rocmfpx --model M.gguf --llama-bin DIR --runs 5
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import subprocess
+import sys
+import threading
+import time
+
+
+def median(xs):
+    return statistics.median(xs)
+
+
+def spread_pct(xs):
+    if len(xs) < 2:
+        return 0.0
+    m = median(xs)
+    return (max(xs) - min(xs)) / m * 100.0
+
+
+def bench_hipfire(model: str, daemon_bin: str, runs: int) -> list[float]:
+    results = []
+    for i in range(runs):
+        t0 = time.perf_counter()
+        proc = subprocess.Popen(
+            [daemon_bin],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        try:
+            proc.stdin.write(
+                json.dumps({"type": "load", "model": model, "params": {"max_seq": 4096}})
+                + "\n"
+            )
+            proc.stdin.flush()
+            loaded = False
+            while not loaded:
+                line = proc.stdout.readline()
+                if not line:
+                    raise RuntimeError(f"run {i}: daemon closed stdout before 'loaded'")
+                msg = line.strip()
+                if not msg:
+                    continue
+                try:
+                    obj = json.loads(msg)
+                except json.JSONDecodeError:
+                    continue  # non-protocol log noise
+                if obj.get("type") == "loaded":
+                    loaded = True
+                    dt = time.perf_counter() - t0
+                    results.append(dt)
+                    print(f"  run {i+1}/{runs}: {dt*1000:.1f} ms  arch={obj.get('arch')}")
+                elif obj.get("type") == "error":
+                    raise RuntimeError(f"run {i}: daemon error: {msg[:400]}")
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        time.sleep(0.3)  # let the pid-file flock release before next spawn
+    return results
+
+
+
+
+READY_MARKER_RE = re.compile(r"main: llama threadpool init")
+
+
+def bench_rocmfpx(model: str, llama_bin_dir: str, runs: int) -> list[float]:
+    """Wall-clock process spawn → end-of-model-load marker.
+
+    The fork suppresses per-tensor load logs and its engine-reported
+    `load time` is clobbered by llama_perf_context_reset, so the reliable
+    ready marker is the first log line emitted after common_init_result
+    returns (`main: llama threadpool init`). The process is killed as soon
+    as the marker fires, so the window excludes prompt eval / generation.
+    """
+    results = []
+    bin_path = f"{llama_bin_dir}/llama-completion"
+    for i in range(runs):
+        t0 = time.perf_counter()
+        proc = subprocess.Popen(
+            [
+                bin_path,
+                "-m",
+                model,
+                "-ngl",
+                "99",
+                "-p",
+                "hi",
+                "-n",
+                "1",
+                "-t",
+                "16",
+                "--no-warmup",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={**dict(__import__("os").environ), "LD_LIBRARY_PATH": llama_bin_dir},
+        )
+        ready = None
+        assert proc.stderr is not None
+
+        def pump():
+            nonlocal ready
+            for line in proc.stderr:
+                if READY_MARKER_RE.search(line):
+                    ready = time.perf_counter() - t0
+                    return  # stop consuming; caller terminates the process
+
+        reader = threading.Thread(target=pump, daemon=True)
+        reader.start()
+        # pump() returns on the marker or at stderr EOF (process exit).
+        reader.join(timeout=600)
+        proc.kill()
+        proc.wait(timeout=10)
+        reader.join(timeout=5)
+        if ready is None:
+            raise RuntimeError(f"run {i}: ready marker never seen")
+        results.append(ready)
+        print(f"  run {i+1}/{runs}: {ready*1000:.1f} ms")
+    return results
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("engine", choices=["hipfire", "rocmfpx"])
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--runs", type=int, default=5)
+    ap.add_argument("--daemon", default="target/release/daemon")
+    ap.add_argument("--llama-bin", default="/home/ghazni/projects/ROCmFPX/build-opt/bin")
+    args = ap.parse_args()
+
+    print(f"== {args.engine} load benchmark: {args.runs} fresh-process runs ==")
+    if args.engine == "hipfire":
+        res = bench_hipfire(args.model, args.daemon, args.runs)
+    else:
+        res = bench_rocmfpx(args.model, args.llama_bin, args.runs)
+
+    print(f"MEDIAN_LOAD_S {median(res):.3f}")
+    print(f"SPREAD_PCT {spread_pct(res):.2f}")
+    print(f"SAMPLES_S {[round(x, 3) for x in res]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

hipfire's model→VRAM load path was leaving most of its bandwidth on the
table for three stacked reasons, each found by measurement:

1. **UMA-only page-cache eviction applied everywhere** — every tensor
   read ended with `posix_fadvise(DONTNEED)`, forcing a full disk
   re-read of the model on *every* load. Correct on unified-memory APUs
   (Strix Halo etc.), pure loss on discrete GPUs.
2. **Serial per-tensor pread** — a single `FADV_WILLNEED` does not
   saturate this box's btrfs md0 (~1.7 GB/s serial vs ~4.5 GB/s with
   concurrent readers), so cold loads serialized behind disk latency.
3. **Heap staging copy per tensor** — `pread` into a fresh Vec, then
   `hipMemcpy` from that copy: page-cache → heap → VRAM instead of
   page-cache → VRAM.

Three commits, one per cause:

- `9842657f` **gate HFQ page-cache eviction on UMA**: `HfqFile`
  gains `evict_page_cache` (default `true` = historical/UMA behavior);
  the qwen35 carrier disables it on non-UMA devices (both pp=1 and
  pp>1 paths); `HIPFIRE_PAGE_EVICTION=1` restores old behavior;
  `arch_is_uma()` classifies gfx1103/1150/1151/1152. deepseek4's
  OOM-sensitive pread+fadvise lifecycle is deliberately untouched.
- `9d51c825` **parallel cache warmer + mincore gate**: 4 worker threads
  pread the data region into the page cache (16 MiB chunks) while the
  loader uploads; a guard stops them on drop. Skipped entirely when
  `mincore` shows ≥90 % of pages already resident.
- `c6edb843` **zero-copy uploads**: qwen35 keeps its mmap alive on
  dGPUs and reads tensors as borrowed slices (`tensor_data`) so
  `hipMemcpy` DMAs straight out of page-cache pages; pread fallback
  preserves UMA behavior.

A fourth idea was tried and **reverted**: blocking `MADV_POPULATE`
before the upload loop measured identical totals (it relocates the same
soft-fault work into one serial stall). Documented in `prepare()`'s
comment so it isn't re-added blindly.

New tooling: `scripts/bench_model_load.py` measures hipfire and the
ROCmFPX llama.cpp fork with identical windows (hipfire: daemon spawn →
`{"type":"loaded"}` protocol response; rocmfpx: spawn → end-of-load log
marker, process killed at marker so prompt eval/gen are excluded).
Microbenchmarks: `h2d_mmap_bench.rs`, `h2d_microbench.rs`.

## Round 2: A3B MoE loads + a latent eviction leak (follow-up campaign)

Deploying the branch to the Ornith-1.5-35B-A3B mq4r serving container
exposed three more issues, found by phase-profiling real daemon loads:

4. **Zero-copy missed the MoE expert sweep** (`0493003f`) — the
   packed-MQ4 loader (`try_load_packed_mq4_experts`) still pread all
   512 experts per blob into fresh heap Vecs before `hipMemcpy`. This
   sweep was ~28 s of every ~31 s load on the A3B model. Fix:
   `HfqFile::data_range()` + an in-file contiguity probe — when all
   experts lie back-to-back and pages are resident, upload straight
   out of one borrowed mmap slice; non-contiguous/overlay/UMA keep the
   old paths.
5. **Parallel reader evicted its own pages** (`761de5d9`) —
   `read_job()` called `fadvise(DONTNEED)` after *every* segment,
   unconditionally, so any load routed through the lane-parallel
   reader re-read the whole model from disk (~0.7 GB/s) on every
   restart. This contradicted the carrier's dGPU keep-resident policy;
   `hfq.evicts_page_cache()` is now threaded through
   `read_jobs_from_path`/`read_job`.
6. **Per-layer residency probing** (`d2072ddf`) — the first cut of the
   zero-copy gate called `mostly_page_cached()` (fresh map+mincore of
   the full multi-GB file) once per layer ≈ 17 s per load of pure
   checking. Memoized per process.

Also riding in this push (`1cd7a890`): **sequential serve requests
seeded the sampler RNG from a compile-time constant** (`0x13579BDF`),
making temp>0 output byte-identical across requests for the same
prompt on the noslots path (batch scheduler already keyed entropy per
attempt). `generate()` now takes a `request_seed`; the daemon derives
it via `batch_rng_for_key(AttemptKey)`. Greedy temp-0 stays fully
deterministic — verified byte-identical pre/post change.

## Round 3: swap correctness + warmer scaling

Two follow-ups from continued load/swap testing on gfx1100:

7. **Stale residency memo across model swaps** (`05ea5cb8`) — the
   per-process memo from `d2072ddf` was correct within one load and
   wrong across loads: swapping from a warm model A to a cold model B
   left B on the zero-copy borrowed-slice path with its pages absent,
   so H2D soft-faulted serially off disk (~0.25 GB/s — exactly the
   mode `0493003f`'s parallel-pread fallback exists to avoid). The
   memo is now keyed to the file instance, not the process. Also drops
   a `debug_assert` in `tensor_data()`: UMA `prepare()` drops the mmap
   by design and returning `None` is the documented fallback contract;
   debug builds on APUs tripped it on every tensor read.
   Measured (9B warm → 27B cold swap, same daemon process): 7466 ms
   before vs **4349 ms** after; fresh-process controls 3616 / 3719 ms.
   Audit tooling committed alongside (gpu-coord lock held by caller):
   `scripts/audit_load_ab.py` (interleaved master/branch load A/B with
   mincore residency probes + loader stderr trace capture),
   `scripts/audit_swap_memo.py` (reproduces the stale-memo swap
   regression), `scripts/audit_parity_check.py` (greedy byte-parity
   across two daemons).
8. **Warmer scaled 4 → 8 threads** (`c9cff760`) — standalone
   time-to-99%-resident for a 5.3 GB mq4 after drop_caches on btrfs
   md0: 4 threads 3.69 GB/s, 8 threads **4.58 GB/s**, 12 threads
   5.00 GB/s (plateau = array sequential ceiling); 8 keeps most of the
   win without a small army of threads competing with the upload
   thread. Two more ideas investigated and **rejected with
   measurements**: chunked `posix_fadvise(WILLNEED)` (prototype
   segfaulted under repeated drop_caches runs; not pursued) and
   pre-init `--warm-file` overlap (net-zero end-to-end: the early
   warmer shortened the weight sweep 1387 → 856 ms but starved the
   carrier's synchronous header/metadata fetches by ≈ the same amount;
   total flat at ~2.33 s across 3 paired runs). Reverted; revisit only
   if a storage class shows serial dead time overlap can actually hide.

Validation for this round: greedy parity vs master byte-identical
(sha256s in the commit messages); steady-state 9B load median
1546 ms ±2.3 % over 3 fresh-process runs; hfq unit tests green.

## Measurements

gfx1100 (RX 7900 XTX), fresh daemon process per run, medians of ≥5 runs.
Shared-box caveat: another agent benchmarks the same GPU/disk, so
run-to-run noise is ±10–20 %; all deltas below exceed it.

**Isolation microbenchmarks** (`h2d_mmap_bench`, repaired in
`d472dab2`; gfx1100, qwen3.5-4b.mq4 2.47 GB file, 64 MiB chunks):
heap-src H2D 28.1 GB/s · mmap warm-PTEs 28.1 GB/s · mmap POPULATE_READ
27.9 GB/s · mmap genuinely cold (pages dropped pre-map) **2.45 GB/s** —
cold-start H2D is disk-bound on this array; the previously cited
"cold-PTEs 4.0 GB/s" came from a mislabeled fully-populated mapping and
is disregarded.

**End-to-end load, hipfire daemon:**

| model | master | final | speedup |
|---|---|---|---|
| qwen3.5-9b (md5 `296092bf…`) | 4338 ms | **~1600–1900 ms** | ~2.4× |
| qwen3.5-27b (sha256 `ea615949…8576e`) | 9901 ms* | **~3900–4400 ms** | ~2.4× |
| qwen3.8-27b (md5 `2fb2edc2…`) | 12 528 ms | **~3650–3800 ms** | ~3.4× |
| ornith-1.5-35b-a3b.mq4r (18.8 GB, warm cache)** | ~29 000–36 000 ms | **~5 500 ms** | ~6× |

*qwen3.5-27b baseline taken mid-campaign after the 9B fix landed; the
clean pre-fix number for the same lineage is the 3.8-27B A/B above
(master binary built from `80a572c8`, interleaved runs, identical
weights).
**Round 2 measurement: container daemon start → `/v1/models` serving,
interleaved old/new binary under a GPU lock; weight-sweep phase alone
dropped ~28 s → ~2.7 s (host-read 0 ms = borrowed-mmap path engaged).

**Reference point — ROCMFPX llama.cpp fork** loading equivalent weights,
same measurement window:

| model | rocmfpx steady-state median | hipfire final |
|---|---|---|
| Qwen3.5-9B Q4_K_M (md5 `d3842bd7…`) | 2189 ms | **2108 ms** |
| Qwen3.5-27B Q4_K_M (md5 `a34c995b…`) | 5908 ms | **4308 ms** |

Traced phase timings post-fix (27B): embed 77 ms / 1.24 GB
(~16 GB/s), lm_head 26 ms, full 64-layer sweep ~1.1 s (~11 GB/s).
Remaining budget: fixed init (~0.5 s), post-KV tail (~0.6 s), disk state.

## Verification

- `cargo test -p hipfire-runtime`: 550 tests pass at each commit.
- Repo MQ4 speed gates pass at commit time (prefill +86–91 % over
  baseline floor, decode +9 %).
- Coherence eyeballed on decoded output post-fix: 9B (Python
  string-reverse function), 27B (mutex paragraph), 3.8-27B (17×23=391,
  19×21=399 with correct reasoning chains).
- Deployed validation: two production serving containers rebuilt from
  this branch (`ornith-mq4rp`, `qwen36-35b-mq4r`, both retained-PM4
  rigs) and verified through their real HTTP serving path — load,
  greedy determinism, temp>0 sampling variation, and PM4 route
  activation checked end-to-end after each deploy.
- Sampler-seed fix verified by A/B: old binary reproduced byte-identical
  completions 3/3 at temp 0.8; fixed binary produced distinct
  generations 5/5, greedy unchanged.
- All GPU measurements serialized through a gpu-coord flock protocol;
  binary + model md5s recorded in the commit messages.

### Round 4: review-fix validation (2026-08-24, commits `edcc7d64`..`d472dab2`)

All five review blockers addressed:

1. **Non-Unix memo fallback** — `mostly_page_cached_memo()` now has a
   `#[cfg(not(unix))]` variant returning `false` (pread path).
   `cargo check -p hipfire-runtime -p hipfire-loader
   --target x86_64-pc-windows-msvc` passes.
2. **UMA classification replaced with a runtime property** — the
   gfx1103/1150/1151/1152 name table is gone. `Gpu::is_uma()` queries
   `hipDeviceGetAttribute(hipDeviceAttributeIntegrated)` live (ordinal
   pinned at 16 by the header enumeration that reproduces profiler.rs's
   MULTIPROCESSOR_COUNT=63; ordinals have shifted between ROCm releases,
   noted in-source). Query failure degrades conservatively to UMA=true =
   historical eviction behavior. Verified on this box's gfx1100:
   attribute returns 0 → dGPU path taken.
3. **Fallible warmer spawn** — `Builder::spawn` with per-thread failure
   tolerated: fewer warmers degrade disk bandwidth only, zero spawns
   skip warming entirely instead of panicking mid-load.
4. **shared_expert quant policy split out** — the `q8_class_of`
   "shared_expert" arm (and its missing VALID_Q8_CLASSES registration)
   is reverted from this PR; it belongs to the Q8-shared MoE prefill
   branch.
5. **H2D benchmark repaired** — byte accounting now counts actual
   iterations inside each timing window; the mislabeled "cold-PTEs" pass
   (run after MADV_POPULATE_READ) replaced by a genuinely cold phase
   (fadvise-drop before map) plus a separate POPULATE phase. Repaired
   numbers above.

Validation for this round (gfx1100, all under the gpu lock):

- Smoke (qwen3.5-4b.mq4): cold load 1146 ms after fadvise drop, warm
  reload 844 ms; decoded output coherent (long multiplication steps +
  correct string-reverse function).
- Final (qwen3.8-27b.mq4, prompt md5 `1d32df5f12c414d3e34c7b35b6611e6c`):
  cold load 4651 ms / warm load 2643 ms; greedy outputs byte-identical
  across cold and warm loads.
- Load-swap audit (`scripts/audit_swap_memo.py`, 4B→27B): 27B
  first-in-proc 2596 ms vs fresh-process control 2703 ms — no stale-memo
  regression.
- Greedy parity vs base (`18d46f76`, interleaved, pages dropped between
  arms): byte-identical, output sha256[:16] `84d20e12286c9aec` both
  binaries.
- `cargo test -p hipfire-runtime`: 573 pass; MQ4 speed gate: prefill
  +80.6%, decode +9.0% over baseline floor.
- gfx1151 UMA hardware is not available in this rig, so the UMA path was
  NOT re-validated on-device this round; with blocker 2 the classification
  is now hardware-reported rather than predicted from a table, which
  removes the misclassification risk the table carried. An on-device
  gfx1151 run remains open follow-up.

- Attempt ledger across the campaign: five failed/rejected attempts
  (eviction gate initially landed only in the pp>1 path; the
  blocking-populate experiment; the ungated first cut of the zero-copy
  gate, which let cold-start H2D soft-fault serially off disk at
  ~0.25 GB/s — now mincore-gated; chunked `posix_fadvise(WILLNEED)`;
  pre-init `--warm-file` overlap) — each documented with measurements
  rather than hidden (rounds 1–3 above).
- Non-qwen35 archs keep default eviction unless their carrier opts in,
  so no other load path changes behavior by default.
- UMA systems are byte-for-byte on the old code path: mmap dropped,
  fadvise per read, owned Vecs.
- The sampler-seed commit touches behavior beyond loading; it is
  included here because it was developed against and validated on this
  branch's deployment targets. Happy to split it out if reviewers
  prefer.


