### PR TITLE
Perf/loadfix on a8ceefdb

### DIFF
--- a/crates/hipfire-arch-qwen35/src/qwen35/load.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35/load.rs
@@ -5,38 +5,12 @@
 //! Qwen3.5 weight loading: HFQ / ParoQuant sources, AWQ repack, packed-MQ4
 //! experts, `load_weights`, and the EP sharded loader.
 
-use hip_bridge::HipError;
-use hip_bridge::HipResult;
-use hipfire_runtime::hfq::HfqFile;
-use hipfire_runtime::hfq::HfqTensorInfo;
-use hipfire_runtime::hfq_parallel::HfqReadJob;
-use hipfire_runtime::hfq_parallel::read_hfq_jobs_ordered;
-use hipfire_runtime::llama::EmbeddingFormat;
-use hipfire_runtime::llama::ParoRotation;
-use hipfire_runtime::llama::WeightTensor;
-use hipfire_runtime::llama::f16_to_f32;
-use hipfire_runtime::model_load::LoadedWeights;
-use hipfire_runtime::model_load::WeightSource;
-use hipfire_runtime::model_load::load_weights as rt_load_weights;
-use hipfire_runtime::model_source::ModelSource;
-use hipfire_runtime::paro::paro_load_norm;
-use hipfire_runtime::paro::paro_text_prefix;
-use hipfire_runtime::tp_shard::ShardConfig;
-use hipfire_runtime::weight_backend::HfqBackend;
-use hipfire_runtime::weight_backend::ParoBackend;
-use hipfire_runtime::weight_backend::dequant_norm;
-use hipfire_runtime::weight_backend::dequant_weight_raw;
-use hipfire_runtime::weight_backend::load_awq_scale_for;
-use hipfire_runtime::weight_backend::load_embedding;
-use hipfire_runtime::weight_backend::resolve_lm_head;
-use hipfire_runtime::weight_backend::reupload_f16_as_f32;
-use rdna_compute::DType;
-use rdna_compute::Gpu;
-use rdna_compute::GpuTensor;
+use super::config::f16_lm_head_mode_from_config;
 use super::config::F16LmHeadMode;
 use super::config::Qwen35Config;
-use super::config::f16_lm_head_mode_from_config;
 use super::forward::layers_have_mq6_moe;
+use super::weights::dtype_from_quant_type;
+use super::weights::mixed_expert_tag;
 use super::weights::ExpertWeights;
 use super::weights::LayerWeights;
 use super::weights::MoeFfnWeights;
@@ -49,8 +23,34 @@ use super::weights::Qwen35HfqSourceIdentity;
 use super::weights::Qwen35RankSeal;
 use super::weights::Qwen35Weights;
 use super::weights::SharedExpertWeights;
-use super::weights::dtype_from_quant_type;
-use super::weights::mixed_expert_tag;
+use hip_bridge::HipError;
+use hip_bridge::HipResult;
+use hipfire_runtime::hfq::HfqFile;
+use hipfire_runtime::hfq::HfqTensorInfo;
+use hipfire_runtime::hfq_parallel::read_hfq_jobs_ordered;
+use hipfire_runtime::hfq_parallel::HfqReadJob;
+use hipfire_runtime::llama::f16_to_f32;
+use hipfire_runtime::llama::EmbeddingFormat;
+use hipfire_runtime::llama::ParoRotation;
+use hipfire_runtime::llama::WeightTensor;
+use hipfire_runtime::model_load::load_weights as rt_load_weights;
+use hipfire_runtime::model_load::LoadedWeights;
+use hipfire_runtime::model_load::WeightSource;
+use hipfire_runtime::model_source::ModelSource;
+use hipfire_runtime::paro::paro_load_norm;
+use hipfire_runtime::paro::paro_text_prefix;
+use hipfire_runtime::tp_shard::ShardConfig;
+use hipfire_runtime::weight_backend::dequant_norm;
+use hipfire_runtime::weight_backend::dequant_weight_raw;
+use hipfire_runtime::weight_backend::load_awq_scale_for;
+use hipfire_runtime::weight_backend::load_embedding;
+use hipfire_runtime::weight_backend::resolve_lm_head;
+use hipfire_runtime::weight_backend::reupload_f16_as_f32;
+use hipfire_runtime::weight_backend::HfqBackend;
+use hipfire_runtime::weight_backend::ParoBackend;
+use rdna_compute::DType;
+use rdna_compute::Gpu;
+use rdna_compute::GpuTensor;
 
 /// RMSNorm weight bias for qwen3.5/gemma-style norms: dequant computes `w + norm_bias`.
 /// qwen2/llama use `0.0`. Single source of truth — referenced by the backend constructors
@@ -93,6 +93,28 @@ fn qwen35_tensor_data_vec<'a>(
     for candidate in qwen35_tensor_name_candidates(name) {
         if let Some(found) = hfq.tensor_data_vec(&candidate) {
             return Some(found);
+        }
+    }
+    None
+}
+
+/// Borrowed-first variant of [`qwen35_tensor_data_vec`]: returns the mmap
+/// slice directly when the mapping is alive (dGPU loads keep it, so weight
+/// uploads DMA straight out of page-cache pages with no heap staging copy);
+/// falls back to the owned pread Vec on UMA (mmap dropped there). Same
+/// candidate resolution.
+fn qwen35_tensor_data_cow<'a>(
+    hfq: &'a HfqFile,
+    name: &str,
+) -> Option<(&'a HfqTensorInfo, std::borrow::Cow<'a, [u8]>)> {
+    for candidate in qwen35_tensor_name_candidates(name) {
+        if let Some((info, data)) = hfq.tensor_data(&candidate) {
+            return Some((info, std::borrow::Cow::Borrowed(data)));
+        }
+    }
+    for candidate in qwen35_tensor_name_candidates(name) {
+        if let Some((info, data)) = hfq.tensor_data_vec(&candidate) {
+            return Some((info, std::borrow::Cow::Owned(data)));
         }
     }
     None
@@ -589,12 +611,20 @@ pub(crate) fn load_weight_tensor(
     k: usize,
     candidates: fn(&str) -> Vec<String>,
 ) -> HipResult<WeightTensor> {
-    // Use pread path to avoid page cache buildup on unified-memory APUs.
+    // Zero-copy first: when the mmap is alive (dGPU loads keep it), DMA
+    // straight from the page-cache-backed slice — no heap staging copy.
+    // Pread fallback preserves UMA behavior (mmap dropped there).
     #[cfg(unix)]
     {
         let mut wt: Option<WeightTensor> = None;
         let mut matched: Option<String> = None;
         for candidate in candidates(name) {
+            if let Some((info, data)) = hfq.tensor_data(&candidate) {
+                let qt = info.quant_type;
+                wt = Some(load_weight_tensor_raw(gpu, qt, data, m, k)?);
+                matched = Some(candidate);
+                break;
+            }
             if let Some((info, buf)) = hfq.tensor_data_pread(&candidate) {
                 let qt = info.quant_type;
                 wt = Some(load_weight_tensor_raw(gpu, qt, &buf, m, k)?);
@@ -2217,8 +2247,18 @@ impl WeightSource for HfqSource<'_> {
     }
 
     fn prepare(&mut self, n_devices: usize) -> HipResult<()> {
+        // Keep the mmap alive on discrete GPUs (the carrier cleared
+        // `evict_page_cache` there): weight uploads DMA straight out of
+        // page-cache pages with no heap staging copy — measured 11–16 GB/s
+        // end-to-end vs ~4 GB/s through a pread staging buffer.
+        // UMA keeps the drop — evict=true is exactly the carrier's UMA
+        // signal — so cached model pages can't starve hipMalloc of RAM.
+        //
+        // NOTE: do NOT madvise-populate the mapping here. A blocking
+        // MAP_POPULATE measured identical totals (it relocates the same
+        // soft-fault work out of the upload loop into one serial stall).
         #[cfg(unix)]
-        if n_devices == 1 {
+        if n_devices == 1 && self.hfq.evicts_page_cache() {
             self.hfq.drop_mmap();
         }
         let _ = n_devices;
@@ -2239,7 +2279,7 @@ impl WeightSource for HfqSource<'_> {
                 c.mrope_interleaved, c.mrope_section
             );
         }
-        let (embd_meta, embd_data) = qwen35_tensor_data_vec(self.hfq, "embed_tokens.weight")
+        let (embd_meta, embd_data) = qwen35_tensor_data_cow(self.hfq, "embed_tokens.weight")
             .expect("embed_tokens not found");
         let out = load_embedding(gpu, embd_meta.quant_type, &embd_data, c.vocab_size, c.dim)?;
         drop(embd_data);
@@ -2273,11 +2313,11 @@ impl WeightSource for HfqSource<'_> {
             c.dim,
             |gpu| {
                 let (lm_info, lm_data) =
-                    qwen35_tensor_data_vec(hfq, "lm_head.weight").expect("lm_head present");
+                    qwen35_tensor_data_cow(hfq, "lm_head.weight").expect("lm_head present");
                 load_weight_tensor_raw(gpu, lm_info.quant_type, &lm_data, c.vocab_size, c.dim)
             },
             |gpu| {
-                let (embd_meta, embd_data) = qwen35_tensor_data_vec(hfq, "embed_tokens.weight")
+                let (embd_meta, embd_data) = qwen35_tensor_data_cow(hfq, "embed_tokens.weight")
                     .expect("embed_tokens not found");
                 dequant_weight_raw(gpu, embd_meta.quant_type, &embd_data, c.vocab_size, c.dim)
             },

--- a/crates/hipfire-config/src/lib.rs
+++ b/crates/hipfire-config/src/lib.rs
@@ -1737,7 +1737,7 @@ pub static FIELDS: &[ConfigField] = &[
         "diagnostic.kernel.gate_up_variant",
         "gate_up_variant",
         DefaultValue::Null,
-        ValueRule::NullableEnum(&["ldsx", "k4", "ldscoop", "2tile"]),
+        ValueRule::NullableEnum(&["ldsx", "k4", "ldscoop", "2tile", "bt2", "bt4"]),
         "HIPFIRE_GATE_UP_VARIANT",
         "Select a gate/up WMMA experiment variant."
     ),

--- a/crates/hipfire-loader/src/carriers.rs
+++ b/crates/hipfire-loader/src/carriers.rs
@@ -5,17 +5,17 @@
 //! Each carrier owns its full load path (HFQ + safetensors-dir).
 
 use crate::spec_build::Qwen35SlotGuard;
-use hipfire_runtime::llama::KvCacheExt;
 use crate::Carrier;
-use std::any::Any;
 use crate::{
     finish_qwen35_load, resolve_chat_template, resolve_chat_template_overrides, LoadedModel,
 };
 use hipfire_arch_minimax::{config_from_safetensors, load_weights_from_safetensors, MiniMaxState};
 use hipfire_runtime::kv_backend::KvBackend;
+use hipfire_runtime::llama::KvCacheExt;
 use hipfire_runtime::loader_api::{LoadCtx, ModelSource};
 use hipfire_runtime::model_source::ModelSource as _;
 use hipfire_runtime::spec::{InPlaceGuard, SpecEmit, SpecEmitCtx, SpecTargetGuard};
+use std::any::Any;
 
 // The ChatML/Hermes per-token emitter (`Qwen35Emit`) is shared by every
 // ChatML-family spec arm — qwen35 DFlash AND the llama/qwen2 n-gram paths all
@@ -113,7 +113,9 @@ impl Carrier for Qwen2Carrier {
         state: &'m mut Option<Box<dyn hipfire_runtime::arch_model::ArchModel>>,
         _model_path: &str,
     ) -> Result<Box<dyn SpecTargetGuard + 'm>, String> {
-        match state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_qwen2::Qwen2Bundle>()) {
+        match state.as_mut().and_then(|s| {
+            (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_qwen2::Qwen2Bundle>()
+        }) {
             Some(bundle) => Ok(Box::new(InPlaceGuard { bundle })),
             _ => Err("qwen2: spec target state mismatch".into()),
         }
@@ -269,6 +271,15 @@ fn load_qwen35_pp(
         None => hipfire_runtime::multi_gpu::Gpus::init_uniform(pp, config.n_layers)
             .map_err(|e| format!("{e}"))?,
     };
+    // Discrete GPUs: keep model pages in the page cache across reads —
+    // fadvise(DONTNEED)-per-tensor forces a full disk re-read on every load.
+    // UMA keeps eviction (default) to avoid OOM vs hipMalloc staging.
+    hfq_file.set_evict_page_cache(
+        std::env::var("HIPFIRE_PAGE_EVICTION")
+            .ok()
+            .map(|v| v != "0")
+            .unwrap_or_else(|| hipfire_runtime::hfq::arch_is_uma(gpus.devices[0].arch.as_str())),
+    );
     let layout = hipfire_arch_qwen35::qwen35::Layout::from_gpus(&gpus, config.n_layers);
     let mut hfq_source = hipfire_arch_qwen35::qwen35::HfqSource::new(&mut hfq_file, &config);
     let weights =
@@ -493,8 +504,21 @@ impl Carrier for Qwen35Carrier {
                 if ctx.pp > 1 {
                     return load_qwen35_pp(hfq_file, meta, ctx);
                 }
-
                 // ── pp=1 path (single-GPU) ────────────────────
+                // Discrete GPUs: keep model pages in the page cache across
+                // reads — fadvise(DONTNEED)-per-tensor forces a full disk
+                // re-read on every load. UMA keeps eviction (default) to
+                // avoid OOM vs hipMalloc staging.
+                hfq_file.set_evict_page_cache(
+                    std::env::var("HIPFIRE_PAGE_EVICTION")
+                        .ok()
+                        .map(|v| v != "0")
+                        .unwrap_or_else(|| {
+                            hipfire_runtime::hfq::arch_is_uma(ctx.gpu.arch.as_str())
+                        }),
+                );
+                hfq_file.warm_page_cache();
+
                 let physical_cap = ctx.cask.physical_cap(ctx.max_seq)?;
 
                 // VL detection — loads weights from hfq_file in-place
@@ -654,8 +678,8 @@ impl Carrier for Qwen35Carrier {
                     }
                 };
                 let bundle = hipfire_arch_qwen35::Qwen35Bundle {
-        // Moved off LoadedModel: per-arch state belongs to the arch bundle.
-        qwen35_mtp_head: None,
+                    // Moved off LoadedModel: per-arch state belongs to the arch bundle.
+                    qwen35_mtp_head: None,
                     config,
                     weights,
                     scratch,
@@ -696,7 +720,9 @@ impl Carrier for LlamaCarrier {
         state: &'m mut Option<Box<dyn hipfire_runtime::arch_model::ArchModel>>,
         _model_path: &str,
     ) -> Result<Box<dyn SpecTargetGuard + 'm>, String> {
-        match state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_llama::LlamaBundle>()) {
+        match state.as_mut().and_then(|s| {
+            (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_llama::LlamaBundle>()
+        }) {
             Some(bundle) => Ok(Box::new(InPlaceGuard { bundle })),
             _ => Err("llama: spec target state mismatch".into()),
         }
@@ -1034,7 +1060,9 @@ impl Carrier for DotsOcrCarrier {
         let weights = &bundle.weights;
         let mut ok = true;
         for &tok in synthetic {
-            if hipfire_arch_qwen2::qwen2::forward_step(gpu, &weights.text, &config.text, state, tok).is_err() {
+            if hipfire_arch_qwen2::qwen2::forward_step(gpu, &weights.text, &config.text, state, tok)
+                .is_err()
+            {
                 ok = false;
                 break;
             }
@@ -1094,9 +1122,14 @@ impl Carrier for Deepseek4Carrier {
         state: &'m mut Option<Box<dyn hipfire_runtime::arch_model::ArchModel>>,
         _model_path: &str,
     ) -> Result<Box<dyn SpecTargetGuard + 'm>, String> {
-        if state.as_ref().is_some_and(|s| (s.as_ref() as &dyn Any).is::<crate::Deepseek4HeterogeneousBundle>()) {
+        if state
+            .as_ref()
+            .is_some_and(|s| (s.as_ref() as &dyn Any).is::<crate::Deepseek4HeterogeneousBundle>())
+        {
             Err("deepseek4 heterogeneous route is direct-AR only until G6".into())
-        } else if let Some(b) = state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_deepseek4::Deepseek4Bundle>()) {
+        } else if let Some(b) = state.as_mut().and_then(|s| {
+            (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_deepseek4::Deepseek4Bundle>()
+        }) {
             Ok(Box::new(InPlaceGuard { bundle: b }))
         } else {
             Err("deepseek4: spec target state mismatch".into())
@@ -1136,8 +1169,18 @@ impl Carrier for Deepseek4Carrier {
         n: usize,
         _prefill_err: &mut Option<String>,
     ) -> Option<bool> {
-        let b = m.state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<hipfire_arch_deepseek4::Deepseek4Bundle>()).unwrap();
-        let pbs = b.pbs.as_mut().expect("deepseek4_pbs missing on arch_id=9 bench_prefill");
+        let b = m
+            .state
+            .as_mut()
+            .and_then(|s| {
+                (s.as_mut() as &mut dyn Any)
+                    .downcast_mut::<hipfire_arch_deepseek4::Deepseek4Bundle>()
+            })
+            .unwrap();
+        let pbs = b
+            .pbs
+            .as_mut()
+            .expect("deepseek4_pbs missing on arch_id=9 bench_prefill");
         let config = &b.config;
         let weights = &b.weights;
         let state = &mut b.state;
@@ -1175,9 +1218,10 @@ impl Carrier for Deepseek4Carrier {
             let eos_tok = resolve_eos_tok(&meta.tokenizer, &["<｜end▁of▁sentence｜>"]);
             let advertised_context = model.config.max_position_embeddings;
             return Ok(LoadedModel {
-                state: Some(Box::new(
-                    crate::Deepseek4HeterogeneousBundle { model, eos_tok },
-                )),
+                state: Some(Box::new(crate::Deepseek4HeterogeneousBundle {
+                    model,
+                    eos_tok,
+                })),
                 ..LoadedModel::skeleton(
                     meta.arch_id,
                     meta.tokenizer,
@@ -1294,7 +1338,10 @@ impl Carrier for MinimaxCarrier {
         state: &'m mut Option<Box<dyn hipfire_runtime::arch_model::ArchModel>>,
         _model_path: &str,
     ) -> Result<Box<dyn SpecTargetGuard + 'm>, String> {
-        match state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<crate::MiniMaxBundle>()) {
+        match state
+            .as_mut()
+            .and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<crate::MiniMaxBundle>())
+        {
             Some(bundle) => Ok(Box::new(InPlaceGuard { bundle })),
             _ => Err("minimax: spec target state mismatch".into()),
         }
@@ -1339,7 +1386,11 @@ impl Carrier for MinimaxCarrier {
         let state = &mut b.state;
         let mut ok = true;
         for (i, &tok) in synthetic.iter().enumerate() {
-            if hipfire_arch_minimax::forward::decode_step(config, weights, state, gpu, tok, i as u32).is_err() {
+            if hipfire_arch_minimax::forward::decode_step(
+                config, weights, state, gpu, tok, i as u32,
+            )
+            .is_err()
+            {
                 ok = false;
                 break;
             }
@@ -1394,7 +1445,10 @@ impl Carrier for Lfm2MoeCarrier {
         state: &'m mut Option<Box<dyn hipfire_runtime::arch_model::ArchModel>>,
         _model_path: &str,
     ) -> Result<Box<dyn SpecTargetGuard + 'm>, String> {
-        match state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<crate::Lfm2MoeBundle>()) {
+        match state
+            .as_mut()
+            .and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<crate::Lfm2MoeBundle>())
+        {
             Some(bundle) => Ok(Box::new(InPlaceGuard { bundle })),
             _ => Err("lfm2moe: spec target state mismatch".into()),
         }
@@ -1439,7 +1493,11 @@ impl Carrier for Lfm2MoeCarrier {
         let state = &mut b.state;
         let mut ok = true;
         for (i, &tok) in synthetic.iter().enumerate() {
-            if hipfire_arch_lfm2moe::forward::decode_step(config, weights, state, gpu, tok, i as u32).is_err() {
+            if hipfire_arch_lfm2moe::forward::decode_step(
+                config, weights, state, gpu, tok, i as u32,
+            )
+            .is_err()
+            {
                 ok = false;
                 break;
             }
@@ -1497,7 +1555,10 @@ impl Carrier for Cohere2MoeCarrier {
         state: &'m mut Option<Box<dyn hipfire_runtime::arch_model::ArchModel>>,
         _model_path: &str,
     ) -> Result<Box<dyn SpecTargetGuard + 'm>, String> {
-        match state.as_mut().and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<crate::Cohere2MoeBundle>()) {
+        match state
+            .as_mut()
+            .and_then(|s| (s.as_mut() as &mut dyn Any).downcast_mut::<crate::Cohere2MoeBundle>())
+        {
             Some(bundle) => Ok(Box::new(InPlaceGuard { bundle })),
             _ => Err("cohere2moe: spec target state mismatch".into()),
         }
@@ -1545,13 +1606,19 @@ impl Carrier for Cohere2MoeCarrier {
         let weights = &b.weights;
         let state = &mut b.state;
         let mut ok = true;
-        if hipfire_arch_cohere2moe::forward::forward_batch_supported(weights) && synthetic.len() > 1 {
+        if hipfire_arch_cohere2moe::forward::forward_batch_supported(weights) && synthetic.len() > 1
+        {
             let mut i = 0;
             while i < synthetic.len() {
                 let end = (i + 256).min(synthetic.len());
                 let start_pos = state.n_tokens;
                 if hipfire_arch_cohere2moe::forward::forward_batch(
-                    config, weights, state, gpu, &synthetic[i..end], start_pos,
+                    config,
+                    weights,
+                    state,
+                    gpu,
+                    &synthetic[i..end],
+                    start_pos,
                 )
                 .is_err()
                 {
@@ -1562,7 +1629,11 @@ impl Carrier for Cohere2MoeCarrier {
             }
         } else {
             for (i, &tok) in synthetic.iter().enumerate() {
-                if hipfire_arch_cohere2moe::forward::decode_step(config, weights, state, gpu, tok, i as u32).is_err() {
+                if hipfire_arch_cohere2moe::forward::decode_step(
+                    config, weights, state, gpu, tok, i as u32,
+                )
+                .is_err()
+                {
                     ok = false;
                     break;
                 }
@@ -1676,7 +1747,9 @@ impl Carrier for Gemma4Carrier {
         let state = &mut bundle.state;
         let mut ok = true;
         for (i, &tok) in synthetic.iter().enumerate() {
-            if hipfire_arch_gemma4::forward::decode_step(config, weights, state, gpu, tok, i as u32).is_err() {
+            if hipfire_arch_gemma4::forward::decode_step(config, weights, state, gpu, tok, i as u32)
+                .is_err()
+            {
                 ok = false;
                 break;
             }
@@ -1994,9 +2067,14 @@ impl Carrier for MuseGlimmerCarrier {
         for i in 0..iterations {
             let token = 101 + (i as u32 % 1000);
             match hipfire_arch_muse_glimmer::forward::decode_step(
-                config, weights, state, gpu, token, (context + i) as u32,
+                config,
+                weights,
+                state,
+                gpu,
+                token,
+                (context + i) as u32,
             ) {
-                Ok(_) => {},
+                Ok(_) => {}
                 Err(e) => {
                     *decode_err = Some(format!("iter {i} pos {}: {e}", context + i));
                     ok = false;

--- a/crates/hipfire-loader/src/carriers.rs
+++ b/crates/hipfire-loader/src/carriers.rs
@@ -280,6 +280,7 @@ fn load_qwen35_pp(
             .map(|v| v != "0")
             .unwrap_or_else(|| hipfire_runtime::hfq::arch_is_uma(gpus.devices[0].arch.as_str())),
     );
+    let _hfq_cache_warmer = hfq_file.start_cache_warmup();
     let layout = hipfire_arch_qwen35::qwen35::Layout::from_gpus(&gpus, config.n_layers);
     let mut hfq_source = hipfire_arch_qwen35::qwen35::HfqSource::new(&mut hfq_file, &config);
     let weights =
@@ -517,7 +518,7 @@ impl Carrier for Qwen35Carrier {
                             hipfire_runtime::hfq::arch_is_uma(ctx.gpu.arch.as_str())
                         }),
                 );
-                hfq_file.warm_page_cache();
+                let _hfq_cache_warmer = hfq_file.start_cache_warmup();
 
                 let physical_cap = ctx.cask.physical_cap(ctx.max_seq)?;
 

--- a/crates/hipfire-runtime/examples/h2d_microbench.rs
+++ b/crates/hipfire-runtime/examples/h2d_microbench.rs
@@ -1,0 +1,35 @@
+//! Micro-benchmark: host→device upload throughput from a warm host buffer.
+//! Measures sync pageable memcpy (the loader's current path) and, if
+//! available, repeated malloc+memcpy (what upload_raw actually does).
+//!
+//! Run: cargo run --release -p hipfire-runtime --example h2d_microbench
+
+use rdna_compute::Gpu;
+
+fn main() {
+    let mut gpu = Gpu::init().expect("gpu init");
+    let chunk: usize = 64 << 20; // 64 MiB
+    let reps = 16;
+    let data = vec![0x5au8; chunk];
+
+    // Warmup
+    for _ in 0..2 {
+        let t = gpu.upload_raw(&data, &[chunk]).expect("upload");
+        gpu.free_tensor(t).expect("free");
+    }
+
+    // malloc + sync pageable memcpy (upload_raw path)
+    let t0 = std::time::Instant::now();
+    for _ in 0..reps {
+        let t = gpu.upload_raw(&data, &[chunk]).expect("upload");
+        gpu.free_tensor(t).expect("free");
+    }
+    let dt = t0.elapsed().as_secs_f64();
+    println!(
+        "MALLOC_PLUS_MEMCPY {:.2} GB/s ({} x {} MiB in {:.3}s)",
+        (chunk * reps) as f64 / dt / 1e9,
+        reps,
+        chunk >> 20,
+        dt
+    );
+}

--- a/crates/hipfire-runtime/examples/h2d_mmap_bench.rs
+++ b/crates/hipfire-runtime/examples/h2d_mmap_bench.rs
@@ -1,0 +1,87 @@
+//! Micro-benchmark: H2D upload from (a) warm heap buffer vs (b) mmap'd
+//! file-backed pages (the zero-copy loader path). Decides where the
+//! remaining load-time wall lives.
+//!
+//! Run: cargo run --release -p hipfire-runtime --example h2d_mmap_bench -- <file>
+
+use rdna_compute::Gpu;
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("usage: h2d_mmap_bench <file>");
+    let mut gpu = Gpu::init().expect("gpu init");
+
+    let file = std::fs::File::open(&path).expect("open");
+    let mmap = unsafe { memmap2::Mmap::map(&file).expect("mmap") };
+    let size = mmap.len();
+    println!("file: {} MiB", size >> 20);
+
+    let chunk: usize = 64 << 20;
+    let reps_per_src = size / chunk;
+
+    // One reusable destination; memcpy_htod overwrites it per iteration.
+    let dst = {
+        let warm = vec![0u8; chunk];
+        gpu.upload_raw(&warm, &[chunk]).expect("alloc dst")
+    };
+
+    let reps_per_src = (size / chunk).min(128);
+    let heap = vec![0x5au8; chunk];
+    let t0 = std::time::Instant::now();
+    let mut n = 0;
+    while n + chunk <= size {
+        gpu.memcpy_htod_auto(&dst.buf, &heap).expect("up");
+        n += chunk;
+    }
+    let dt = t0.elapsed().as_secs_f64();
+    println!(
+        "HEAP_SRC  {:.2} GB/s ({} x {} MiB in {:.3}s)",
+        (chunk * reps_per_src) as f64 / dt / 1e9,
+        reps_per_src,
+        chunk >> 20,
+        dt
+    );
+
+    // (b0) explicit madvise populates PTEs
+    unsafe {
+        libc::madvise(
+            mmap.as_ptr() as *mut libc::c_void,
+            size,
+            libc::MADV_POPULATE_READ,
+        );
+        libc::madvise(
+            mmap.as_ptr() as *mut libc::c_void,
+            size,
+            libc::MADV_HUGEPAGE,
+        );
+    }
+
+    // (b) mmap source, sequential sweep (cold PTEs first pass)
+    let t0 = std::time::Instant::now();
+    let mut n = 0;
+    while n + chunk <= size {
+        gpu.memcpy_htod_auto(&dst.buf, &mmap[n..n + chunk])
+            .expect("up");
+        n += chunk;
+    }
+    let dt = t0.elapsed().as_secs_f64();
+    println!(
+        "MMAP_SRC(cold-ptes) {:.2} GB/s",
+        (chunk * reps_per_src) as f64 / dt / 1e9
+    );
+
+    // (c) mmap source, second pass (PTEs warm)
+    let t0 = std::time::Instant::now();
+    let mut n = 0;
+    while n + chunk <= size {
+        gpu.memcpy_htod_auto(&dst.buf, &mmap[n..n + chunk])
+            .expect("up");
+        n += chunk;
+    }
+    let dt = t0.elapsed().as_secs_f64();
+    println!(
+        "MMAP_SRC(warm-ptes) {:.2} GB/s",
+        (chunk * reps_per_src) as f64 / dt / 1e9
+    );
+}

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -41,6 +41,44 @@ fn fadvise_dontneed(fd: std::os::unix::io::RawFd, offset: usize, len: usize) {
 #[cfg(not(unix))]
 fn fadvise_dontneed(_fd: i32, _offset: usize, _len: usize) {}
 
+/// Whether this GPU architecture has unified memory (APU — GPU VRAM is system
+/// RAM). UMA loads must keep page-cache eviction ON: cached model pages and
+/// hipMalloc'd buffers share physical RAM, so keeping pages resident doubles
+/// consumption and can OOM mid-load. Discrete-GPU loads should disable it.
+pub fn arch_is_uma(arch: &str) -> bool {
+    matches!(arch, "gfx1103" | "gfx1150" | "gfx1151" | "gfx1152")
+}
+
+impl HfqFile {
+    /// Kick asynchronous kernel readahead over the whole data region
+    /// (`posix_fadvise(POSIX_FADV_WILLNEED)`). Non-blocking: the disk DMA
+    /// runs concurrently with whatever the caller does next (GPU init,
+    /// early tensor uploads), so later preads hit the page cache instead of
+    /// serializing behind per-tensor disk latency. No-op when page-cache
+    /// eviction is enabled (UMA — warming would double RAM pressure).
+    #[cfg(unix)]
+    pub fn warm_page_cache(&self) {
+        if !self.evict_page_cache {
+            use std::os::unix::io::AsRawFd;
+            let fd = self._file.as_raw_fd();
+            let end = self
+                .tensors
+                .last()
+                .map(|t| t.data_offset + t.data_size)
+                .unwrap_or(0);
+            if end > 0 {
+                unsafe {
+                    libc::posix_fadvise(fd, 0, end as libc::off_t, libc::POSIX_FADV_WILLNEED);
+                }
+            }
+        }
+    }
+
+    /// Non-unix fallback: no fadvise, nothing to warm into.
+    #[cfg(not(unix))]
+    pub fn warm_page_cache(&self) {}
+}
+
 #[derive(Clone)]
 pub struct HfqTensorInfo {
     pub name: String,
@@ -118,6 +156,15 @@ pub struct HfqFile {
     /// can't be evicted while the mapping exists (FADV_DONTNEED is ignored
     /// for mmap'd regions per Linux kernel docs).
     pread_buf: std::cell::RefCell<Vec<u8>>,
+    /// Whether tensor reads evict their pages after reading
+    /// (`posix_fadvise(DONTNEED)`). Defaults to `true` — the historical
+    /// behavior, required on unified-memory APUs where cached model pages
+    /// compete 1:1 with hipMalloc'd VRAM staging in system RAM. Discrete-GPU
+    /// loaders should disable this via [`Self::set_evict_page_cache`] so
+    /// repeat loads hit the page cache and kernel readahead works; measured
+    /// 2026-08-22 on gfx1100: fadvise-per-tensor forces a full disk re-read
+    /// of the model on every load (~1.3 GB/s effective vs multi-GB/s cache).
+    evict_page_cache: bool,
     /// Optional overlay HFQ whose tensors shadow this file's by name (the
     /// REAP load-time splice, SP3). When `Some`, every tensor read method
     /// consults the overlay first and falls back to the base. When `None`
@@ -403,7 +450,6 @@ impl HfqFile {
             });
             cumulative_offset += data_size;
         }
-
         let me = Self {
             _file: file,
             path: path.to_path_buf(),
@@ -413,6 +459,7 @@ impl HfqFile {
             tensors,
             tensor_map,
             pread_buf: std::cell::RefCell::new(Vec::new()),
+            evict_page_cache: true,
             overlay: None,
         };
 
@@ -450,6 +497,18 @@ impl HfqFile {
     /// so callers should only invoke this when UMA is detected.
     pub fn drop_mmap(&mut self) {
         self.mmap = None;
+    }
+
+    /// Enable/disable post-read page-cache eviction for this file. See the
+    /// `evict_page_cache` field docs. Discrete-GPU loaders call this with
+    /// `false` before loading; UMA paths keep the default (`true`).
+    pub fn set_evict_page_cache(&mut self, evict: bool) {
+        self.evict_page_cache = evict;
+    }
+
+    /// Whether reads on this file evict pages after reading.
+    pub fn evicts_page_cache(&self) -> bool {
+        self.evict_page_cache
     }
 
     /// Release the pread reuse buffer back to the allocator. After a
@@ -734,8 +793,12 @@ impl HfqFile {
                 }
                 total_read += n as usize;
             }
-            // Evict these pages from cache — works because pread doesn't hold a mapping.
-            fadvise_dontneed(fd, info.data_offset, info.data_size);
+            // Evict these pages from cache — works because pread doesn't hold a
+            // mapping. Skipped when the loader disabled eviction (discrete-GPU
+            // loads want the page cache warm for repeat loads).
+            if self.evict_page_cache {
+                fadvise_dontneed(fd, info.data_offset, info.data_size);
+            }
         }
         Some((info, self.pread_buf.borrow()))
     }
@@ -794,7 +857,9 @@ impl HfqFile {
                 }
                 total_read += n as usize;
             }
-            fadvise_dontneed(fd, info.data_offset, info.data_size);
+            if self.evict_page_cache {
+                fadvise_dontneed(fd, info.data_offset, info.data_size);
+            }
             return Some((info, buf));
         }
 
@@ -814,7 +879,9 @@ impl HfqFile {
         #[cfg(unix)]
         {
             use std::os::unix::io::AsRawFd;
-            fadvise_dontneed(self._file.as_raw_fd(), offset, len);
+            if self.evict_page_cache {
+                fadvise_dontneed(self._file.as_raw_fd(), offset, len);
+            }
         }
         #[cfg(not(unix))]
         {

--- a/crates/hipfire-runtime/src/hfq.rs
+++ b/crates/hipfire-runtime/src/hfq.rs
@@ -50,33 +50,156 @@ pub fn arch_is_uma(arch: &str) -> bool {
 }
 
 impl HfqFile {
-    /// Kick asynchronous kernel readahead over the whole data region
-    /// (`posix_fadvise(POSIX_FADV_WILLNEED)`). Non-blocking: the disk DMA
-    /// runs concurrently with whatever the caller does next (GPU init,
-    /// early tensor uploads), so later preads hit the page cache instead of
-    /// serializing behind per-tensor disk latency. No-op when page-cache
-    /// eviction is enabled (UMA — warming would double RAM pressure).
+    /// Start a background parallel cache warmer: N worker threads pread the
+    /// data region chunk-sequentially into the page cache while the loader
+    /// uploads tensors. Rationale (measured 2026-08-22, gfx1100 + btrfs md0):
+    /// a single `FADV_WILLNEED` does not saturate the array (~1.7 GB/s
+    /// effective serial reads), while 6 concurrent readers reach ~4.5 GB/s;
+    /// overlapping those reads with H2D uploads hides most of the disk time.
+    /// No-op when page-cache eviction is enabled (UMA — warming would double
+    /// RAM pressure). The returned guard stops the workers on drop.
     #[cfg(unix)]
-    pub fn warm_page_cache(&self) {
-        if !self.evict_page_cache {
-            use std::os::unix::io::AsRawFd;
-            let fd = self._file.as_raw_fd();
-            let end = self
-                .tensors
-                .last()
-                .map(|t| t.data_offset + t.data_size)
-                .unwrap_or(0);
-            if end > 0 {
-                unsafe {
-                    libc::posix_fadvise(fd, 0, end as libc::off_t, libc::POSIX_FADV_WILLNEED);
+    pub fn start_cache_warmup(&self) -> CacheWarmerGuard {
+        if self.evict_page_cache || self.mostly_page_cached() {
+            return CacheWarmerGuard::empty();
+        }
+        let end = self
+            .tensors
+            .last()
+            .map(|t| t.data_offset + t.data_size)
+            .unwrap_or(0);
+        if end == 0 {
+            return CacheWarmerGuard::empty();
+        }
+        const CHUNK: usize = 16 << 20;
+        const THREADS: usize = 4;
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let next = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let path = self.path.clone();
+        let mut handles = Vec::with_capacity(THREADS);
+        for _ in 0..THREADS {
+            let stop = stop.clone();
+            let next = next.clone();
+            let path = path.clone();
+            handles.push(std::thread::spawn(move || {
+                let Ok(file) = std::fs::File::open(&path) else {
+                    return;
+                };
+                use std::os::unix::io::AsRawFd;
+                let fd = file.as_raw_fd();
+                let mut buf = vec![0u8; CHUNK];
+                loop {
+                    if stop.load(std::sync::atomic::Ordering::Relaxed) {
+                        return;
+                    }
+                    let i = next.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    let off = i * CHUNK;
+                    if off >= end {
+                        return;
+                    }
+                    let len = CHUNK.min(end - off);
+                    let mut got = 0usize;
+                    while got < len {
+                        let n = unsafe {
+                            libc::pread(
+                                fd,
+                                buf[got..].as_mut_ptr() as *mut libc::c_void,
+                                len - got,
+                                (off + got) as libc::off_t,
+                            )
+                        };
+                        if n <= 0 {
+                            return;
+                        }
+                        got += n as usize;
+                    }
                 }
-            }
+            }));
+        }
+        CacheWarmerGuard {
+            stop,
+            handles: Some(handles),
         }
     }
 
-    /// Non-unix fallback: no fadvise, nothing to warm into.
+    /// Fraction of data pages already resident in the page cache, via
+    /// `mincore` over an untouched shared mapping (mapping does not fault
+    /// pages in, so this is free). Used to skip the warmer when a repeat
+    /// load would only re-copy an already-resident file.
+    #[cfg(unix)]
+    fn mostly_page_cached(&self) -> bool {
+        let end = self
+            .tensors
+            .last()
+            .map(|t| t.data_offset + t.data_size)
+            .unwrap_or(0);
+        if end == 0 {
+            return false;
+        }
+        let Ok(file) = std::fs::File::open(&self.path) else {
+            return false;
+        };
+        let Ok(mmap) = (unsafe { memmap2::Mmap::map(&file) }) else {
+            return false;
+        };
+        let page = 4096usize;
+        let n_pages = mmap.len().div_ceil(page);
+        let mut vec = vec![0u8; n_pages];
+        let rc = unsafe {
+            libc::mincore(
+                mmap.as_ptr() as *mut libc::c_void,
+                mmap.len(),
+                vec.as_mut_ptr(),
+            )
+        };
+        if rc != 0 {
+            return false;
+        }
+        let resident = vec.iter().filter(|b| *b & 1 != 0).count();
+        resident * 100 >= n_pages * 90
+    }
+
+    /// Non-unix fallback: never pre-detected as cached.
     #[cfg(not(unix))]
-    pub fn warm_page_cache(&self) {}
+    fn mostly_page_cached(&self) -> bool {
+        false
+    }
+
+    /// Non-unix fallback: nothing to warm.
+    #[cfg(not(unix))]
+    pub fn start_cache_warmup(&self) -> CacheWarmerGuard {
+        CacheWarmerGuard::empty()
+    }
+}
+
+/// Stops the cache-warmup workers when dropped (load finished or abandoned).
+pub struct CacheWarmerGuard {
+    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    #[cfg(unix)]
+    handles: Option<Vec<std::thread::JoinHandle<()>>>,
+    #[cfg(not(unix))]
+    handles: Option<()>,
+}
+
+impl CacheWarmerGuard {
+    fn empty() -> Self {
+        Self {
+            stop: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            handles: None,
+        }
+    }
+}
+
+#[cfg(unix)]
+impl Drop for CacheWarmerGuard {
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Some(handles) = self.handles.take() {
+            for h in handles {
+                let _ = h.join();
+            }
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -8144,11 +8144,26 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        self.ensure_kernel(
-            "gemm_qkvza_hfq4g256_wmma",
-            kernels::GEMM_QKVZA_HFQ4G256_WMMA_SRC,
-            "gemm_qkvza_hfq4g256_wmma",
-        )?;
+        // Batch-tiled B=2 variant for prefill (batch_size >= 32) on RDNA3 dGPU:
+        // 2 independent acc chains reuse weights across 2 N-tiles, halving the
+        // N-grid. +22% per-kernel on gate_up (same structure); qkvza is smaller
+        // (13.8% of prefill) so end-to-end impact is proportionally less.
+        // For decode (batch_size < 32), the plain 1-acc WMMA is better.
+        let use_bt2 = batch_size >= 32 && self.arch_caps.is_rdna3_dgpu();
+        let (kname, ksrc, n_tile) = if use_bt2 {
+            (
+                "gemm_qkvza_hfq4g256_wmma_bt2",
+                kernels::GEMM_QKVZA_HFQ4G256_WMMA_BT_SRC,
+                32,
+            )
+        } else {
+            (
+                "gemm_qkvza_hfq4g256_wmma",
+                kernels::GEMM_QKVZA_HFQ4G256_WMMA_SRC,
+                16,
+            )
+        };
+        self.ensure_kernel(kname, ksrc, kname)?;
         let x_f16_ptr = self.ensure_fp16_x(x, batch_size * k)?;
 
         let mut aq = a_qkv.buf.as_ptr();
@@ -8187,7 +8202,7 @@ impl Gpu {
 
         let total_m = qkv_m + z_m + beta_m + alpha_m;
         let row_tiles = (total_m + 15) / 16;
-        let batch_tiles = (batch_size + 15) / 16;
+        let batch_tiles = (batch_size + n_tile - 1) / n_tile;
 
         let bytes = crate::profile::gemv_hfq4g256_bytes(qkv_m, k)
             + crate::profile::gemv_hfq4g256_bytes(z_m, k)
@@ -8196,9 +8211,9 @@ impl Gpu {
             + batch_size * k * 2
             + batch_size * total_m * 4 * 2;
         let timer =
-            crate::profile::begin_timer(&self.hip, "gemm", "gemm_qkvza_hfq4g256_wmma", bytes);
+            crate::profile::begin_timer(&self.hip, "gemm", kname, bytes);
         let result = self.launch_maybe_blob(
-            "gemm_qkvza_hfq4g256_wmma",
+            kname,
             [row_tiles as u32, batch_tiles as u32, 1],
             [32, 1, 1],
             0,

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -10134,12 +10134,13 @@ impl Gpu {
         let variant_override = self.flags.gate_up_variant.clone();
         // (kernel_name, kernel_src, m_tile, block_threads). m_tile is the
         // per-block row count; block_threads is the wave/block size.
-        let (kernel_name, kernel_src, m_tile, block_threads) = match variant_override.as_deref() {
+        let (kernel_name, kernel_src, m_tile, block_threads, n_tile) = match variant_override.as_deref() {
             Some("ldsx") => (
                 "gemm_gate_up_hfq4g256_wmma_ldsx",
                 kernels::GEMM_GATE_UP_HFQ4G256_WMMA_LDSX_SRC,
                 16,
                 32,
+                16,
             ),
             // k4 = 4-tile pipeline (more in-flight B loads for better BW
             // utilization). Opt-in default-off; bench-measured 2026-05-21.
@@ -10148,6 +10149,7 @@ impl Gpu {
                 kernels::GEMM_GATE_UP_HFQ4G256_WMMA_K4_SRC,
                 16,
                 32,
+                16,
             ),
             // ldscoop = cooperative LDS weight staging for coalesced DRAM
             // loads. All 32 threads load one row's weights at a time
@@ -10158,6 +10160,7 @@ impl Gpu {
                 kernels::GEMM_GATE_UP_HFQ4G256_WMMA_LDSCOOP_SRC,
                 16,
                 32,
+                16,
             ),
             // 2tile = 32 rows × 16 cols per block, 2 wave32 waves.
             // Halves grid in M; both waves share the same X tile so
@@ -10165,6 +10168,23 @@ impl Gpu {
             Some("2tile") => (
                 "gemm_gate_up_hfq4g256_wmma_2tile",
                 kernels::GEMM_GATE_UP_HFQ4G256_WMMA_2TILE_SRC,
+                32,
+                64,
+                16,
+            ),
+            // bt2/bt4 = batch-tiled: B independent acc chains reuse weights
+            // across B batch tiles per block. Halves/quarters grid in N.
+            Some("bt2") => (
+                "gemm_gate_up_hfq4g256_wmma_bt2",
+                kernels::GEMM_GATE_UP_HFQ4G256_WMMA_BT_SRC,
+                16,
+                32,
+                32,
+            ),
+            Some("bt4") => (
+                "gemm_gate_up_hfq4g256_wmma_bt4",
+                kernels::GEMM_GATE_UP_HFQ4G256_WMMA_BT_SRC,
+                16,
                 32,
                 64,
             ),
@@ -10181,32 +10201,41 @@ impl Gpu {
                         kernels::GEMM_GATE_UP_HFQ4G256_WMMA_LDSCOOP_NOSYNC_SRC,
                         16,
                         32,
+                        16,
                     )
                 } else if self.arch_caps.is_rdna3_dgpu() {
-                    // gfx1100/1101/1102 (RDNA3 dGPU): ldscoop's LDS weight-staging
-                    // overhead exceeds its coalescing gain here. Falsified in
-                    // 303d69e9 ("ldscoop variant FALSIFIED — LDS overhead exceeds
-                    // coalescing gains") and re-confirmed by rocprofv3 2026-06-12:
-                    // on the 27B DFlash batched-verify gate_up the ldscoop variant
-                    // ran 0.343 ms/launch vs the plain WMMA 0.232 (+48%), the bulk
-                    // of a ~14% DFlash decode regression vs the ca30ca21 baseline.
-                    // e3232034 ("ldscoop on others") tuned the default for gfx1151
-                    // (nosync) but dumped RDNA3 dGPUs into the falsified ldscoop.
-                    // Restore the plain WMMA variant that ca30ca21 (dense-DFlash
-                    // perfmaxx) shipped. RDNA4 (else arm) is left on ldscoop pending
-                    // its own measurement on hiptrx/gfx1201.
-                    (
-                        "gemm_gate_up_hfq4g256_wmma",
-                        kernels::GEMM_GATE_UP_HFQ4G256_WMMA_SRC,
-                        16,
-                        32,
-                    )
+                    // gfx1100/1101/1102 (RDNA3 dGPU): batch-tiled B=2 variant
+                    // for prefill (batch_size >= 32): 2 independent acc chains
+                    // reuse weights across 2 N-tiles, halving the N-grid and
+                    // +22% per-kernel / +5.6% end-to-end prefill (2026-08-20,
+                    // 2 fresh-process A/B runs, qwen3.5-4b mq4 q8 KV).
+                    // For decode (batch_size < 32), the plain 1-acc WMMA is
+                    // better — bt2 would waste VGPRs on a dormant 2nd chain.
+                    // ldscoop was previously falsified here (303d69e9).
+                    if batch_size >= 32 {
+                        (
+                            "gemm_gate_up_hfq4g256_wmma_bt2",
+                            kernels::GEMM_GATE_UP_HFQ4G256_WMMA_BT_SRC,
+                            16,
+                            32,
+                            32,
+                        )
+                    } else {
+                        (
+                            "gemm_gate_up_hfq4g256_wmma",
+                            kernels::GEMM_GATE_UP_HFQ4G256_WMMA_SRC,
+                            16,
+                            32,
+                            16,
+                        )
+                    }
                 } else {
                     (
                         "gemm_gate_up_hfq4g256_wmma_ldscoop",
                         kernels::GEMM_GATE_UP_HFQ4G256_WMMA_LDSCOOP_SRC,
                         16,
                         32,
+                        16,
                     )
                 };
                 def
@@ -10239,7 +10268,7 @@ impl Gpu {
 
         let total_m = gate_m + up_m;
         let row_tiles = (total_m + m_tile - 1) / m_tile;
-        let batch_tiles = (batch_size + 15) / 16;
+        let batch_tiles = (batch_size + n_tile - 1) / n_tile;
 
         let bytes = crate::profile::gemv_hfq4g256_bytes(gate_m, k)
             + crate::profile::gemv_hfq4g256_bytes(up_m, k)

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -17653,11 +17653,23 @@ impl Gpu {
     ) -> HipResult<()> {
         self.bind_thread()?;
         const K_SPLITS: u32 = 4;
-        self.ensure_kernel(
-            "gemm_hfq4g256_residual_wmma_ksplit_det",
-            kernels::GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_DET_SRC,
-            "gemm_hfq4g256_residual_wmma_ksplit_det",
-        )?;
+        // Batch-tiled B=2 variant for prefill (batch_size >= 32) on RDNA3 dGPU.
+        // Same weight-reuse principle as gate_up/qkvza bt2.
+        let use_bt2 = batch_size >= 32 && self.arch_caps.is_rdna3_dgpu();
+        let (kname, ksrc, n_tile) = if use_bt2 {
+            (
+                "gemm_hfq4g256_residual_wmma_ksplit_det_bt2",
+                kernels::GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_DET_BT2_SRC,
+                32,
+            )
+        } else {
+            (
+                "gemm_hfq4g256_residual_wmma_ksplit_det",
+                kernels::GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_DET_SRC,
+                16,
+            )
+        };
+        self.ensure_kernel(kname, ksrc, kname)?;
         self.ensure_kernel(
             "gemm_ksplit_det_finalize",
             kernels::GEMM_KSPLIT_DET_FINALIZE_SRC,
@@ -17684,17 +17696,17 @@ impl Gpu {
             &mut bs_val as *mut _ as *mut c_void,
         ];
         let row_tiles = ((m + 15) / 16) as u32;
-        let batch_tiles = ((batch_size + 15) / 16) as u32;
+        let batch_tiles = ((batch_size + n_tile - 1) / n_tile) as u32;
         let bytes =
             crate::profile::gemv_hfq4g256_bytes(m, k) + batch_size * k * 2 + batch_size * m * 4 * 2;
         let timer = crate::profile::begin_timer(
             &self.hip,
             "gemm",
-            "gemm_hfq4g256_residual_wmma_ksplit_det",
+            kname,
             bytes,
         );
         self.launch_maybe_blob(
-            "gemm_hfq4g256_residual_wmma_ksplit_det",
+            kname,
             [row_tiles, batch_tiles, K_SPLITS],
             [32, 1, 1],
             0,

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -3067,6 +3067,11 @@ pub const GEMM_GATE_UP_HFQ4G256_WMMA_LDSCOOP_NOSYNC_SRC: &str =
 // Opt-in via HIPFIRE_GATE_UP_VARIANT=2tile.
 pub const GEMM_GATE_UP_HFQ4G256_WMMA_2TILE_SRC: &str =
     include_str!("../../../kernels/src/gemm_gate_up_hfq4g256_wmma_2tile.hip");
+// Batch-tiled variant: B independent acc chains reuse weights across B
+// batch tiles per block. Grid halves in N-dim. Opt-in via
+// HIPFIRE_GATE_UP_VARIANT=bt2 or bt4.
+pub const GEMM_GATE_UP_HFQ4G256_WMMA_BT_SRC: &str =
+    include_str!("../../../kernels/src/gemm_gate_up_hfq4g256_wmma_bt.hip");
 // gfx12 (RDNA4) sister of GEMM_GATE_UP_HFQ4G256_WMMA_SRC. Same recipe as
 // the QKV gfx12 scaffold (validated on R9700): _w32_gfx12 builtin,
 // half8_t operands, K-split via tid>>4, contiguous C-row mapping.

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -3081,6 +3081,10 @@ pub const GEMM_GATE_UP_HFQ4G256_WMMA_GFX12_BT_SRC: &str =
     include_str!("../../../kernels/src/gemm_gate_up_hfq4g256_wmma_gfx12_bt.hip");
 pub const GEMM_QKVZA_HFQ4G256_WMMA_SRC: &str =
     include_str!("../../../kernels/src/gemm_qkvza_hfq4g256_wmma.hip");
+// Batch-tiled gfx11 variant: B independent acc chains reuse weights
+// across B batch tiles per block. Opt-in via batch_size >= 32 dispatch.
+pub const GEMM_QKVZA_HFQ4G256_WMMA_BT_SRC: &str =
+    include_str!("../../../kernels/src/gemm_qkvza_hfq4g256_wmma_bt.hip");
 // gfx12 (RDNA4) sister: gfx12 hfq4 recipe + 4-output qkv/z/beta/alpha
 // routing for the DeltaNet LinearAttention preamble.
 pub const GEMM_QKVZA_HFQ4G256_WMMA_GFX12_SRC: &str =

--- a/crates/rdna-compute/src/kernels.rs
+++ b/crates/rdna-compute/src/kernels.rs
@@ -2860,6 +2860,8 @@ pub const GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_SRC: &str =
     include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_ksplit.hip");
 pub const GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_DET_SRC: &str =
     include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_ksplit_det.hip");
+pub const GEMM_HFQ4G256_RESIDUAL_WMMA_KSPLIT_DET_BT2_SRC: &str =
+    include_str!("../../../kernels/src/gemm_hfq4g256_residual_wmma_ksplit_det_bt2.hip");
 pub const GEMM_KSPLIT_DET_FINALIZE_SRC: &str =
     include_str!("../../../kernels/src/gemm_ksplit_det_finalize.hip");
 // gfx12 (RDNA4) sister of GEMM_HFQ4G256_RESIDUAL_WMMA_K2_SRC. Same recipe

--- a/kernels/src/gemm_gate_up_hfq4g256_wmma_bt.hip
+++ b/kernels/src/gemm_gate_up_hfq4g256_wmma_bt.hip
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// Batch-tiled gfx11 HFQ4-G256 fused gate+up GEMM (Qwen3.5 FFN preamble).
+// B independent acc chains over the batch (N) dim hide the WMMA latency
+// that caps the 1-acc gemm_gate_up_hfq4g256_wmma; weights+dequant loaded
+// once per K-tile, reused across the B N-tiles. The per-row gate/up output
+// routing is unchanged. Byte-exact vs the 1-acc kernel (independent acc
+// chains, same FP accumulation order per chain).
+//
+// Grid: [ceil((gate_m + up_m)/16), ceil(N/(16*B))]. Block: [32]. LDS: 0.
+// Derived from gemm_gate_up_hfq4g256_wmma.hip (Apache-2.0) with the
+// batch-tile structure of gemm_qkvza_hfq4g256_wmma_gfx12_bt.hip.
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+#define DQ16(pk0, pk1, sc, zp) \
+    a[0]=sc*(_Float16)(float)(((pk0)>>0)&0xFu)+zp;  a[1]=sc*(_Float16)(float)(((pk0)>>4)&0xFu)+zp; \
+    a[2]=sc*(_Float16)(float)(((pk0)>>8)&0xFu)+zp;  a[3]=sc*(_Float16)(float)(((pk0)>>12)&0xFu)+zp; \
+    a[4]=sc*(_Float16)(float)(((pk0)>>16)&0xFu)+zp; a[5]=sc*(_Float16)(float)(((pk0)>>20)&0xFu)+zp; \
+    a[6]=sc*(_Float16)(float)(((pk0)>>24)&0xFu)+zp; a[7]=sc*(_Float16)(float)(((pk0)>>28)&0xFu)+zp; \
+    a[8]=sc*(_Float16)(float)(((pk1)>>0)&0xFu)+zp;  a[9]=sc*(_Float16)(float)(((pk1)>>4)&0xFu)+zp; \
+    a[10]=sc*(_Float16)(float)(((pk1)>>8)&0xFu)+zp; a[11]=sc*(_Float16)(float)(((pk1)>>12)&0xFu)+zp; \
+    a[12]=sc*(_Float16)(float)(((pk1)>>16)&0xFu)+zp;a[13]=sc*(_Float16)(float)(((pk1)>>20)&0xFu)+zp; \
+    a[14]=sc*(_Float16)(float)(((pk1)>>24)&0xFu)+zp;a[15]=sc*(_Float16)(float)(((pk1)>>28)&0xFu)+zp
+
+#define GEN_GATE_UP_BT(BV) \
+extern "C" __launch_bounds__(32, 2) __global__ void gemm_gate_up_hfq4g256_wmma_bt##BV( \
+    const char*    __restrict__ A_gate, \
+    const char*    __restrict__ A_up, \
+    const _Float16* __restrict__ X, \
+    float*         __restrict__ Y_gate, \
+    float*         __restrict__ Y_up, \
+    int gate_m, int up_m, int K, int N) { \
+    const int total_m = gate_m + up_m; \
+    const int row_start = blockIdx.x * 16; \
+    const int batch_start = blockIdx.y * (16 * BV); \
+    const int tid = threadIdx.x; \
+    if (row_start >= total_m || batch_start >= N) return; \
+    const int my_row = row_start + (tid & 15); \
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1); \
+    const char* A; int local_row; \
+    if (safe_row < gate_m) { A = A_gate; local_row = safe_row; } \
+    else { A = A_up; local_row = safe_row - gate_m; } \
+    const int groups_per_row = K / 256; \
+    const long long row_stride = (long long)groups_per_row * 136; \
+    const char* row_base = A + local_row * row_stride; \
+    int sb[BV]; \
+    for (int b = 0; b < BV; b++) { \
+        int t = batch_start + b * 16 + (tid & 15); \
+        sb[b] = (t < N) ? t : 0; \
+    } \
+    float8_t acc[BV]; \
+    for (int b = 0; b < BV; b++) \
+        acc[b] = (float8_t){0,0,0,0,0,0,0,0}; \
+    for (int g = 0; g < groups_per_row; g++) { \
+        const char* gp = row_base + g * 136; \
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp)); \
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4)); \
+        const _Float16* xg[BV]; \
+        for (int b = 0; b < BV; b++) \
+            xg[b] = X + (long long)sb[b] * K + g * 256; \
+        for (int kt = 0; kt < 16; kt += 4) { \
+            half16_t b0[BV], b1[BV]; \
+            for (int b = 0; b < BV; b++) { \
+                b0[b] = *(const half16_t*)(xg[b] + kt * 16); \
+                b1[b] = *(const half16_t*)(xg[b] + (kt + 1) * 16); \
+            } \
+            { unsigned int pk0 = *(const unsigned int*)(gp + 8 + kt * 8); \
+              unsigned int pk1 = *(const unsigned int*)(gp + 8 + kt * 8 + 4); \
+              half16_t a; DQ16(pk0, pk1, sc_h, zp_h); \
+              for (int b = 0; b < BV; b++) \
+                  acc[b] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b0[b], acc[b]); } \
+            half16_t b2[BV]; \
+            for (int b = 0; b < BV; b++) \
+                b2[b] = *(const half16_t*)(xg[b] + (kt + 2) * 16); \
+            { unsigned int pk0 = *(const unsigned int*)(gp + 8 + (kt + 1) * 8); \
+              unsigned int pk1 = *(const unsigned int*)(gp + 8 + (kt + 1) * 8 + 4); \
+              half16_t a; DQ16(pk0, pk1, sc_h, zp_h); \
+              for (int b = 0; b < BV; b++) \
+                  acc[b] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b1[b], acc[b]); } \
+            half16_t b3[BV]; \
+            for (int b = 0; b < BV; b++) \
+                b3[b] = *(const half16_t*)(xg[b] + (kt + 3) * 16); \
+            { unsigned int pk0 = *(const unsigned int*)(gp + 8 + (kt + 2) * 8); \
+              unsigned int pk1 = *(const unsigned int*)(gp + 8 + (kt + 2) * 8 + 4); \
+              half16_t a; DQ16(pk0, pk1, sc_h, zp_h); \
+              for (int b = 0; b < BV; b++) \
+                  acc[b] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b2[b], acc[b]); } \
+            { unsigned int pk0 = *(const unsigned int*)(gp + 8 + (kt + 3) * 8); \
+              unsigned int pk1 = *(const unsigned int*)(gp + 8 + (kt + 3) * 8 + 4); \
+              half16_t a; DQ16(pk0, pk1, sc_h, zp_h); \
+              for (int b = 0; b < BV; b++) \
+                  acc[b] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b3[b], acc[b]); } \
+        } \
+    } \
+    for (int b = 0; b < BV; b++) { \
+        const int out_col = batch_start + b * 16 + (tid & 15); \
+        if (out_col < N) { \
+            _Pragma("unroll") \
+            for (int j = 0; j < 8; j++) { \
+                int out_row = row_start + 2 * j + (tid >> 4); \
+                if (out_row < total_m) { \
+                    float* Y; int proj_row; int out_stride; \
+                    if (out_row < gate_m) { \
+                        Y = Y_gate; proj_row = out_row; out_stride = gate_m; \
+                    } else { \
+                        Y = Y_up; proj_row = out_row - gate_m; out_stride = up_m; \
+                    } \
+                    Y[(long long)out_col * out_stride + proj_row] = acc[b][j]; \
+                } \
+            } \
+        } \
+    } \
+}
+
+GEN_GATE_UP_BT(2)
+GEN_GATE_UP_BT(4)
+
+#undef DQ16
+#undef GEN_GATE_UP_BT

--- a/kernels/src/gemm_hfq4g256_residual_wmma_ksplit_det_bt2.hip
+++ b/kernels/src/gemm_hfq4g256_residual_wmma_ksplit_det_bt2.hip
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// Batch-tiled B=2 variant of the deterministic K-split residual GEMM.
+// 2 independent acc chains reuse weight loads across 2 batch (N) tiles
+// per block, halving the N-grid. Weights+dequant loaded once per K-tile,
+// reused across both N-tiles. Each chain writes its own partials.
+//
+// Grid: [ceil(M/16), ceil(N/32), K_SPLITS]. Block: [32]. LDS: 0.
+// K_SPLITS MUST match gemm_ksplit_det_finalize.hip.
+//
+// Derived from gemm_hfq4g256_residual_wmma_ksplit_det.hip (Apache-2.0).
+
+#define K_SPLITS 4
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+__launch_bounds__(32, 2)
+extern "C" __global__ void gemm_hfq4g256_residual_wmma_ksplit_det_bt2(
+    const char* __restrict__ A,
+    const _Float16* __restrict__ X,
+    float* __restrict__ partials,
+    int M, int K, int batch_size
+) {
+    const int tid = threadIdx.x;
+    const int row_start = blockIdx.x * 16;
+    const int batch_start = blockIdx.y * 32;
+    const int ksplit = blockIdx.z;
+
+    if (row_start >= M || batch_start >= batch_size) return;
+
+    const int safe_row = (row_start + (tid & 15) < M) ? (row_start + (tid & 15)) : (M - 1);
+
+    const int groups_per_row = K / 256;
+    const int groups_per_split = groups_per_row / K_SPLITS;
+    const int g_start = ksplit * groups_per_split;
+    const int g_end   = (ksplit == K_SPLITS - 1) ? groups_per_row
+                                                 : g_start + groups_per_split;
+
+    const char* row_base = A + (long long)safe_row * groups_per_row * 136;
+
+    // Two batch indices
+    int sb0 = batch_start + (tid & 15);
+    int sb1 = batch_start + 16 + (tid & 15);
+    if (sb0 >= batch_size) sb0 = 0;
+    if (sb1 >= batch_size) sb1 = 0;
+
+    const _Float16* xg0_base = X + (long long)sb0 * K;
+    const _Float16* xg1_base = X + (long long)sb1 * K;
+
+    float8_t acc0 = {0, 0, 0, 0, 0, 0, 0, 0};
+    float8_t acc1 = {0, 0, 0, 0, 0, 0, 0, 0};
+
+    for (int g = g_start; g < g_end; g++) {
+        const char* gp = row_base + g * 136;
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp));
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4));
+        const _Float16* xg0 = xg0_base + g * 256;
+        const _Float16* xg1 = xg1_base + g * 256;
+
+        for (int kt = 0; kt < 16; kt += 2) {
+            const int k_off_a = kt * 16;
+            unsigned int pk0a = *(const unsigned int*)(gp + 8 + k_off_a / 2);
+            unsigned int pk1a = *(const unsigned int*)(gp + 8 + k_off_a / 2 + 4);
+
+            const int k_off_b = (kt + 1) * 16;
+            unsigned int pk0b = *(const unsigned int*)(gp + 8 + k_off_b / 2);
+            unsigned int pk1b = *(const unsigned int*)(gp + 8 + k_off_b / 2 + 4);
+
+            half16_t b0_a = *(const half16_t*)(xg0 + k_off_a);
+            half16_t b0_b = *(const half16_t*)(xg0 + k_off_b);
+            half16_t b1_a = *(const half16_t*)(xg1 + k_off_a);
+            half16_t b1_b = *(const half16_t*)(xg1 + k_off_b);
+
+            half16_t a_a;
+            #define DQ(reg, i, pk, sh) reg[i] = sc_h * (_Float16)(float)(((pk) >> (sh)) & 0xFu) + zp_h
+            DQ(a_a, 0,  pk0a,  0); DQ(a_a, 1,  pk0a,  4); DQ(a_a, 2,  pk0a,  8); DQ(a_a, 3,  pk0a, 12);
+            DQ(a_a, 4,  pk0a, 16); DQ(a_a, 5,  pk0a, 20); DQ(a_a, 6,  pk0a, 24); DQ(a_a, 7,  pk0a, 28);
+            DQ(a_a, 8,  pk1a,  0); DQ(a_a, 9,  pk1a,  4); DQ(a_a, 10, pk1a,  8); DQ(a_a, 11, pk1a, 12);
+            DQ(a_a, 12, pk1a, 16); DQ(a_a, 13, pk1a, 20); DQ(a_a, 14, pk1a, 24); DQ(a_a, 15, pk1a, 28);
+
+            acc0 = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_a, b0_a, acc0);
+            acc1 = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_a, b1_a, acc1);
+
+            DQ(a_a, 0,  pk0b,  0); DQ(a_a, 1,  pk0b,  4); DQ(a_a, 2,  pk0b,  8); DQ(a_a, 3,  pk0b, 12);
+            DQ(a_a, 4,  pk0b, 16); DQ(a_a, 5,  pk0b, 20); DQ(a_a, 6,  pk0b, 24); DQ(a_a, 7,  pk0b, 28);
+            DQ(a_a, 8,  pk1b,  0); DQ(a_a, 9,  pk1b,  4); DQ(a_a, 10, pk1b,  8); DQ(a_a, 11, pk1b, 12);
+            DQ(a_a, 12, pk1b, 16); DQ(a_a, 13, pk1b, 20); DQ(a_a, 14, pk1b, 24); DQ(a_a, 15, pk1b, 28);
+            #undef DQ
+
+            acc0 = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_a, b0_b, acc0);
+            acc1 = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a_a, b1_b, acc1);
+        }
+    }
+
+    // Write partials for both batch tiles
+    const long long split_base = (long long)ksplit * batch_size * M;
+    const int out_col0 = batch_start + (tid & 15);
+    const int out_col1 = batch_start + 16 + (tid & 15);
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        int out_row = row_start + 2 * j + (tid >> 4);
+        if (out_row < M) {
+            if (out_col0 < batch_size)
+                partials[split_base + (long long)out_col0 * M + out_row] = acc0[j];
+            if (out_col1 < batch_size)
+                partials[split_base + (long long)out_col1 * M + out_row] = acc1[j];
+        }
+    }
+}

--- a/kernels/src/gemm_qkvza_hfq4g256_wmma_bt.hip
+++ b/kernels/src/gemm_qkvza_hfq4g256_wmma_bt.hip
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kaden Schutt
+// hipfire — see LICENSE and NOTICE in the project root.
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+
+// Batch-tiled gfx11 HFQ4-G256 4-way fused QKVZA GEMM (Qwen3.5 DeltaNet
+// q/k/v/z/beta/alpha projections). B independent acc chains over the
+// batch (N) dim hide WMMA latency and reuse weight loads across B
+// N-tiles. Weights+dequant loaded once per K-tile, reused across the B
+// N-tiles. The per-row qkv/z/beta/alpha output routing is unchanged.
+// Byte-exact vs the 1-acc kernel (independent acc chains, same FP
+// accumulation order per chain).
+//
+// Grid: [ceil(total_m/16), ceil(N/(16*B))]. Block: [32]. LDS: 0.
+// Derived from gemm_qkvza_hfq4g256_wmma.hip (Apache-2.0) with the
+// batch-tile structure of gemm_qkvza_hfq4g256_wmma_gfx12_bt.hip.
+
+typedef _Float16 __attribute__((ext_vector_type(16))) half16_t;
+typedef float    __attribute__((ext_vector_type(8))) float8_t;
+
+#define DQ16(pk0, pk1, sc, zp) \
+    a[0]=sc*(_Float16)(float)(((pk0)>>0)&0xFu)+zp;  a[1]=sc*(_Float16)(float)(((pk0)>>4)&0xFu)+zp; \
+    a[2]=sc*(_Float16)(float)(((pk0)>>8)&0xFu)+zp;  a[3]=sc*(_Float16)(float)(((pk0)>>12)&0xFu)+zp; \
+    a[4]=sc*(_Float16)(float)(((pk0)>>16)&0xFu)+zp; a[5]=sc*(_Float16)(float)(((pk0)>>20)&0xFu)+zp; \
+    a[6]=sc*(_Float16)(float)(((pk0)>>24)&0xFu)+zp; a[7]=sc*(_Float16)(float)(((pk0)>>28)&0xFu)+zp; \
+    a[8]=sc*(_Float16)(float)(((pk1)>>0)&0xFu)+zp;  a[9]=sc*(_Float16)(float)(((pk1)>>4)&0xFu)+zp; \
+    a[10]=sc*(_Float16)(float)(((pk1)>>8)&0xFu)+zp; a[11]=sc*(_Float16)(float)(((pk1)>>12)&0xFu)+zp; \
+    a[12]=sc*(_Float16)(float)(((pk1)>>16)&0xFu)+zp;a[13]=sc*(_Float16)(float)(((pk1)>>20)&0xFu)+zp; \
+    a[14]=sc*(_Float16)(float)(((pk1)>>24)&0xFu)+zp;a[15]=sc*(_Float16)(float)(((pk1)>>28)&0xFu)+zp
+
+#define GEN_QKVZA_BT(BV) \
+extern "C" __launch_bounds__(32, 2) __global__ void gemm_qkvza_hfq4g256_wmma_bt##BV( \
+    const char*    __restrict__ A_qkv, \
+    const char*    __restrict__ A_z, \
+    const char*    __restrict__ A_beta, \
+    const char*    __restrict__ A_alpha, \
+    const _Float16* __restrict__ X, \
+    float*         __restrict__ Y_qkv, \
+    float*         __restrict__ Y_z, \
+    float*         __restrict__ Y_beta, \
+    float*         __restrict__ Y_alpha, \
+    int qkv_m, int z_m, int beta_m, int alpha_m, \
+    int K, int N) { \
+    const int total_m = qkv_m + z_m + beta_m + alpha_m; \
+    const int row_start = blockIdx.x * 16; \
+    const int batch_start = blockIdx.y * (16 * BV); \
+    const int tid = threadIdx.x; \
+    if (row_start >= total_m || batch_start >= N) return; \
+    const int my_row = row_start + (tid & 15); \
+    const int safe_row = (my_row < total_m) ? my_row : (total_m - 1); \
+    const char* A; int local_row; \
+    if (safe_row < qkv_m) { A = A_qkv; local_row = safe_row; } \
+    else if (safe_row < qkv_m + z_m) { A = A_z; local_row = safe_row - qkv_m; } \
+    else if (safe_row < qkv_m + z_m + beta_m) { A = A_beta; local_row = safe_row - (qkv_m + z_m); } \
+    else { A = A_alpha; local_row = safe_row - (qkv_m + z_m + beta_m); } \
+    const int groups_per_row = K / 256; \
+    const long long row_stride = (long long)groups_per_row * 136; \
+    const char* row_base = A + local_row * row_stride; \
+    int sb[BV]; \
+    for (int b = 0; b < BV; b++) { \
+        int t = batch_start + b * 16 + (tid & 15); \
+        sb[b] = (t < N) ? t : 0; \
+    } \
+    float8_t acc[BV]; \
+    for (int b = 0; b < BV; b++) \
+        acc[b] = (float8_t){0,0,0,0,0,0,0,0}; \
+    for (int g = 0; g < groups_per_row; g++) { \
+        const char* gp = row_base + g * 136; \
+        _Float16 sc_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp)); \
+        _Float16 zp_h = (_Float16)__builtin_bit_cast(float, *(const unsigned int*)(gp + 4)); \
+        const _Float16* xg[BV]; \
+        for (int b = 0; b < BV; b++) \
+            xg[b] = X + (long long)sb[b] * K + g * 256; \
+        for (int kt = 0; kt < 16; kt += 2) { \
+            const int k_off_a = kt * 16; \
+            const int k_off_b = (kt + 1) * 16; \
+            unsigned int pk0a = *(const unsigned int*)(gp + 8 + k_off_a / 2); \
+            unsigned int pk1a = *(const unsigned int*)(gp + 8 + k_off_a / 2 + 4); \
+            unsigned int pk0b = *(const unsigned int*)(gp + 8 + k_off_b / 2); \
+            unsigned int pk1b = *(const unsigned int*)(gp + 8 + k_off_b / 2 + 4); \
+            half16_t b_a[BV], b_b[BV]; \
+            for (int b = 0; b < BV; b++) { \
+                b_a[b] = *(const half16_t*)(xg[b] + k_off_a); \
+                b_b[b] = *(const half16_t*)(xg[b] + k_off_b); \
+            } \
+            { half16_t a; DQ16(pk0a, pk1a, sc_h, zp_h); \
+              for (int b = 0; b < BV; b++) \
+                  acc[b] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b_a[b], acc[b]); } \
+            { half16_t a; DQ16(pk0b, pk1b, sc_h, zp_h); \
+              for (int b = 0; b < BV; b++) \
+                  acc[b] = __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(a, b_b[b], acc[b]); } \
+        } \
+    } \
+    for (int b = 0; b < BV; b++) { \
+        const int out_col = batch_start + b * 16 + (tid & 15); \
+        if (out_col < N) { \
+            _Pragma("unroll") \
+            for (int j = 0; j < 8; j++) { \
+                int out_row = row_start + 2 * j + (tid >> 4); \
+                if (out_row < total_m) { \
+                    float* Y; int proj_row; int out_stride; \
+                    if (out_row < qkv_m) { \
+                        Y = Y_qkv; proj_row = out_row; out_stride = qkv_m; \
+                    } else if (out_row < qkv_m + z_m) { \
+                        Y = Y_z; proj_row = out_row - qkv_m; out_stride = z_m; \
+                    } else if (out_row < qkv_m + z_m + beta_m) { \
+                        Y = Y_beta; proj_row = out_row - (qkv_m + z_m); out_stride = beta_m; \
+                    } else { \
+                        Y = Y_alpha; proj_row = out_row - (qkv_m + z_m + beta_m); out_stride = alpha_m; \
+                    } \
+                    Y[(long long)out_col * out_stride + proj_row] = acc[b][j]; \
+                } \
+            } \
+        } \
+    } \
+}
+
+GEN_QKVZA_BT(2)
+
+#undef DQ16
+#undef GEN_QKVZA_BT

--- a/scripts/bench_model_load.py
+++ b/scripts/bench_model_load.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Model-load wall-clock benchmark: hipfire daemon vs llama.cpp (ROCmFPX).
+
+Measures one thing per engine and reports medians of identical windows:
+
+  hipfire : daemon process spawn → {"type":"loaded"} protocol response.
+            Includes process init + GPU context + full weight upload.
+  rocmfpx : process spawn → engine-reported `load time` (print_timings),
+            cross-checked with wall-clock to end-of-load log line.
+
+GPU access MUST be serialized externally through /home/ghazni/gpu-coord/
+(e.g. gpu-ctl run ... -- python3 scripts/bench_model_load.py ...).
+This script never touches the lock itself so the caller owns acquisition.
+
+Usage:
+  python3 scripts/bench_model_load.py hipfire  --model M.hfq --runs 5 [--daemon PATH]
+  python3 scripts/bench_model_load.py rocmfpx --model M.gguf --llama-bin DIR --runs 5
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import subprocess
+import sys
+import threading
+import time
+
+
+def median(xs):
+    return statistics.median(xs)
+
+
+def spread_pct(xs):
+    if len(xs) < 2:
+        return 0.0
+    m = median(xs)
+    return (max(xs) - min(xs)) / m * 100.0
+
+
+def bench_hipfire(model: str, daemon_bin: str, runs: int) -> list[float]:
+    results = []
+    for i in range(runs):
+        t0 = time.perf_counter()
+        proc = subprocess.Popen(
+            [daemon_bin],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        try:
+            proc.stdin.write(
+                json.dumps({"type": "load", "model": model, "params": {"max_seq": 4096}})
+                + "\n"
+            )
+            proc.stdin.flush()
+            loaded = False
+            while not loaded:
+                line = proc.stdout.readline()
+                if not line:
+                    raise RuntimeError(f"run {i}: daemon closed stdout before 'loaded'")
+                msg = line.strip()
+                if not msg:
+                    continue
+                try:
+                    obj = json.loads(msg)
+                except json.JSONDecodeError:
+                    continue  # non-protocol log noise
+                if obj.get("type") == "loaded":
+                    loaded = True
+                    dt = time.perf_counter() - t0
+                    results.append(dt)
+                    print(f"  run {i+1}/{runs}: {dt*1000:.1f} ms  arch={obj.get('arch')}")
+                elif obj.get("type") == "error":
+                    raise RuntimeError(f"run {i}: daemon error: {msg[:400]}")
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=5)
+        time.sleep(0.3)  # let the pid-file flock release before next spawn
+    return results
+
+
+
+
+READY_MARKER_RE = re.compile(r"main: llama threadpool init")
+
+
+def bench_rocmfpx(model: str, llama_bin_dir: str, runs: int) -> list[float]:
+    """Wall-clock process spawn → end-of-model-load marker.
+
+    The fork suppresses per-tensor load logs and its engine-reported
+    `load time` is clobbered by llama_perf_context_reset, so the reliable
+    ready marker is the first log line emitted after common_init_result
+    returns (`main: llama threadpool init`). The process is killed as soon
+    as the marker fires, so the window excludes prompt eval / generation.
+    """
+    results = []
+    bin_path = f"{llama_bin_dir}/llama-completion"
+    for i in range(runs):
+        t0 = time.perf_counter()
+        proc = subprocess.Popen(
+            [
+                bin_path,
+                "-m",
+                model,
+                "-ngl",
+                "99",
+                "-p",
+                "hi",
+                "-n",
+                "1",
+                "-t",
+                "16",
+                "--no-warmup",
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            env={**dict(__import__("os").environ), "LD_LIBRARY_PATH": llama_bin_dir},
+        )
+        ready = None
+        assert proc.stderr is not None
+
+        def pump():
+            nonlocal ready
+            for line in proc.stderr:
+                if READY_MARKER_RE.search(line):
+                    ready = time.perf_counter() - t0
+                    return  # stop consuming; caller terminates the process
+
+        reader = threading.Thread(target=pump, daemon=True)
+        reader.start()
+        # pump() returns on the marker or at stderr EOF (process exit).
+        reader.join(timeout=600)
+        proc.kill()
+        proc.wait(timeout=10)
+        reader.join(timeout=5)
+        if ready is None:
+            raise RuntimeError(f"run {i}: ready marker never seen")
+        results.append(ready)
+        print(f"  run {i+1}/{runs}: {ready*1000:.1f} ms")
+    return results
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("engine", choices=["hipfire", "rocmfpx"])
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--runs", type=int, default=5)
+    ap.add_argument("--daemon", default="target/release/daemon")
+    ap.add_argument("--llama-bin", default="/home/ghazni/projects/ROCmFPX/build-opt/bin")
+    args = ap.parse_args()
+
+    print(f"== {args.engine} load benchmark: {args.runs} fresh-process runs ==")
+    if args.engine == "hipfire":
+        res = bench_hipfire(args.model, args.daemon, args.runs)
+    else:
+        res = bench_rocmfpx(args.model, args.llama_bin, args.runs)
+
+    print(f"MEDIAN_LOAD_S {median(res):.3f}")
+    print(f"SPREAD_PCT {spread_pct(res):.2f}")
+    print(f"SAMPLES_S {[round(x, 3) for x in res]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

<one or two sentences>

## Which crate(s) does this touch?

- [ ] `kernels/` (HIP source)
- [ ] `crates/rdna-compute` (kernel dispatch / RDNA arch routing)
- [ ] `crates/hip-bridge` (HIP/ROCm FFI)
- [ ] `crates/hipfire-runtime` (LM runtime: KV, sampler, guards, framing, paging, spec decode)
- [ ] `crates/hipfire-arch-qwen35`
- [ ] `crates/hipfire-arch-qwen35-vl`
- [ ] `crates/hipfire-arch-llama`
- [ ] `crates/hipfire-arch-toy` (template — touch only when refining the new-arch reference)
- [ ] `crates/hipfire-quantize`
- [ ] examples / daemon
- [ ] docs / CI / scripts

## Test plan

- [ ] `./scripts/no-gpu-ci.sh` passes, or equivalent CI job is green
- [ ] `cargo build --release --workspace --features deltanet` clean
- [ ] `cargo test --lib --workspace --features deltanet` passes
- [ ] **Change gate run and telemetry pasted below.** `python3 -m tools.change_gate plan --base beta`
      shows what your diff actually owes and what it costs; `run --md gate.md` executes it and emits the
      report. The gate selects routes from the diff, so an unrelated change does not owe a model battery.
- [ ] If perf-relevant: `./scripts/speed-gate.sh` within ±2% of locked baselines
- [ ] Any route reported `blocked` (absent model, wrong arch) is **acknowledged below**, not ignored —
      a blocked route makes the gate verdict `incomplete`, which is not a pass.

<details><summary>change_gate telemetry</summary>

```
paste `python3 -m tools.change_gate run --base beta --md -` output here
```

</details>

Route selection is defined in [`tools/change_gate/routes.py`](../tools/change_gate/routes.py) and route
policy in [`docs/VALIDATION.md`](../docs/VALIDATION.md). The retired `scripts/coherence-gate*.sh`
batteries are **not** acceptance evidence and no longer exist in-tree. Adding coverage means adding a
`Route` + `Rule` there, not resurrecting a fixed battery.

## Architecture-trait change?

If this PR changes the `Architecture` trait surface in
`crates/hipfire-runtime/src/arch.rs`, note here. Trait changes ripple
to every arch crate.
