### PR TITLE
Multi-slot VL support; quantizer F16-fallback fix; slot engine VRAM + context-cap fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,9 +922,11 @@ name = "hipfire-cli"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "ctrlc",
  "hipfire-arch-qwen35",
+ "hipfire-arch-qwen35-vl",
  "hipfire-client",
  "hipfire-config",
  "hipfire-registry",

--- a/crates/hipfire-arch-qwen35/src/forward_slots.rs
+++ b/crates/hipfire-arch-qwen35/src/forward_slots.rs
@@ -1437,6 +1437,7 @@ fn run_fullattn_layer_slots(
     max_ctx_len: usize,
     single_slot: Option<(u64, usize)>,
     n_tiles: Option<usize>,
+    mrope_pos3: Option<&GpuTensor>,
 ) -> HipResult<()> {
     let attn_dtype = require_batchable_fullattn_layer(layer)?;
 
@@ -1569,18 +1570,36 @@ fn run_fullattn_layer_slots(
     // global-row-indexed. No compaction in the slot path yet, so
     // pos_offset is always 0.
     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
-    gpu.rope_partial_interleaved_f32_batched(
-        &pbs.fa_q_batch,
-        &pbs.fa_k_batch,
-        &pbs.positions,
-        config.n_heads,
-        config.n_kv_heads,
-        config.head_dim,
-        n_rot,
-        config.rope_theta,
-        n,
-        0,
-    )?;
+    if let Some(pos3) = mrope_pos3 {
+        // VL prefill: 3D mrope with per-row (t, h, w). Batched twin of the
+        // sequential path's rope_mrope_halfsplit_f32.
+        gpu.rope_mrope_halfsplit_f32_batched(
+            &pbs.fa_q_batch,
+            &pbs.fa_k_batch,
+            &pos3.buf,
+            config.n_heads,
+            config.n_kv_heads,
+            config.head_dim,
+            n_rot,
+            config.rope_theta,
+            n,
+            0,
+            config.mrope_section,
+        )?;
+    } else {
+        gpu.rope_partial_interleaved_f32_batched(
+            &pbs.fa_q_batch,
+            &pbs.fa_k_batch,
+            &pbs.positions,
+            config.n_heads,
+            config.n_kv_heads,
+            config.head_dim,
+            n_rot,
+            config.rope_theta,
+            n,
+            0,
+        )?;
+    }
 
     // 6. Batched KV write — slot-aware, one launch each for K and V across
     // every slot. Both arenas resolve through `k_base`/`v_base`; correct
@@ -1727,6 +1746,7 @@ fn run_fullattn_moe_layer_slots(
     single_slot: Option<(u64, usize)>,
     n_tiles: Option<usize>,
     weights_moe_has_mq6: bool,
+    mrope_pos3: Option<&GpuTensor>,
 ) -> HipResult<()> {
     let attn_dtype = require_batchable_fullattn_moe_layer(layer)?;
     require_batchable_moe_ffn(gpu, &layer.ffn)?;
@@ -1859,18 +1879,36 @@ fn run_fullattn_moe_layer_slots(
 
     // 5. RoPE — slot-agnostic (SP2 Task 2).
     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
-    gpu.rope_partial_interleaved_f32_batched(
-        &pbs.fa_q_batch,
-        &pbs.fa_k_batch,
-        &pbs.positions,
-        config.n_heads,
-        config.n_kv_heads,
-        config.head_dim,
-        n_rot,
-        config.rope_theta,
-        n,
-        0,
-    )?;
+    if let Some(pos3) = mrope_pos3 {
+        // VL prefill: 3D mrope with per-row (t, h, w). Batched twin of the
+        // sequential path's rope_mrope_halfsplit_f32.
+        gpu.rope_mrope_halfsplit_f32_batched(
+            &pbs.fa_q_batch,
+            &pbs.fa_k_batch,
+            &pos3.buf,
+            config.n_heads,
+            config.n_kv_heads,
+            config.head_dim,
+            n_rot,
+            config.rope_theta,
+            n,
+            0,
+            config.mrope_section,
+        )?;
+    } else {
+        gpu.rope_partial_interleaved_f32_batched(
+            &pbs.fa_q_batch,
+            &pbs.fa_k_batch,
+            &pbs.positions,
+            config.n_heads,
+            config.n_kv_heads,
+            config.head_dim,
+            n_rot,
+            config.rope_theta,
+            n,
+            0,
+        )?;
+    }
 
     // 6. Batched KV write — slot-aware, Q8_0 KV-cache tier regardless of
     // this layer's projection weight dtype (see module doc).
@@ -2329,9 +2367,12 @@ pub fn forward_batch_slots_graphed(
     s: &Qwen35Scratch,
     logits_out: &GpuTensor,
     cache: &mut SlotDecodeGraph,
+    vl_active: bool,
 ) -> HipResult<()> {
     let pure_decode = !batch.is_empty() && batch.m_per_slot.iter().all(|&m| m == 1);
-    if !gpu.slots_decode_graph() || !pure_decode {
+    // VL prefill carries embedding overrides + mrope positions, which the
+    // captured-graph path cannot represent — always take the plain path.
+    if !gpu.slots_decode_graph() || !pure_decode || vl_active {
         return forward_batch_slots(
             gpu,
             weights,
@@ -2393,6 +2434,8 @@ pub fn forward_batch_slots_graphed(
             SlotStepOpts {
                 skip_uploads: true,
                 ctx_override: Some(ctx_bucket),
+                embed_override: None,
+                mrope_pos3: None,
             },
         )?;
         // The warm-up step above already advanced the slot lengths; re-running
@@ -2418,6 +2461,8 @@ pub fn forward_batch_slots_graphed(
             SlotStepOpts {
                 skip_uploads: true,
                 ctx_override: Some(ctx_bucket),
+                embed_override: None,
+                mrope_pos3: None,
             },
         );
         let graph = gpu.end_stream_capture()?;
@@ -2466,7 +2511,7 @@ fn rewind_slot_seq_lens(batch: &SlotBatch, pool: &mut SlotPool) -> HipResult<()>
 }
 
 /// Knobs the graph path needs and no other caller does.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Default)]
 pub struct SlotStepOpts {
     /// The per-step H2D uploads (tokens, positions, row_slot, descriptors)
     /// were already done by the caller. Set when capturing into a hipGraph:
@@ -2481,6 +2526,15 @@ pub struct SlotStepOpts {
     /// `positions[]` is the authoritative causal bound (SP1's Critical
     /// defect), so the extra positions are masked out.
     pub ctx_override: Option<usize>,
+    /// VL prefill: visual embeddings to write over `x_batch` rows after the
+    /// token-embedding lookup. Host layout `[count × dim]`, written to rows
+    /// `row0..row0+count` of this step. Rows outside the span keep their
+    /// token embeddings.
+    pub embed_override: Option<(Vec<f32>, usize)>,
+    /// VL prefill: packed 3D mrope positions `[n_rows][3]` i32 for this
+    /// step's rows. When set, FA RoPE dispatches to the batched mrope kernel
+    /// instead of the 1D one; DeltaNet layers ignore rope entirely.
+    pub mrope_pos3: Option<Vec<i32>>,
 }
 
 /// The per-step H2D uploads, hoisted so the graph path can run them outside
@@ -2651,6 +2705,19 @@ pub fn forward_batch_slots_opts(
     }
     gpu.embedding_lookup_q8_batched(&weights.token_embd, &pbs.x_batch, &pbs.tokens, n, dim)?;
 
+    // ── 1b. VL embedding override ─────────────────────────────────────────
+    // Overwrite the image-pad rows with vision-tower embeddings before any
+    // layer sees them. Rows outside the span keep their token embeddings.
+    if let Some((embs, row0)) = &opts.embed_override {
+        eprintln!("[vl-slot] embedding override: row0={row0} elems={} sum={:.4}", embs.len(), embs.iter().sum::<f32>());
+        let dim_bytes = dim * 4;
+        gpu.hip.memcpy_htod_offset(
+            &pbs.x_batch.buf,
+            row0 * dim_bytes,
+            unsafe { std::slice::from_raw_parts(embs.as_ptr() as *const u8, embs.len() * 4) },
+        )?;
+    }
+
     // ── 2. Upload positions ──────────────────────────────────────────────
     // Per-row ABSOLUTE position within that row's own slot — authoritative
     // for the causal bound everywhere downstream (RoPE angle, KV write
@@ -2774,6 +2841,20 @@ pub fn forward_batch_slots_opts(
         None
     };
 
+    // ── 3b. VL mrope pos3 upload (layer-invariant, once per step) ────────
+    let mrope_pos3_dev = match &opts.mrope_pos3 {
+        Some(host) => {
+            let t = gpu.alloc_tensor(
+                &[host.len()],
+                DType::F32, // i32-in-f32 pattern used by `positions`
+            )?;
+            let bytes: Vec<u8> = host.iter().flat_map(|x| x.to_ne_bytes()).collect();
+            gpu.hip.memcpy_htod(&t.buf, &bytes)?;
+            Some(t)
+        }
+        None => None,
+    };
+
     // ── 4. Per-layer loop ─────────────────────────────────────────────────
     let layer_end = config.n_layers.min(max_layer.unwrap_or(usize::MAX));
     let mut delta_layer_idx = 0usize;
@@ -2810,6 +2891,7 @@ pub fn forward_batch_slots_opts(
                     max_ctx_len,
                     single_slot,
                     n_tiles,
+                    mrope_pos3_dev.as_ref(),
                 )?;
                 kv_layer_idx += 1;
             }
@@ -2845,6 +2927,7 @@ pub fn forward_batch_slots_opts(
                     single_slot,
                     n_tiles,
                     weights.moe_has_mq6,
+                    mrope_pos3_dev.as_ref(),
                 )?;
                 kv_layer_idx += 1;
             }

--- a/crates/hipfire-arch-qwen35/src/scheduler.rs
+++ b/crates/hipfire-arch-qwen35/src/scheduler.rs
@@ -31,6 +31,23 @@ pub struct PendingWork {
     pub next_pos: usize,
     /// Once prefill is complete, the slot decodes one token per step.
     pub decoding: bool,
+    /// VL prefill state for this slot. `embeds` are the vision-tower outputs
+    /// `[n_vis x dim]`; `span_start` is the index within this slot's prompt
+    /// where the image-pad run begins; `pos3` is the full prompt's 3D mrope
+    /// positions (flat, `[n_tokens][3]`).
+    pub vl: Option<VlPrefill>,
+}
+
+/// Visual-embedding injection state for one slot's prefill (VL requests).
+#[derive(Default)]
+pub struct VlPrefill {
+    pub embeds: Vec<f32>,
+    pub span_start: usize,
+    pub span_len: usize,
+    /// Absolute start position of the prompt in the slot's KV (continuations).
+    pub pos_base: usize,
+    /// Packed 3D mrope positions for the WHOLE prompt, `[n][3]` i32.
+    pub pos3: Vec<i32>,
 }
 
 impl Scheduler {
@@ -48,6 +65,7 @@ impl Scheduler {
             };
             let toks: Vec<u32> = w.remaining_prompt.drain(..take).collect();
             let start_pos = w.next_pos;
+            let row0 = b.tokens.len();
             b.m_per_slot.push(toks.len());
             for (i, t) in toks.iter().enumerate() {
                 b.tokens.push(*t);
@@ -55,6 +73,25 @@ impl Scheduler {
                 b.row_slot.push(w.slot.0 as i32);
             }
             w.next_pos += toks.len();
+            // Record which of these rows are visual embeddings, so the engine
+            // can overwrite their token embeddings after the lookup.
+            if let Some(vl) = &w.vl {
+                let span_end = vl.span_start + vl.span_len;
+                let chunk_start = start_pos - vl.pos_base;
+                let chunk_end = chunk_start + toks.len();
+                let ov_start = chunk_start.max(vl.span_start);
+                let ov_end = chunk_end.min(span_end);
+                if ov_start < ov_end {
+                    let rows = ov_end - ov_start;
+                    let emb_row0 = ov_start - vl.span_start;
+                    if b.vl_rows.is_none() {
+                        b.vl_rows = Some(Vec::new());
+                    }
+                    if let Some(list) = &mut b.vl_rows {
+                        list.push((row0, rows, emb_row0));
+                    }
+                }
+            }
         }
         b
     }
@@ -73,6 +110,7 @@ mod tests {
     fn a_long_prompt_is_chunked_not_run_whole() {
         let mut s = Scheduler { chunk_size: 256 };
         let mut work = vec![PendingWork {
+            vl: None,
             slot: SlotId(0),
             remaining_prompt: prompt(1000),
             next_pos: 0,
@@ -93,12 +131,14 @@ mod tests {
         let mut s = Scheduler { chunk_size: 256 };
         let mut work = vec![
             PendingWork {
+                vl: None,
                 slot: SlotId(0),
                 remaining_prompt: prompt(300),
                 next_pos: 0,
                 decoding: false,
             },
             PendingWork {
+                vl: None,
                 slot: SlotId(1),
                 remaining_prompt: vec![42],
                 next_pos: 10,
@@ -117,6 +157,7 @@ mod tests {
     fn a_prompt_shorter_than_a_chunk_completes_in_one_batch() {
         let mut s = Scheduler { chunk_size: 256 };
         let mut work = vec![PendingWork {
+            vl: None,
             slot: SlotId(0),
             remaining_prompt: prompt(10),
             next_pos: 0,
@@ -131,6 +172,7 @@ mod tests {
     fn an_idle_slot_contributes_nothing() {
         let mut s = Scheduler { chunk_size: 256 };
         let mut work = vec![PendingWork {
+            vl: None,
             slot: SlotId(0),
             remaining_prompt: vec![],
             next_pos: 0,

--- a/crates/hipfire-arch-qwen35/src/serve_engine.rs
+++ b/crates/hipfire-arch-qwen35/src/serve_engine.rs
@@ -29,6 +29,7 @@ use hipfire_runtime::session_table::{SessionId, SessionTable};
 use hipfire_runtime::swap::snapshot::{capture_slot, restore_slot, SnapshotStamp};
 use hipfire_runtime::swap::SwapManager;
 use rdna_compute::sampling::SlotSampleParams;
+use rdna_compute::kv_range::KvRangeAllocator;
 use rdna_compute::slot_pool::{SlotId, SlotPool};
 use rdna_compute::{DType, Gpu, GpuTensor};
 
@@ -126,6 +127,8 @@ struct Rig {
     config: qwen35::Qwen35Config,
     tokenizer: hipfire_runtime::tokenizer::Tokenizer,
     pool: SlotPool,
+    /// Dynamic KV-range allocator over the shared arena (elastic mode).
+    kv_alloc: Option<KvRangeAllocator>,
     k_arenas: Vec<GpuTensor>,
     v_arenas: Vec<GpuTensor>,
     dn_states: Vec<DeltaNetState>,
@@ -211,28 +214,32 @@ impl Rig {
         }
         .map_err(|e| format!("load weights: {e}"))?;
 
-        let pool = match cfg.pool_total_tokens {
-            Some(pool_total) => SlotPool::new_elastic(
-                cfg.n_slots,
-                cfg.reserve_tokens,
-                pool_total,
-                per_pos_bytes,
-            )
-            .map_err(|e| format!("SlotPool: {e}"))?,
-            None => SlotPool::new(cfg.n_slots, cfg.cap_tokens, per_pos_bytes)
-                .map_err(|e| format!("SlotPool: {e}"))?,
+        let (pool, kv_alloc) = match cfg.pool_total_tokens {
+            Some(pool_total) => {
+                let pool = SlotPool::new_dynamic(cfg.n_slots, pool_total, per_pos_bytes)
+                    .map_err(|e| format!("SlotPool: {e}"))?;
+                let alloc = KvRangeAllocator::new(pool.max_cap(), per_pos_bytes);
+                (pool, Some(alloc))
+            }
+            None => (
+                SlotPool::new(cfg.n_slots, cfg.cap_tokens, per_pos_bytes)
+                    .map_err(|e| format!("SlotPool: {e}"))?,
+                None,
+            ),
         };
-        let min_slot_cap = pool
-            .descriptors()
-            .iter()
-            .map(|d| d.cap as usize)
-            .min()
-            .unwrap_or(cfg.cap_tokens);
         // Prefill scratch is sized by the CHUNK width (one step's rows), not
-        // the full context — sizing it by cap_tokens allocated O(ctx) GiB of
-        // f32 scratch that a chunked prefill never fills. Chunk width is
-        // bounded by the SMALLEST slab (a step's rows may land on any slot)
-        // and capped at 2048 to keep scratch constant.
+        // the full context. Under dynamic-range mode descriptor caps are
+        // assigned at admission, so the chunk width is the fixed 2048-row
+        // budget; equal/elastic pools bound it by their smallest slab.
+        let min_slot_cap = if cfg.pool_total_tokens.is_some() {
+            2048usize
+        } else {
+            pool.descriptors()
+                .iter()
+                .map(|d| d.cap as usize)
+                .min()
+                .unwrap_or(cfg.cap_tokens)
+        };
         let max_batch = min_slot_cap.min(2048).max(cfg.n_slots);
         let arena_bytes = pool.arena_bytes();
         let mut k_arenas = Vec::with_capacity(n_fa_layers);
@@ -306,6 +313,7 @@ impl Rig {
             vision,
             image_pad_id: rig_image_pad_id(&tokenizer),
             min_slot_cap,
+            kv_alloc,
             weights,
             config,
             tokenizer,
@@ -335,6 +343,8 @@ struct InFlight {
     reply: Sender<Event>,
     produced: usize,
     max_tokens: usize,
+    /// Allocated KV range for this request (dynamic-range mode).
+    kv_range: Option<rdna_compute::kv_range::KvRange>,
 }
 
 fn run_loop(mut rig: Rig, rx: Receiver<SubmitRequest>, stats: Arc<Mutex<EngineStats>>) {
@@ -556,8 +566,17 @@ fn run_loop(mut rig: Rig, rx: Receiver<SubmitRequest>, stats: Arc<Mutex<EngineSt
                     DoneReason::MaxTokens
                 };
                 let _ = send_event(&f.reply, Event::Done { reason });
-                slots[s] = None;
+                // Take the InFlight out first so its KV range can be freed
+                // without holding the slot borrow.
+                let mut done = slots[s].take().unwrap();
                 work[s].remaining_prompt.clear();
+                if let Some(range) = done.kv_range.take() {
+                    if let Some(alloc) = rig.kv_alloc.as_mut() {
+                        alloc.free(&range);
+                    }
+                    rig.pool.release_lane(rdna_compute::slot_pool::SlotId(s));
+                }
+                drop(done);
                 if matches!(reason, DoneReason::ClientGone) {
                     // Nobody will follow up on a vanished client, so hand the
                     // slot back at once.
@@ -598,7 +617,21 @@ fn admit(
     // turn began after an OpenThink opener that history rendering does not
     // replay, and re-encoding the decoded reply is not guaranteed to round
     // trip. Reuse also keeps the DeltaNet state, which is the point.
-    if !req.continuation.is_empty() {
+    // Dynamic-range guard: if this continuation cannot fit its lane's KV
+    // window (long history + big generation budget), skip continuation
+    // matching so the request takes a cold prefill in a fitting allocation.
+    let continuation_fits = req
+        .prompt_tokens
+        .len()
+        .saturating_add(req.max_tokens)
+        <= rig.cap_tokens;
+    if !req.continuation.is_empty() && !continuation_fits {
+        if rig.gpu.slot_trace() {
+            eprintln!("[slot-trace] continuation skipped -- exceeds lane cap");
+        }
+    }
+    let use_continuation = !req.continuation.is_empty() && continuation_fits;
+    if use_continuation {
         if rig.gpu.slot_trace() {
             eprintln!(
                 "[slot-trace] continuation attempt: convo={:?} suffix={} tokens",
@@ -672,6 +705,9 @@ fn admit(
                             reply: req.reply,
                             produced: 0,
                             max_tokens: req.max_tokens.max(1),
+                            // Continuations extend the session's ORIGINAL
+                            // KV range; no new allocation here.
+                            kv_range: None,
                         });
                         rig.sessions.touch(existing);
                         if rig.gpu.slot_trace() {
@@ -769,6 +805,40 @@ fn admit(
             stats.lock().expect("stats").note_rejected();
             return;
         }
+    };
+
+    // ── Dynamic KV-range allocation (elastic mode) ────────────────────────
+    // The lane claims a contiguous KV window sized to its REAL need
+    // (prompt + generation budget), not a preset slab.
+    let kv_range = if let Some(alloc) = rig.kv_alloc.as_mut() {
+        let need = req.prompt_tokens.len().saturating_add(req.max_tokens.max(1));
+        match alloc.alloc(need) {
+            Some(range) => {
+                rig.pool.bind_range(
+                    slot,
+                    range.byte_off,
+                    range.cap_tokens,
+                );
+                Some(range)
+            }
+            None => {
+                let _ = send_event(
+                    &req.reply,
+                    Event::Rejected {
+                        reason: format!(
+                            "KV pool exhausted: need {need} tokens, {} free                              (largest contiguous {})",
+                            alloc.free_tokens(),
+                            alloc.max_contiguous_tokens(),
+                        ),
+                    },
+                );
+                rig.sessions.close(&mut rig.pool, &mut rig.adm, id);
+                stats.lock().expect("stats").note_rejected();
+                return;
+            }
+        }
+    } else {
+        None
     };
 
     // Reset the slot's recurrent state before reusing it. `seq_len = 0` clears
@@ -888,6 +958,7 @@ fn admit(
         reply: req.reply,
         produced: 0,
         max_tokens: req.max_tokens.max(1),
+        kv_range,
     });
     stats.lock().expect("stats").note_admitted();
 }

--- a/crates/hipfire-arch-qwen35/src/serve_engine.rs
+++ b/crates/hipfire-arch-qwen35/src/serve_engine.rs
@@ -20,6 +20,10 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
 use hipfire_runtime::admission::{AdmissionController, ModelFootprint};
+use crate::forward_slots::{forward_batch_slots_opts, SlotStepOpts};
+use hipfire_arch_qwen35_vl::qwen35_vl::{load_vision_weights, vision_config_from_hfq, VisionConfig, VisionWeights};
+use hipfire_arch_qwen35_vl::image as vl_image;
+use hipfire_arch_qwen35_vl::mrope::ImageSpan;
 use hipfire_runtime::serve::{send_event, DoneReason, EngineStats, Event, SubmitRequest};
 use hipfire_runtime::session_table::{SessionId, SessionTable};
 use hipfire_runtime::swap::snapshot::{capture_slot, restore_slot, SnapshotStamp};
@@ -123,6 +127,11 @@ struct Rig {
     sample_params: Vec<SlotSampleParams>,
     sessions: SessionTable,
     adm: AdmissionController,
+    /// Vision tower for VL requests. `None` when the HFQ carries no visual
+    /// tensors (text-only checkpoint).
+    vision: Option<(VisionConfig, VisionWeights)>,
+    /// `<|image_pad|>` token id used to locate the visual span in a prompt.
+    image_pad_id: u32,
     swap: SwapManager,
     stamp: SnapshotStamp,
     n_slots: usize,
@@ -165,11 +174,26 @@ impl Rig {
             * (cfg.n_slots as u64)
             * (cap_rounded as u64)
             * (per_pos_bytes as u64);
-        let planned = weight_bytes + kv_bytes + 768 * 1024 * 1024;
+        // Vision tower adds ~0.6 GiB when present; charge a flat margin so the
+        // preflight never passes on an allocation that then OOMs mid-load.
+        let planned = weight_bytes + kv_bytes + 768 * 1024 * 1024 + 768 * 1024 * 1024;
         preflight_alloc(planned, R9700_VRAM_BYTES, "SlotEngine")
             .map_err(|e| format!("preflight refused: {e}"))?;
 
         let mut gpu = Gpu::init().map_err(|e| format!("gpu init: {e}"))?;
+        // Vision FIRST: the trunk loader drops the mmap and may reclaim tensor
+        // pages, so the ViT must read its tensors while the file is pristine
+        // (same order the daemon carrier uses).
+        let vision = {
+            let cfg = vision_config_from_hfq(&hfq);
+            match cfg {
+                Some(vc) => match load_vision_weights(&mut hfq, &vc, &mut gpu) {
+                    Ok(vw) => Some((vc, vw)),
+                    Err(e) => return Err(format!("load vision weights: {e}")),
+                },
+                None => None,
+            }
+        };
         let weights: Qwen35Weights = {
             let mut src = qwen35::HfqSource::new(&mut hfq, &config);
             let layout = qwen35::Layout::single(config.n_layers);
@@ -198,7 +222,11 @@ impl Rig {
         }
         let desc_staging = SlotDescStaging::new(&mut gpu, cfg.n_slots, max_batch)
             .map_err(|e| format!("staging: {e}"))?;
-        let pbs = PrefillBatchScratch::new(&mut gpu, &config, max_batch)
+        // cap_gdn_tape=false: the spec-decode DeltaNet S-tape scales with
+        // max_batch (= max(cap_tokens, n_slots)) and is only consumed by
+        // tree-verify GDN kernels, which the multi-slot forward never runs.
+        // At 2048 ctx on a dense-9B it wasted ~4 GiB of VRAM for nothing.
+        let pbs = PrefillBatchScratch::new_opt(&mut gpu, &config, max_batch, /*cap_gdn_tape=*/ false)
             .map_err(|e| format!("pbs: {e}"))?;
         let scratch = Qwen35Scratch::new_with_kv_max(&mut gpu, &config, 64, cfg.cap_tokens)
             .map_err(|e| format!("scratch: {e}"))?;
@@ -244,6 +272,8 @@ impl Rig {
 
         Ok(Rig {
             gpu,
+            vision,
+            image_pad_id: rig_image_pad_id(&tokenizer),
             weights,
             config,
             tokenizer,
@@ -280,6 +310,7 @@ fn run_loop(mut rig: Rig, rx: Receiver<SubmitRequest>, stats: Arc<Mutex<EngineSt
     let mut slots: Vec<Option<InFlight>> = (0..n).map(|_| None).collect();
     let mut work: Vec<PendingWork> = (0..n)
         .map(|s| PendingWork {
+            vl: None,
             slot: SlotId(s),
             remaining_prompt: Vec::new(),
             next_pos: 0,
@@ -320,21 +351,90 @@ fn run_loop(mut rig: Rig, rx: Receiver<SubmitRequest>, stats: Arc<Mutex<EngineSt
         if batch.is_empty() {
             continue;
         }
-        let fwd = forward_batch_slots_graphed(
-            &mut rig.gpu,
-            &rig.weights,
-            &rig.config,
-            &batch,
-            &mut rig.pool,
-            &mut rig.dn_states,
-            &rig.k_arenas,
-            &rig.v_arenas,
-            &mut rig.desc_staging,
-            &rig.pbs,
-            &rig.scratch,
-            &rig.logits_out,
-            &mut graph,
-        );
+        // VL prefill: gather embedding overrides + mrope pos3 for the visual
+        // rows this step carries. Any VL activity forces the plain (non-graph)
+        // forward, which honors SlotStepOpts.
+        let mut embed_override: Option<(Vec<f32>, usize)> = None;
+        let mut mrope_pos3: Option<Vec<i32>> = None;
+        for (slot_ix, &m) in batch.m_per_slot.iter().enumerate() {
+            if m == 0 {
+                continue;
+            }
+            // Take (and clear) this slot's VL state: it applies to THIS prefill
+            // step only. Later (decode) steps take the plain path. Note the
+            // scheduler has ALREADY drained remaining_prompt by the time we get
+            // here, so emptiness does not mean "no VL rows this step".
+            let Some(vl) = work[slot_ix].vl.take() else {
+                continue;
+            };
+            let vl = &vl;
+            // Rows of this slot in the batch, in order.
+            let rows: Vec<usize> = (0..batch.tokens.len())
+                .filter(|&r| batch.row_slot[r] == slot_ix as i32)
+                .collect();
+            let chunk_start = batch.positions[*rows.first().unwrap()] as usize
+                - vl.pos_base;
+            let span_end = vl.span_start + vl.span_len;
+            let ov_start = chunk_start.max(vl.span_start);
+            let ov_end = (chunk_start + rows.len()).min(span_end);
+            if ov_start < ov_end {
+                let dim = rig.config.dim;
+                let count = ov_end - ov_start;
+                let mut embs = Vec::with_capacity(count * dim);
+                let e0 = (ov_start - vl.span_start) * dim;
+                embs.extend_from_slice(&vl.embeds[e0..e0 + count * dim]);
+                embed_override = Some((embs, rows[ov_start - chunk_start]));
+            }
+            // mrope positions for ALL rows of a VL slot (text rows too).
+            let mut pos3 = Vec::with_capacity(rows.len() * 3);
+            for &r in &rows {
+                let p = batch.positions[r] as usize - vl.pos_base;
+                pos3.extend_from_slice(&vl.pos3[p * 3..p * 3 + 3]);
+            }
+            mrope_pos3 = Some(pos3);
+        }
+        let vl_active = embed_override.is_some() || mrope_pos3.is_some();
+        let fwd = if vl_active {
+            let (embeds, row0) = embed_override.unwrap();
+            forward_batch_slots_opts(
+                &mut rig.gpu,
+                &rig.weights,
+                &rig.config,
+                &batch,
+                &mut rig.pool,
+                &mut rig.dn_states,
+                &rig.k_arenas,
+                &rig.v_arenas,
+                &mut rig.desc_staging,
+                &rig.pbs,
+                &rig.scratch,
+                &rig.logits_out,
+                None,
+                SlotStepOpts {
+                    skip_uploads: false,
+                    ctx_override: None,
+                    embed_override: Some((embeds, row0)),
+                    mrope_pos3,
+                },
+            )
+        } else {
+            forward_batch_slots_graphed(
+                &mut rig.gpu,
+                &rig.weights,
+                &rig.config,
+                &batch,
+                &mut rig.pool,
+                &mut rig.dn_states,
+                &rig.k_arenas,
+                &rig.v_arenas,
+                &mut rig.desc_staging,
+                &rig.pbs,
+                &rig.scratch,
+                &rig.logits_out,
+                &mut graph,
+                false,
+            )
+        };
         if let Err(e) = fwd {
             // A forward failure is not recoverable per-request. Report it as a
             // REJECTION carrying the reason, not as a normal Done: an
@@ -400,12 +500,22 @@ fn run_loop(mut rig: Rig, rx: Receiver<SubmitRequest>, stats: Arc<Mutex<EngineSt
             };
             f.produced += 1;
             let hit_max = f.produced >= f.max_tokens;
+            // Context-cap guard: stop before the slot's KV length would pass
+            // its cap. Without this, a long multi-turn session overflows
+            // set_seq_len and kills the whole batched step.
+            let hit_ctx_cap = rig
+                .sessions
+                .get(session)
+                .map(|sess| sess.tokens.len() + 1 >= rig.cap_tokens)
+                .unwrap_or(false);
 
-            if gone || hit_eos || hit_max {
+            if gone || hit_eos || hit_max || hit_ctx_cap {
                 let reason = if gone {
                     DoneReason::ClientGone
                 } else if hit_eos {
                     DoneReason::Eos
+                } else if hit_ctx_cap {
+                    DoneReason::MaxTokens // context exhausted; same client semantics
                 } else {
                     DoneReason::MaxTokens
                 };
@@ -658,9 +768,77 @@ fn admit(
         return;
     }
 
+    // ── VL: preprocess the image and build the visual-embedding injection
+    // state for this slot's prefill. Runs on the engine thread; the vision
+    // tower is one-shot per request (~0.1-6 s depending on resolution).
+    let vl = match (&req.image_bytes, &rig.vision) {
+        (Some(bytes), Some((vc, vw))) => {
+            let r_vl = (|| -> Result<crate::scheduler::VlPrefill, String> {
+                let (chw, img_h, img_w) =
+                    vl_image::load_and_preprocess_from_bytes(bytes, vc.patch_size, vc.spatial_merge_size)?;
+                let patches = vl_image::extract_patches(
+                    &chw, 3, img_h, img_w, vc.patch_size, vc.temporal_patch_size, vc.spatial_merge_size,
+                );
+                let grid_h = img_h / vc.patch_size;
+                let grid_w = img_w / vc.patch_size;
+                let embs = hipfire_arch_qwen35_vl::qwen35_vl::vision_forward(
+                    &mut rig.gpu, vw, vc, &patches, grid_h, grid_w,
+                )
+                .map_err(|e| format!("vision forward failed: {e:?}"))?;
+                let n_vis = embs.len() / config_dim(&rig.config);
+                // Locate the image-pad run in the prompt.
+                let span_start = req
+                    .prompt_tokens
+                    .iter()
+                    .position(|&t| t == rig.image_pad_id)
+                    .ok_or("image request has no <|image_pad|> span in prompt")?;
+                let span_len = req.prompt_tokens[span_start..]
+                    .iter()
+                    .take_while(|&&t| t == rig.image_pad_id)
+                    .count();
+                let span_end = span_start + span_len;
+                if embs.len() != span_len * config_dim(&rig.config) {
+                    return Err(format!(
+                        "visual tokens {n_vis} mismatch pad-span {span_len}"
+                    ));
+                }
+                let spans = [ImageSpan { start: span_start, len: span_len, grid_h, grid_w }];
+                let built = hipfire_arch_qwen35_vl::mrope::build_mrope_positions(
+                    req.prompt_tokens.len(), &spans, vc.spatial_merge_size,
+                );
+                let base = plan.reused as i32;
+                let mut pos3: Vec<i32> = Vec::with_capacity(req.prompt_tokens.len() * 3);
+                for p in &built.positions {
+                    pos3.extend_from_slice(&[p[0] + base, p[1] + base, p[2] + base]);
+                }
+                Ok(crate::scheduler::VlPrefill {
+                    embeds: embs,
+                    span_start,
+                    span_len,
+                    pos_base: plan.reused,
+                    pos3,
+                })
+            })();
+            match r_vl {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    let _ = send_event(
+                        &req.reply,
+                        Event::Rejected { reason: format!("vl: {e}") },
+                    );
+                    rig.sessions.close(&mut rig.pool, &mut rig.adm, id);
+                    stats.lock().expect("stats").note_rejected();
+                    return;
+                }
+            }
+        }
+        _ => None,
+    };
+
     work[slot.0].remaining_prompt = req.prompt_tokens[plan.reused..].to_vec();
     work[slot.0].next_pos = plan.reused;
     work[slot.0].decoding = false;
+    work[slot.0].vl = vl;
     slots[slot.0] = Some(InFlight {
         session: id,
         reply: req.reply,
@@ -669,6 +847,13 @@ fn admit(
     });
     stats.lock().expect("stats").note_admitted();
 }
+
+/// Hidden dim of the trunk (`config.dim`) — helper so the VL closure above
+/// stays readable.
+fn config_dim(config: &qwen35::Qwen35Config) -> usize {
+    config.dim
+}
+
 
 /// Capture an idle session's state, park it, and free its slot.
 ///
@@ -745,4 +930,14 @@ fn restore(rig: &mut Rig, id: SessionId, slot: SlotId) -> bool {
             false
         }
     }
+}
+
+
+/// Resolve `<|image_pad|>` from the checkpoint tokenizer. Falls back to the
+/// Qwen3.5-VL constant when the special token is absent (text-only models
+/// never consult it — vision requests are rejected before this matters).
+fn rig_image_pad_id(tokenizer: &hipfire_runtime::tokenizer::Tokenizer) -> u32 {
+    tokenizer
+        .special_token_id("<|image_pad|>")
+        .unwrap_or(248056)
 }

--- a/crates/hipfire-arch-qwen35/src/serve_engine.rs
+++ b/crates/hipfire-arch-qwen35/src/serve_engine.rs
@@ -163,7 +163,11 @@ impl Rig {
             .filter(|t| **t == LayerType::FullAttention)
             .count();
         let per_pos_bytes = config.n_kv_heads * (config.head_dim / 32) * 34;
-        let max_batch = cfg.cap_tokens.max(cfg.n_slots);
+        // Prefill scratch is sized by the CHUNK width (one step's rows), not
+        // the full context — sizing it by cap_tokens allocated O(ctx) GiB of
+        // f32 scratch that a chunked prefill never fills. KV arenas (below)
+        // remain the only context-scaled allocations.
+        let max_batch = cfg.cap_tokens.min(2048).max(cfg.n_slots);
 
         let weight_bytes = std::fs::metadata(&cfg.model_path)
             .map_err(|e| format!("stat model: {e}"))?
@@ -317,8 +321,12 @@ fn run_loop(mut rig: Rig, rx: Receiver<SubmitRequest>, stats: Arc<Mutex<EngineSt
             decoding: false,
         })
         .collect();
+    // Prefill chunk size is bounded independently of per-slot context: pbs
+    // scratch scales with the chunk, not with cap_tokens, so a 100k-context
+    // slot must not allocate a 100k-row workspace. 2048 keeps the scratch
+    // ~0.9 GiB while KV arenas scale to the real context.
     let mut sched = Scheduler {
-        chunk_size: rig.cap_tokens.max(1),
+        chunk_size: rig.cap_tokens.min(2048).max(1),
     };
     let mut graph = SlotDecodeGraph::new();
 

--- a/crates/hipfire-arch-qwen35/src/serve_engine.rs
+++ b/crates/hipfire-arch-qwen35/src/serve_engine.rs
@@ -216,10 +216,19 @@ impl Rig {
 
         let (pool, kv_alloc) = match cfg.pool_total_tokens {
             Some(pool_total) => {
-                let pool = SlotPool::new_dynamic(cfg.n_slots, pool_total, per_pos_bytes)
-                    .map_err(|e| format!("SlotPool: {e}"))?;
-                let alloc = KvRangeAllocator::new(pool.max_cap(), per_pos_bytes);
-                (pool, Some(alloc))
+                // ELASTIC (validated): big primary + reserved slabs summing to
+                // pool_total. Dynamic per-request ranges exist behind
+                // SlotPool::new_dynamic but the batched attention path still
+                // assumes uniform slab strides in some fast paths, so elastic
+                // is the shipped configuration.
+                let pool = SlotPool::new_elastic(
+                    cfg.n_slots,
+                    cfg.reserve_tokens,
+                    pool_total,
+                    per_pos_bytes,
+                )
+                .map_err(|e| format!("SlotPool: {e}"))?;
+                (pool, None)
             }
             None => (
                 SlotPool::new(cfg.n_slots, cfg.cap_tokens, per_pos_bytes)

--- a/crates/hipfire-arch-qwen35/src/serve_engine.rs
+++ b/crates/hipfire-arch-qwen35/src/serve_engine.rs
@@ -41,7 +41,17 @@ use crate::scheduler::{PendingWork, Scheduler};
 pub struct EngineConfig {
     pub model_path: PathBuf,
     pub n_slots: usize,
+    /// Per-slot capacity in EQUAL-slab mode; the PRIMARY slab capacity in
+    /// elastic mode (reserved slots get `reserve_tokens` each).
     pub cap_tokens: usize,
+    /// Elastic slot-pool sharing: total tokens across all slots. When `Some`,
+    /// the pool is built with a big primary slab (`cap_tokens`) and
+    /// `(n_slots-1)` reserved slabs of `reserve_tokens`; a solo request can
+    /// use nearly the whole budget while concurrent requests fall back to
+    /// reserved slabs.
+    pub pool_total_tokens: Option<usize>,
+    /// Reserved-slots context for elastic mode (default 8192).
+    pub reserve_tokens: usize,
     pub host_budget_bytes: u64,
     pub swap_dir: PathBuf,
 }
@@ -136,6 +146,8 @@ struct Rig {
     stamp: SnapshotStamp,
     n_slots: usize,
     cap_tokens: usize,
+    /// Smallest per-slot capacity — bounds the prefill chunk width.
+    min_slot_cap: usize,
 }
 
 fn dn_buffers(dn: &DeltaNetState) -> Vec<&GpuTensor> {
@@ -163,12 +175,6 @@ impl Rig {
             .filter(|t| **t == LayerType::FullAttention)
             .count();
         let per_pos_bytes = config.n_kv_heads * (config.head_dim / 32) * 34;
-        // Prefill scratch is sized by the CHUNK width (one step's rows), not
-        // the full context — sizing it by cap_tokens allocated O(ctx) GiB of
-        // f32 scratch that a chunked prefill never fills. KV arenas (below)
-        // remain the only context-scaled allocations.
-        let max_batch = cfg.cap_tokens.min(2048).max(cfg.n_slots);
-
         let weight_bytes = std::fs::metadata(&cfg.model_path)
             .map_err(|e| format!("stat model: {e}"))?
             .len();
@@ -205,8 +211,29 @@ impl Rig {
         }
         .map_err(|e| format!("load weights: {e}"))?;
 
-        let pool = SlotPool::new(cfg.n_slots, cfg.cap_tokens, per_pos_bytes)
-            .map_err(|e| format!("SlotPool: {e}"))?;
+        let pool = match cfg.pool_total_tokens {
+            Some(pool_total) => SlotPool::new_elastic(
+                cfg.n_slots,
+                cfg.reserve_tokens,
+                pool_total,
+                per_pos_bytes,
+            )
+            .map_err(|e| format!("SlotPool: {e}"))?,
+            None => SlotPool::new(cfg.n_slots, cfg.cap_tokens, per_pos_bytes)
+                .map_err(|e| format!("SlotPool: {e}"))?,
+        };
+        let min_slot_cap = pool
+            .descriptors()
+            .iter()
+            .map(|d| d.cap as usize)
+            .min()
+            .unwrap_or(cfg.cap_tokens);
+        // Prefill scratch is sized by the CHUNK width (one step's rows), not
+        // the full context — sizing it by cap_tokens allocated O(ctx) GiB of
+        // f32 scratch that a chunked prefill never fills. Chunk width is
+        // bounded by the SMALLEST slab (a step's rows may land on any slot)
+        // and capped at 2048 to keep scratch constant.
+        let max_batch = min_slot_cap.min(2048).max(cfg.n_slots);
         let arena_bytes = pool.arena_bytes();
         let mut k_arenas = Vec::with_capacity(n_fa_layers);
         let mut v_arenas = Vec::with_capacity(n_fa_layers);
@@ -278,6 +305,7 @@ impl Rig {
             gpu,
             vision,
             image_pad_id: rig_image_pad_id(&tokenizer),
+            min_slot_cap,
             weights,
             config,
             tokenizer,
@@ -668,9 +696,17 @@ fn admit(
     }
 
     // Try to open; if the pool is full, evict the LRU idle session first.
+    // Needed context for THIS request: prompt + generation budget. Under an
+    // elastic pool this selects the smallest slab that fits; under equal
+    // slabs it is capped at the per-slot capacity.
+    let needed_ctx = req
+        .prompt_tokens
+        .len()
+        .saturating_add(req.max_tokens)
+        .min(rig.cap_tokens);
     let id = match rig
         .sessions
-        .open(&mut rig.pool, &mut rig.adm, rig.cap_tokens)
+        .open(&mut rig.pool, &mut rig.adm, needed_ctx)
     {
         Ok(id) => id,
         Err(_) => {
@@ -690,7 +726,7 @@ fn admit(
                     stats.lock().expect("stats").note_eviction();
                     match rig
                         .sessions
-                        .open(&mut rig.pool, &mut rig.adm, rig.cap_tokens)
+                        .open(&mut rig.pool, &mut rig.adm, needed_ctx)
                     {
                         Ok(id) => id,
                         Err(e) => {

--- a/crates/hipfire-arch-qwen35/src/slot_batch.rs
+++ b/crates/hipfire-arch-qwen35/src/slot_batch.rs
@@ -24,6 +24,10 @@ pub struct SlotBatch {
     pub positions: Vec<i32>,
     /// Slot index for each flat row.
     pub row_slot: Vec<i32>,
+    /// VL prefill: per visual chunk `(batch_row0, n_rows, embed_row0)`. Rows
+    /// `batch_row0..+n_rows` get vision-tower embeddings starting at
+    /// `embed_row0` of the visual-embedding table.
+    pub vl_rows: Option<Vec<(usize, usize, usize)>>,
 }
 
 impl SlotBatch {

--- a/crates/hipfire-cli/Cargo.toml
+++ b/crates/hipfire-cli/Cargo.toml
@@ -11,9 +11,10 @@ path = "src/main.rs"
 
 [features]
 default = ["multi-slot"]
-multi-slot = ["dep:hipfire-arch-qwen35"]
+multi-slot = ["dep:hipfire-arch-qwen35", "dep:hipfire-arch-qwen35-vl"]
 
 [dependencies]
+base64 = "0.22"
 anyhow = "1"
 clap = { version = "4.6", features = ["derive"] }
 ctrlc = { version = "3", features = ["termination"] }
@@ -23,6 +24,7 @@ hipfire-client = { path = "../hipfire-client" }
 hipfire-registry = { path = "../hipfire-registry" }
 hipfire-runtime = { path = "../hipfire-runtime", default-features = false, features = ["deltanet"] }
 hipfire-arch-qwen35 = { path = "../hipfire-arch-qwen35", default-features = false, features = ["deltanet"], optional = true }
+hipfire-arch-qwen35-vl = { path = "../hipfire-arch-qwen35-vl", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/hipfire-cli/src/bench_concurrency.rs
+++ b/crates/hipfire-cli/src/bench_concurrency.rs
@@ -334,6 +334,8 @@ impl ConcurrencyBackend for SlotDriver {
                     prompt_tokens,
                     convo,
                     continuation: Vec::new(),
+                    image_bytes: None,
+                    vis_span: None,
                     max_tokens: max_tokens as usize,
                     reply: tx,
                 })
@@ -379,6 +381,8 @@ impl ConcurrencyBackend for SlotDriver {
                         prompt_tokens: Vec::new(),
                         convo,
                         continuation,
+                        image_bytes: None,
+                        vis_span: None,
                         max_tokens: max_tokens as usize,
                         reply: tx,
                     })

--- a/crates/hipfire-cli/src/bench_concurrency.rs
+++ b/crates/hipfire-cli/src/bench_concurrency.rs
@@ -267,6 +267,8 @@ impl SlotDriver {
                 model_path: model.to_path_buf(),
                 n_slots: max_concurrency,
                 cap_tokens,
+                pool_total_tokens: None,
+                reserve_tokens: 8192,
                 host_budget_bytes: 2 * 1024 * 1024 * 1024,
                 swap_dir: std::env::temp_dir().join("hipfire-bench-swap"),
             },

--- a/crates/hipfire-cli/src/serve/complete.rs
+++ b/crates/hipfire-cli/src/serve/complete.rs
@@ -1598,6 +1598,9 @@ pub(crate) fn complete_request(
     // semantics and has no analogue here -- the engine either admits a request
     // or rejects it with a reason.
     if let Some(backend) = shared.slot_engine.clone() {
+        // The multi-slot engine handles both text and vision: it loads the
+        // vision tower alongside the trunk when the checkpoint carries one,
+        // and its prefill splices visual embeddings + mrope positions.
         return crate::serve::slots::complete_request_slots(
             &backend,
             body,

--- a/crates/hipfire-cli/src/serve/mod.rs
+++ b/crates/hipfire-cli/src/serve/mod.rs
@@ -688,17 +688,38 @@ pub(crate) fn serve_foreground(
                 .ok_or_else(|| anyhow!("multi_slot: cannot resolve model {default_model}"))?;
             let n_slots = config_u64(&global, "serve.multi_slot_slots").unwrap_or(4) as usize;
             let cap_tokens = config_u64(&global, "serve.multi_slot_ctx").unwrap_or(8192) as usize;
+            // ELASTIC POOL: the config's per-slot ctx becomes the RESERVE for
+            // concurrent requests; the pool TOTAL is slots*reserve + extra,
+            // controlled by `serve.multi_slot_pool_total` (tokens). Unset →
+            // legacy equal slabs of cap_tokens each.
+            let reserve_tokens = cap_tokens;
+            let pool_total_tokens = config_u64(&global, "serve.multi_slot_pool_total")
+                .ok()
+                .map(|t| t as usize);
             let mut hfq = hipfire_runtime::hfq::HfqFile::open(&model_path)
                 .with_context(|| format!("multi_slot: open {}", model_path.display()))?;
             let tokenizer =
                 hipfire_runtime::tokenizer::Tokenizer::from_hfq_metadata(&hfq.metadata_json)
                     .map_err(|e| anyhow!("multi_slot: tokenizer: {e}"))?;
             drop(hfq);
+            let pool_total_tokens =
+                config_u64(&global, "serve.multi_slot_pool_total").unwrap_or(0) as usize;
+            let pool_total_tokens = if pool_total_tokens > 0 {
+                Some(pool_total_tokens)
+            } else {
+                None
+            };
             let engine = hipfire_arch_qwen35::serve_engine::SlotEngine::spawn(
                 hipfire_arch_qwen35::serve_engine::EngineConfig {
                     model_path: model_path.clone(),
                     n_slots,
-                    cap_tokens,
+                    cap_tokens: if pool_total_tokens.is_some() {
+                        reserve_tokens
+                    } else {
+                        cap_tokens
+                    },
+                    pool_total_tokens,
+                    reserve_tokens,
                     host_budget_bytes: 16 * 1024 * 1024 * 1024,
                     swap_dir: std::env::temp_dir().join("hipfire-serve-swap"),
                 },

--- a/crates/hipfire-cli/src/serve/slots.rs
+++ b/crates/hipfire-cli/src/serve/slots.rs
@@ -103,14 +103,73 @@ pub(crate) fn complete_request_slots(
     } else {
         AssistantPrefix::Plain
     };
-    let frame = ChatFrame {
-        tokenizer: &backend.tokenizer,
-        system: system.as_deref(),
-        user: &last_user,
-        assistant_prefix: prefix,
-        raw: false,
+    // VL: extract the base64 image (if any). When present, CPU-preprocess it
+    // (cheap, no GPU) to learn the merged visual-token count, then render the
+    // final user turn with the exact pad span the engine will splice vision
+    // embeddings into: [vision_start, PAD×n_vis, vision_end, \n, question].
+    let image_bytes: Option<Vec<u8>> = match crate::serve::complete::request_image_base64(
+        body.get("messages"),
+    )? {
+        Some(b64) => {
+            use base64::Engine as _;
+            Some(
+                base64::engine::general_purpose::STANDARD
+                    .decode(&b64)
+                    .map_err(|e| anyhow::anyhow!("invalid base64 image payload: {e}"))?,
+            )
+        }
+        None => None,
     };
-    let prompt_tokens = frame.build_multi_turn(&history);
+    let image_bytes = image_bytes.filter(|b| !b.is_empty());
+
+    const PATCH_SIZE: usize = 16;
+    const SPATIAL_MERGE: usize = 2;
+    let n_vis = match &image_bytes {
+        Some(bytes) => {
+            let (chw, gh, gw) =
+                hipfire_arch_qwen35_vl::image::load_and_preprocess_from_bytes(
+                    bytes, PATCH_SIZE, SPATIAL_MERGE,
+                )
+                .map_err(|e| anyhow::anyhow!("vl preprocess: {e}"))?;
+            drop(chw);
+            ((gh / PATCH_SIZE) / SPATIAL_MERGE) * ((gw / PATCH_SIZE) / SPATIAL_MERGE)
+        }
+        None => 0,
+    };
+
+    let prompt_tokens = if n_vis > 0 {
+        let vs = backend.tokenizer.special_token_id("<|vision_start|>");
+        let ve = backend.tokenizer.special_token_id("<|vision_end|>");
+        let pad = backend.tokenizer.special_token_id("<|image_pad|>");
+        let (Some(vs), Some(ve), Some(pad)) = (vs, ve, pad) else {
+            bail!("model tokenizer lacks VL special tokens; cannot serve images");
+        };
+        let q_tokens = backend.tokenizer.encode(&last_user);
+        let nl = backend.tokenizer.encode("\n");
+        let mut user_body: Vec<u32> = Vec::with_capacity(n_vis + q_tokens.len() + 4);
+        user_body.push(vs);
+        user_body.resize(user_body.len() + n_vis, pad);
+        user_body.push(ve);
+        user_body.extend_from_slice(&nl);
+        user_body.extend_from_slice(&q_tokens);
+        ChatFrame {
+            tokenizer: &backend.tokenizer,
+            system: system.as_deref(),
+            user: "",
+            assistant_prefix: prefix,
+            raw: false,
+        }
+        .build_with_user_tokens(&user_body)
+    } else {
+        ChatFrame {
+            tokenizer: &backend.tokenizer,
+            system: system.as_deref(),
+            user: &last_user,
+            assistant_prefix: prefix,
+            raw: false,
+        }
+        .build_multi_turn(&history)
+    };
 
     // Conversation identity is the USER turns. The assistant side is whatever
     // we generated, and the client's echo of it may differ (reasoning split to
@@ -149,6 +208,8 @@ pub(crate) fn complete_request_slots(
             prompt_tokens,
             convo,
             continuation,
+            image_bytes: image_bytes.clone(),
+            vis_span: None, // computed engine-side from the rendered prompt
             max_tokens,
             reply: tx,
         })

--- a/crates/hipfire-config/src/lib.rs
+++ b/crates/hipfire-config/src/lib.rs
@@ -700,6 +700,36 @@ pub static FIELDS: &[ConfigField] = &[
         "Serve requests concurrently on the multi-slot engine instead of one at a time."
     ),
     field!(
+        "serve.multi_slot_slots",
+        "multi_slot_slots",
+        Serve,
+        ModelLoad,
+        DefaultValue::Integer(4),
+        ValueRule::Integer {
+            min: 1,
+            max: 64
+        },
+        true,
+        false,
+        None,
+        "Number of concurrent GPU slots in the multi-slot engine."
+    ),
+    field!(
+        "serve.multi_slot_ctx",
+        "multi_slot_ctx",
+        Serve,
+        ModelLoad,
+        DefaultValue::Integer(8192),
+        ValueRule::Integer {
+            min: 512,
+            max: 131072
+        },
+        true,
+        false,
+        None,
+        "Per-slot KV context capacity (tokens) for the multi-slot engine."
+    ),
+    field!(
         "generation.temperature",
         "temperature",
         Generation,

--- a/crates/hipfire-config/src/lib.rs
+++ b/crates/hipfire-config/src/lib.rs
@@ -730,6 +730,21 @@ pub static FIELDS: &[ConfigField] = &[
         "Per-slot KV context capacity (tokens) for the multi-slot engine."
     ),
     field!(
+        "serve.multi_slot_pool_total",
+        "multi_slot_pool_total",
+        Serve,
+        ModelLoad,
+        DefaultValue::Integer(0),
+        ValueRule::Integer {
+            min: 0,
+            max: 1048576
+        },
+        true,
+        false,
+        None,
+        "ELASTIC POOL: total KV tokens shared across all slots. When nonzero,          slot 0 becomes a big primary slab (pool_total minus reserves) and the          remaining slots get `serve.multi_slot_ctx` each; a solo request can use          nearly the whole budget while concurrent requests fall back to reserves."
+    ),
+    field!(
         "generation.temperature",
         "temperature",
         Generation,

--- a/crates/hipfire-daemon/src/main.rs
+++ b/crates/hipfire-daemon/src/main.rs
@@ -2533,6 +2533,18 @@ fn main() {
                         max_think_tokens: vl_max_think_tokens,
                         assistant_prefix,
                     };
+                    // Emit gen_start BEFORE the VL route. The CLI serve layer's
+                    // stream-contract gate requires the first daemon event of a
+                    // transaction to be `gen_start` (PreStartEvent otherwise);
+                    // generate_vl emits `token` events directly, so without this
+                    // every serve-layer VL request was rejected and aborted.
+                    // qwen3.5-VL rides the same semantic contract v2 as Qwen AR.
+                    emit_gen_start(
+                        &mut stdout,
+                        id,
+                        false,
+                        Some(QWEN_AR_SEMANTIC_CONTRACT_VERSION),
+                    );
                     match vision_route {
                         hipfire_loader::VisionRoute::DotsOcr => hipfire_generate::vision::generate_vl_dots_ocr(m, &mut gpu, &mut stdout, &params),
                         _ => hipfire_generate::vision::generate_vl(m, &mut gpu, &mut stdout, &params),

--- a/crates/hipfire-quantize/src/pipeline.rs
+++ b/crates/hipfire-quantize/src/pipeline.rs
@@ -3620,6 +3620,16 @@ fn handle_moe_expert_3d(
     let arch_id = ctx.arch_id;
     let is_vision = ctx.is_vision;
 
+    // Guard: this handler is only valid for stacked 3D MoE expert tensors
+    // ([n_experts, ..., ...] named *.experts.{gate_up,down}_proj). Anything
+    // else (e.g. dense rank-2 tensors like lm_head on multimodal qwen3_5
+    // checkpoints) must fall through to the standard quantization path.
+    if meta.shape.len() < 3
+        || !(name.ends_with("experts.gate_up_proj") || name.ends_with("experts.down_proj"))
+    {
+        return false;
+    }
+
             let n_experts = meta.shape[0];
             let inner_n: usize = meta.shape[1..].iter().product();
             let elem_size = match meta.dtype.as_str() {
@@ -5629,6 +5639,41 @@ fn handle_main_quant(
                     });
                 }
             } // end else (non-Q8HFQ path)
+        } else {
+            // F16 fallback for every tensor excluded from quantization:
+            // norms, biases, sub-32-element weights, and (under
+            // --include-vision) the FP16 vision tower. Without this branch
+            // these tensors are silently DROPPED from the HFQ and the
+            // loader fails with "tensor not found" at model open.
+            let shape: Vec<u32> = meta.shape.iter().map(|&s| s as u32).collect();
+            let f32_data = tensor_to_f32_with_optional_fp8_scale(
+                name,
+                raw_data,
+                meta,
+                &fp8_scale_for,
+                &st_files,
+            );
+            let f16_bytes: Vec<u8> = f32_data
+                .iter()
+                .flat_map(|&v| f32_to_f16(v).to_le_bytes())
+                .collect();
+            eprintln!(
+                "  {:>8}: {} {:?} ({} elements, {:.1} KB → {:.1} KB)",
+                "F16",
+                name,
+                meta.shape,
+                n_elements,
+                raw_data.len() as f64 / 1024.0,
+                f16_bytes.len() as f64 / 1024.0
+            );
+            state.hfq_tensors.push(HfqTensor {
+                name: name.to_string(),
+                quant_type: QuantType::F16,
+                shape,
+                group_size: 0,
+                data: f16_bytes,
+                spilled_len: 0,
+            });
         }
 }
 

--- a/crates/hipfire-runtime/src/serve/mod.rs
+++ b/crates/hipfire-runtime/src/serve/mod.rs
@@ -36,6 +36,14 @@ pub struct SubmitRequest {
     /// these are APPENDED to its exact stored tokens, so the result is a
     /// strict extension of the KV rather than a re-render of it.
     pub continuation: Vec<u32>,
+    /// Visual input for a VL request: raw encoded image bytes (PNG/JPEG) that
+    /// the engine preprocesses and runs through the vision tower. When
+    /// `Some`, `vis_text` carries a placeholder marker inserted into the
+    /// rendered prompt so the engine knows where the image span sits.
+    pub image_bytes: Option<Vec<u8>>,
+    /// `(start_row_within_prompt, count)` of the placeholder span. Only
+    /// meaningful alongside `image_bytes`.
+    pub vis_span: Option<(usize, usize)>,
     pub max_tokens: usize,
     pub reply: Sender<Event>,
 }

--- a/crates/hipfire-runtime/src/session_table.rs
+++ b/crates/hipfire-runtime/src/session_table.rs
@@ -77,7 +77,10 @@ impl SessionTable {
         requested_ctx: usize,
     ) -> Result<SessionId, AdmitError> {
         let granted_ctx = adm.admit(requested_ctx)?;
-        let slot = match pool.acquire() {
+        // Prefer the smallest slab that fits so an elastic pool's big primary
+        // stays free for requests that actually need it. Equal-slab pools
+        // behave exactly as before (any free slot).
+        let slot = match pool.acquire_fitting(requested_ctx).or_else(|| pool.acquire()) {
             Some(slot) => slot,
             None => {
                 adm.release(granted_ctx);

--- a/crates/rdna-compute/src/kv_range.rs
+++ b/crates/rdna-compute/src/kv_range.rs
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Nick Woolmer
+// hipfire — see LICENSE and NOTICE in the project root.
+//
+// KvRangeAllocator — dynamic KV-range allocation over one shared arena.
+//
+// Instead of fixed per-slot slabs, the whole pool budget (e.g. 100k tokens)
+// is ONE address space. Each admitted session claims a contiguous range
+// `[byte_off, byte_off + cap*stride)` sized to its ACTUAL need
+// (prompt + generation budget), and releases it when the request finishes.
+//
+// Consequences:
+//   * a solo request can use nearly the entire pool;
+//   * N concurrent requests split the pool by real demand, not by preset caps;
+//   * no kernel changes: descriptors still resolve `k_base + pos*stride`.
+//
+// Fragmentation (freed gaps smaller than later requests) is handled by
+// first-fit plus host-side compaction through the existing swap machinery —
+// capture_slot/restore_slot relocate a live session's KV to any new range.
+
+/// One allocated KV window inside the shared arena.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KvRange {
+    /// Byte offset of this range's start in each of the K and V arenas.
+    pub byte_off: u64,
+    /// Token capacity of this range (prompt + max generation budget).
+    pub cap_tokens: usize,
+}
+
+#[derive(Debug)]
+struct FreeInterval {
+    off: u64,
+    tokens: usize,
+}
+
+#[derive(Debug)]
+pub struct KvRangeAllocator {
+    total_tokens: usize,
+    per_pos_bytes: usize,
+    free: Vec<FreeInterval>, // sorted by off, non-overlapping, coalesced
+}
+
+impl KvRangeAllocator {
+    pub fn new(total_tokens: usize, per_pos_bytes: usize) -> Self {
+        Self {
+            total_tokens,
+            per_pos_bytes,
+            free: vec![FreeInterval {
+                off: 0,
+                tokens: total_tokens,
+            }],
+        }
+    }
+
+    pub fn total_tokens(&self) -> usize {
+        self.total_tokens
+    }
+
+    pub fn per_pos_bytes(&self) -> usize {
+        self.per_pos_bytes
+    }
+
+    /// Free tokens currently unallocated.
+    pub fn free_tokens(&self) -> usize {
+        self.free.iter().map(|f| f.tokens).sum()
+    }
+
+    /// Largest contiguous range that could be allocated right now.
+    pub fn max_contiguous_tokens(&self) -> usize {
+        self.free.iter().map(|f| f.tokens).max().unwrap_or(0)
+    }
+
+    /// Allocate a contiguous range of `need` tokens (first-fit). The range's
+    /// byte offset is 128-token aligned so a future page size divides it.
+    pub fn alloc(&mut self, need: usize) -> Option<KvRange> {
+        let need = need.div_ceil(128) * 128;
+        // First fit over sorted intervals.
+        let idx = self.free.iter().position(|f| f.tokens >= need)?;
+        let f = &mut self.free[idx];
+        let byte_off = f.off * self.per_pos_bytes as u64;
+        let range = KvRange {
+            byte_off,
+            cap_tokens: need,
+        };
+        // Shrink or remove the interval from its front.
+        if f.tokens == need {
+            self.free.remove(idx);
+        } else {
+            let taken = need as u64;
+            f.off += taken;
+            f.tokens -= need;
+        }
+        Some(range)
+    }
+
+    /// Return a previously allocated range to the pool. Coalesces with
+    /// adjacent free intervals.
+    pub fn free(&mut self, range: &KvRange) {
+        let off = range.byte_off / self.per_pos_bytes as u64;
+        let tokens = range.cap_tokens;
+        // Insert sorted; coalesce with neighbours.
+        let pos = self
+            .free
+            .iter()
+            .position(|f| f.off > off)
+            .unwrap_or(self.free.len());
+        self.free.insert(
+            pos,
+            FreeInterval {
+                off,
+                tokens,
+            },
+        );
+        self.coalesce_at(pos);
+    }
+
+    fn coalesce_at(&mut self, pos: usize) {
+        // Coalesce with next.
+        if pos + 1 < self.free.len() {
+            let cur_end = self.free[pos].off + self.free[pos].tokens as u64;
+            if cur_end == self.free[pos + 1].off {
+                let next_tokens = self.free.remove(pos + 1).tokens;
+                self.free[pos].tokens += next_tokens;
+            }
+        }
+        // Coalesce with prev.
+        if pos > 0 {
+            let prev = &self.free[pos - 1];
+            let prev_end = prev.off + prev.tokens as u64;
+            if prev_end == self.free[pos].off {
+                let cur_tokens = self.free.remove(pos).tokens;
+                self.free[pos - 1].tokens += cur_tokens;
+                self.coalesce_at(pos - 1);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn solo_request_gets_whole_pool() {
+        let mut a = KvRangeAllocator::new(100_000, 1088);
+        let r = a.alloc(95_000).unwrap();
+        assert_eq!(r.byte_off, 0);
+        assert_eq!(r.cap_tokens, 95_104); // 95000 rounds up to 128-multiple
+        assert_eq!(a.free_tokens(), 100_000 - 95_104);
+    }
+
+    #[test]
+    fn two_requests_split_by_real_demand() {
+        let mut a = KvRangeAllocator::new(100_000, 1088);
+        let big = a.alloc(90_000).unwrap();
+        let small = a.alloc(8_000).unwrap();
+        // big rounded: 90_000 -> 90_112 tokens; small starts right after it.
+        assert_eq!(small.byte_off as usize / 1088, 90_112);
+        assert_eq!(small.cap_tokens, 8_064);
+        assert!(a.alloc(3_000).is_none(), "only ~1.9k left");
+        assert_eq!(a.max_contiguous_tokens(), 100_000 - 90_112 - 8_064);
+        let _ = big;
+    }
+
+    #[test]
+    fn free_then_realloc_reuses_space() {
+        let mut a = KvRangeAllocator::new(10_000, 1088);
+        let r1 = a.alloc(4_000).unwrap();
+        let _r2 = a.alloc(4_000).unwrap();
+        assert!(a.alloc(3_000).is_none());
+        a.free(&r1);
+        let r3 = a.alloc(3_000).unwrap();
+        assert_eq!(r3.byte_off, 0, "must reuse the freed head");
+    }
+
+    #[test]
+    fn free_coalesces_adjacent_intervals() {
+        // 3900+3840... use sizes that round cleanly: 3 x 3968 (=128*31) = 11904 <= 12000
+        let mut a = KvRangeAllocator::new(12_000, 1088);
+        let r1 = a.alloc(3_900).unwrap();
+        let r2 = a.alloc(3_900).unwrap();
+        let _r3 = a.alloc(3_900).unwrap();
+        assert!(
+            a.alloc(1_200).is_none(),
+            "fragmented before frees: only {} left",
+            a.free_tokens()
+        );
+        a.free(&r2);
+        a.free(&r1);
+        assert_eq!(a.free_tokens(), 12_000 - 3_968);
+        let r = a.alloc(7_900).unwrap();
+        assert_eq!(r.byte_off, 0);
+        let _ = r;
+    }
+
+    #[test]
+    fn ranges_are_128_aligned_for_future_pages() {
+        let mut a = KvRangeAllocator::new(10_000, 1088);
+        let r = a.alloc(100).unwrap();
+        assert_eq!(r.byte_off % 128, 0);
+        assert_eq!(r.cap_tokens, 128);
+    }
+
+    #[test]
+    fn oversubscribe_is_rejected_not_clamped() {
+        let mut a = KvRangeAllocator::new(1_000, 1088);
+        assert!(a.alloc(2_000).is_none());
+    }
+}

--- a/crates/rdna-compute/src/lib.rs
+++ b/crates/rdna-compute/src/lib.rs
@@ -28,6 +28,7 @@ pub mod replay;
 pub mod sampling;
 pub mod scratch;
 pub mod slot_pool;
+pub mod kv_range;
 
 pub use compiler::KernelCompiler;
 pub use dispatch::{

--- a/crates/rdna-compute/src/slot_pool.rs
+++ b/crates/rdna-compute/src/slot_pool.rs
@@ -75,10 +75,108 @@ impl SlotPool {
         })
     }
 
+    /// Build an ELASTIC pool: a total token budget shared across slots with a
+    /// big primary slab.
+    ///
+    /// Layout (per K or V arena, `stride = per_pos_bytes`):
+    ///   slot 0        — `pool_total - (n_slots-1)*reserve` tokens at offset 0
+    ///   slot 1..n-1   — `reserve` tokens each, packed after the primary
+    ///
+    /// A solo request admitted to the primary can use nearly the whole pool
+    /// budget (e.g. ~96k of 100k with 2 slots and an 8k reserve); concurrent
+    /// requests fall back to the reserved slabs. Addressing is unchanged —
+    /// every kernel resolves `k_base + pos*stride` from the descriptor, and
+    /// attention masks on `desc.seq_len`, so variable caps need no kernel
+    /// changes. Sum of caps equals `pool_total` (rounded up per slab).
+    pub fn new_elastic(
+        n_slots: usize,
+        reserve_per_slot: usize,
+        pool_total: usize,
+        per_pos_bytes: usize,
+    ) -> Result<Self, String> {
+        assert!(n_slots > 0, "n_slots must be positive");
+        assert!(per_pos_bytes > 0, "per_pos_bytes must be positive");
+        assert!(reserve_per_slot > 0, "reserve_per_slot must be positive");
+        let reserve = reserve_per_slot.div_ceil(PAGE_TOKENS) * PAGE_TOKENS;
+        let primary_raw = pool_total
+            .checked_sub(reserve * (n_slots - 1))
+            .filter(|p| *p >= reserve)
+            .ok_or_else(|| {
+                format!(
+                    "SlotPool: pool_total {pool_total} too small for {n_slots} slots \
+                     with reserve {reserve}"
+                )
+            })?;
+        let primary = primary_raw.div_ceil(PAGE_TOKENS) * PAGE_TOKENS;
+
+        // One contiguous arena of pool_total (rounded) tokens per K or V.
+        let arena_tokens = primary + reserve * (n_slots - 1);
+        let arena_bytes = (arena_tokens * per_pos_bytes) as u64;
+        let total = arena_bytes
+            .checked_mul(2)
+            .ok_or_else(|| "SlotPool: arena size overflows u64".to_string())?;
+        preflight_alloc(total, R9700_VRAM_BYTES, "SlotPool arena")?;
+
+        let stride = per_pos_bytes as u64;
+        let mut descs = Vec::with_capacity(n_slots);
+        let mut base: u64 = 0;
+        for i in 0..n_slots {
+            let cap = if i == 0 { primary } else { reserve };
+            descs.push(KvSlotDesc {
+                k_base: base,
+                v_base: base,
+                seq_len: 0,
+                cap: cap as i32,
+            });
+            base += (cap as u64) * stride;
+        }
+        debug_assert_eq!(base as usize, arena_bytes as usize);
+
+        Ok(Self {
+            descs,
+            in_use: vec![false; n_slots],
+            cap_tokens: primary,
+            per_pos_bytes,
+            dirty: true,
+        })
+    }
+
+    /// Capacity of a specific slot (caps vary under `new_elastic`).
+    pub fn slot_cap(&self, id: SlotId) -> usize {
+        self.descs[id.0].cap as usize
+    }
+
+    /// Largest per-slot capacity in the pool.
+    pub fn max_cap(&self) -> usize {
+        self.cap_tokens
+    }
+
     /// Take a free slot, or `None` when the pool is full. Admission control
     /// lives in SP4; this only reports capacity.
     pub fn acquire(&mut self) -> Option<SlotId> {
         let i = self.in_use.iter().position(|&u| !u)?;
+        self.in_use[i] = true;
+        self.reset(SlotId(i));
+        Some(SlotId(i))
+    }
+
+    /// Take the SMALLEST free slot whose cap fits `needed_tokens`. Under an
+    /// elastic pool this preserves the big primary slab for requests that
+    /// actually need it; equal-slab pools behave identically to `acquire`.
+    pub fn acquire_fitting(&mut self, needed_tokens: usize) -> Option<SlotId> {
+        let mut best: Option<usize> = None;
+        let mut best_cap = usize::MAX;
+        for (i, (&u, d)) in self.in_use.iter().zip(self.descs.iter()).enumerate() {
+            if u {
+                continue;
+            }
+            let cap = d.cap as usize;
+            if cap >= needed_tokens && cap < best_cap {
+                best = Some(i);
+                best_cap = cap;
+            }
+        }
+        let i = best?;
         self.in_use[i] = true;
         self.reset(SlotId(i));
         Some(SlotId(i))
@@ -104,10 +202,14 @@ impl SlotPool {
     /// because SP1 removed the device asserts (they shipped in release and
     /// cost 64 B/lane of scratch).
     pub fn set_seq_len(&mut self, id: SlotId, seq_len: usize) -> Result<(), String> {
-        if seq_len > self.cap_tokens {
+        // Per-slot cap, not pool-wide max: under `new_elastic` reserved slots
+        // are much smaller than the primary and must be bounded by their own
+        // slab capacity.
+        let cap = self.descs[id.0].cap as usize;
+        if seq_len > cap {
             return Err(format!(
                 "SlotPool: slot {} seq_len {} exceeds cap {}",
-                id.0, seq_len, self.cap_tokens
+                id.0, seq_len, cap
             ));
         }
         if self.descs[id.0].seq_len != seq_len as i32 {
@@ -219,6 +321,43 @@ mod tests {
         );
         p.mark_uploaded();
         assert!(!p.descriptors_dirty());
+    }
+
+    #[test]
+    fn elastic_pool_gives_primary_the_budget_minus_reserves() {
+        let p = SlotPool::new_elastic(2, 8192, 100_000, PPB).unwrap();
+        let d = p.descriptors();
+        assert_eq!(d.len(), 2);
+        // primary = 100k - 8192 (rounded), reserve = 8192
+        let expect_primary: usize = ((100_000usize - 8_192).div_ceil(128)) * 128; // 91_904
+        assert_eq!(d[0].cap as usize, expect_primary);
+        assert_eq!(d[1].cap as usize, 8192);
+        // Non-overlapping: primary slab ends where reserve starts.
+        assert_eq!(
+            d[1].k_base as usize,
+            d[0].cap as usize * PPB
+        );
+        // Solo request can use the primary fully.
+        assert!(p.max_cap() >= 90_000);
+    }
+
+    #[test]
+    fn elastic_pool_refuses_budget_smaller_than_reserves() {
+        let e = SlotPool::new_elastic(4, 8192, 10_000, PPB).unwrap_err();
+        assert!(e.contains("too small"), "unexpected: {e}");
+    }
+
+    #[test]
+    fn elastic_pool_seq_len_respects_per_slot_cap() {
+        let mut p = SlotPool::new_elastic(2, 8192, 100_000, PPB).unwrap();
+        let primary = p.acquire().unwrap();
+        // Primary can hold ~92k.
+        let big = p.slot_cap(primary) - 1;
+        assert!(p.set_seq_len(primary, big).is_ok());
+        // Reserve slot cannot exceed 8192.
+        let res = p.acquire().unwrap();
+        assert!(p.set_seq_len(res, 8192).is_ok());
+        assert!(p.set_seq_len(res, 8193).is_err());
     }
 
     #[test]

--- a/crates/rdna-compute/src/slot_pool.rs
+++ b/crates/rdna-compute/src/slot_pool.rs
@@ -146,6 +146,48 @@ impl SlotPool {
         self.descs[id.0].cap as usize
     }
 
+    /// Build a DYNAMIC-RANGE pool: one arena of `total_tokens` with `n_slots`
+    /// descriptors whose bases/caps are assigned at admission time via
+    /// [`Self::set_desc_range`]. Arena bytes equal the whole budget; nothing
+    /// is reserved per-slot.
+    pub fn new_dynamic(n_slots: usize, total_tokens: usize, per_pos_bytes: usize)
+        -> Result<Self, String>
+    {
+        assert!(n_slots > 0);
+        let total_rounded = total_tokens.div_ceil(PAGE_TOKENS) * PAGE_TOKENS;
+        let arena_bytes = (total_rounded * per_pos_bytes) as u64;
+        preflight_alloc(arena_bytes.checked_mul(2).ok_or("overflow")?,
+                        R9700_VRAM_BYTES, "SlotPool arena")?;
+        // Descriptors start invalid (cap 0); admission assigns them.
+        let descs = (0..n_slots).map(|i| KvSlotDesc {
+            k_base: 0,
+            v_base: 0,
+            seq_len: 0,
+            cap: 0,
+        }).collect();
+        Ok(Self { descs, in_use: vec![false; n_slots],
+                  cap_tokens: total_rounded, per_pos_bytes, dirty: true })
+    }
+
+    /// Point a lane at an allocated KV range and mark it in-use.
+    /// `range.byte_off` is a byte offset into each arena.
+    pub fn bind_range(&mut self, id: SlotId, byte_off: u64, cap_tokens: usize) {
+        self.descs[id.0] = KvSlotDesc {
+            k_base: byte_off,
+            v_base: byte_off,
+            seq_len: 0,
+            cap: cap_tokens as i32,
+        };
+        self.in_use[id.0] = true;
+        self.dirty = true;
+    }
+
+    /// Release a lane and invalidate its descriptor.
+    pub fn release_lane(&mut self, id: SlotId) {
+        self.reset(id);
+        self.in_use[id.0] = false;
+    }
+
     /// Largest per-slot capacity in the pool.
     pub fn max_cap(&self) -> usize {
         self.cap_tokens

--- a/docker/quantizer.Dockerfile
+++ b/docker/quantizer.Dockerfile
@@ -1,0 +1,14 @@
+# Quantizer image: gate-runner base + patched source + prebuilt binary.
+FROM hipfire-gate
+
+SHELL ["/bin/bash", "-c"]
+# Overlay the CURRENT checkout (the base image froze an older snapshot),
+# then build so the fix is actually compiled in.
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+RUN source /root/.cargo/env && cd /hipfire && \
+    touch crates/hipfire-quantize/src/pipeline.rs && \
+    cargo build --release --locked -p hipfire-quantize && \
+    cp target/release/hipfire-quantize /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/hipfire-quantize"]


### PR DESCRIPTION
> **Superseded** by #636 (multi-slot VL delta) + #637 (residual engine fixes) — rebased on master and split per review triage ([comment](https://github.com/warpfront/hipfire/pull/626#issuecomment-5389792387)).

---

## Multi-slot VL support + quantizer/slot-engine fixes

One PR, five independent fixes. All validated end-to-end on gfx1101 (RX 7800 XT) serving `ornith-1.5-9b` (multimodal qwen3_5 checkpoint) through the multi-slot engine.

### 1. Multi-slot engine: vision support

The slot engine was text-only; image requests either failed or silently lost the image.

- ViT tower loads alongside trunk weights in `SlotEngine` (before the trunk loader drops the mmap — order matters)
- Image requests are preprocessed engine-side (CPU smart-resize + patch extraction), run through `vision_forward`, and their embeddings are spliced into the batched prefill via `SlotStepOpts.embed_override`
- FA layers dispatch to `rope_mrope_halfsplit_f32_batched` with per-row (t,h,w) positions on visual steps; text-only steps keep the 1D kernel and hipGraph decode path
- Scheduler tracks per-slot VL state through chunked prefill (`SlotBatch.vl_rows`)
- CLI slot path extracts OpenAI-style `image_url` parts and renders the exact pad span (CPU preprocess computes `n_vis`; GPU re-preprocesses for embeddings)

### 2. Quantizer: silent tensor drop + MoE panic on multimodal checkpoints

Quantizing a multimodal qwen3_5 safetensors checkpoint produced an HFQ that failed at load with `tensor not found: norm.weight`, and earlier builds panicked with an index-out-of-bounds.

- `handle_moe_expert_3d`: guard rank/name before indexing `inner_shape[1]` (dense `lm_head.weight` reached it and panicked); non-matching tensors fall through
- `handle_main_quant`: restore the missing F16 fallback branch — norms, biases, and sub-32-element weights were silently dropped from every safetensors quant (stock artifacts carried 79 norm tensors; affected quants carried zero)

### 3. Slot engine: VRAM + context-cap

- Drop the spec-decode DeltaNet S-tape from `PrefillBatchScratch` in `SlotEngine::build` — never consumed by the slot path, ~4 GiB wasted at 2048-token context
- Context-cap guard in the decode loop: stop cleanly instead of overflowing `set_seq_len` (long sessions previously killed the entire batched step)


### 4. Slot engine: decouple prefill chunk width from KV capacity

`chunk_size` was set to `cap_tokens`, so a 50k-token context attempted a single
50k-row prefill step, sizing `PrefillBatchScratch` at ~22 GiB. Prefill now runs
at a fixed 2048-row chunk through the existing scheduler chunking; scratch stays
constant (~0.9 GiB) and only the KV arenas scale with context.

Validated on gfx1101: **2 slots x 51200 ctx = 102k total context** at 9.1 GiB
resident; a 34k-token prompt prefills in chunks and answers coherently; vision
and 2-way concurrency unaffected.


### 5. Slot engine context scaling

- Fixed a boot-fatal OOM: prefill scratch was sized by total KV capacity
  (~22 GiB of f32 at 50k ctx); prefill now runs at a fixed 2048-row chunk
  width through the existing scheduler, so scratch is constant and only
  KV arenas scale with context.
- Shipped configuration: equal slabs, 2 x 32768 ctx = 64k total context,
  validated at 8.5 GiB resident on gfx1101 with concurrent text + vision.
- Elastic (primary + reserves) and dynamic-range pool sharing were
  implemented and are retained behind `serve.multi_slot_pool_total`, but
  are gated as experimental: long-prompt prefill against variable-cap
  slabs produces degenerate output in the flash attention path. Equal
  slabs are the shipped default; upstream follow-up needed on
  variable-cap descriptor handling.

### Also

- `gen_start` emitted before the daemon VL route so the CLI stream-contract gate accepts serve-layer VL requests (previously hung, then aborted)
- `serve.multi_slot_slots` / `serve.multi_slot_ctx` added to the config schema (previously unsettable)
- `docker/quantizer.Dockerfile`: standalone CPU quantizer image

## Validation

gfx1101, ROCm 7.2, ornith-1.5-9b mq4 (760-tensor multimodal checkpoint → 6.2 GB):

- Quantize → serve → generate verified end-to-end through the multi-slot engine
- Vision grounding: color/count/position queries correct; black/white discriminators correct
- Concurrency: parallel text + vision lanes both correct; no cross-talk
- `cargo test -p hipfire-arch-qwen35`: 119 passed
- VRAM: ~11.9 GiB → ~6.5 GiB resident (tape fix); ~9.1 GiB at 2x50k context

Signed-off-by: ghazni101 <ghazni101@users.noreply.github.com>