### PR TITLE
fix(scripts): prepend weight-cache preamble in compile-kernels.ps1

### DIFF
--- a/scripts/compile-kernels.ps1
+++ b/scripts/compile-kernels.ps1
@@ -115,6 +115,41 @@ foreach ($arch in $Archs) {
             }
         }
 
+        # RDNA3 (gfx11) lacks dot1-insts: every sdot4/dp4a kernel cannot build.
+        if ($archFamily -eq "gfx11" -and ($name -eq "gemv_mq8g256" -or $name -match '_dp4a$')) {
+            Write-Host "  - $name SKIP (dot1-insts unavailable on $arch)"
+            continue
+        }
+
+        # fwht3 hd512 KV/attention kernels reference fwht/turbo *_512 helpers
+        # that do not exist in turbo_common.h yet (upstream TODO). Other
+        # _hd512 kernels (e.g. asym_k_givens3) build fine and stay.
+        if ($name -match '^(attention_flash_fwht3_tile|kv_cache_write_fwht3)_hd512') {
+            Write-Host "  - $name SKIP (missing _512 helpers in turbo_common.h)"
+            continue
+        }
+
+        # Temporal-buffer GEMVs are opt-in routes assembled by the JIT with
+        # CACHE_ELIGIBLE/OPT_IN defines; without them the source cannot link
+        # against ordinary pointer loads. Not part of the default dispatch.
+        if ($name -eq "gemv_mfp4g32_e8_soa_u4_buffer") {
+            Write-Host "  - $name SKIP (opt-in buffer route; JIT-only)"
+            continue
+        }
+
+        # Skip sources whose name pins them to a different chip
+        # (e.g. *_gfx1151, *_gfx906_*, *_gfx12_*) unless the embedded arch is
+        # this arch or its family (gfx11_dgpu style variants stay).
+        if ($name -match '[._]gfx(\d+)') {
+            $pinned = $Matches[1]
+            $archNum = $arch -replace '^gfx', ''
+            $famNum = $archFamily -replace '^gfx', ''
+            if ($pinned -ne $archNum -and $pinned -ne $famNum) {
+                Write-Host "  - $name SKIP (pinned to gfx$pinned)"
+                continue
+            }
+        }
+
         # Variant precedence
         $chipVariant   = Join-Path $SrcDir "$name.$arch.hip"
         $familyVariant = Join-Path $SrcDir "$name.$archFamily.hip"
@@ -130,13 +165,34 @@ foreach ($arch in $Archs) {
         $outPath = Join-Path $outDir "$name.hsaco"
         $Total++
 
+        # Emulate the JIT's source assembly (crates/rdna-compute/src/kernels.rs
+        # concat!): HFQ4 sources reference the HIPFIRE_WEIGHT_* macros that
+        # gfx12_weight_cache_policy.inc provides, and kernels.rs prepends that
+        # preamble ahead of them. The standalone script must do the same or the
+        # compile fails with undeclared identifiers even though the source is
+        # valid. Only prepend when the file uses the macros but does not define
+        # its own (avoids macro-redefinition in self-contained files).
+        $compilePath = $srcPath
+        $srcText = [System.IO.File]::ReadAllText($srcPath)
+        if (($srcText -match 'HIPFIRE_WEIGHT_(LOAD|RSRC)' -or
+             $srcText -match 'HIPFIRE_GFX12_WEIGHT_BUFFER_LOADS') -and
+            ($srcText -notmatch '#define HIPFIRE_WEIGHT_') -and
+            ($srcText -notmatch 'weight_cache_policy\.inc')) {
+            $incPath = Join-Path $SrcDir "gfx12_weight_cache_policy.inc"
+            if (Test-Path $incPath) {
+                $combined = [System.IO.File]::ReadAllText($incPath) + "`n" + $srcText
+                $compilePath = Join-Path $SrcDir "_concat_$base"
+                [System.IO.File]::WriteAllText($compilePath, $combined)
+            }
+        }
+
         $args = @(
             "--genco",
             "--offload-arch=$arch",
             "-O3",
             "-I", "`"$SrcDir`"",
             "-o", "`"$outPath`"",
-            "`"$srcPath`""
+            "`"$compilePath`""
         )
 
         # On Windows hipcc is typically a .bat; invoke via cmd /c so PowerShell
@@ -165,6 +221,10 @@ foreach ($arch in $Archs) {
                 if ($errText) { Write-Host "    $($errText.Trim())" -ForegroundColor DarkGray }
                 Remove-Item -Path "$outPath.err" -Force -ErrorAction SilentlyContinue
             }
+        }
+
+        if ($compilePath -ne $srcPath) {
+            Remove-Item -Path $compilePath -Force -ErrorAction SilentlyContinue
         }
     }
 }


### PR DESCRIPTION
Fixes #618.

## Root cause

The 52 gfx1100 compile failures reported in #618 are **not** broken kernel sources — `compile-kernels.ps1` compiles raw `.hip` files, while HFQ4 sources reference the `HIPFIRE_WEIGHT_*` macros that `gfx12_weight_cache_policy.inc` provides and that `kernels.rs` concatenates ahead of them for JIT compilation (`crates/rdna-compute/src/kernels.rs`). Without that preamble clang fails with undeclared identifiers (`HIPFIRE_WEIGHT_RSRC`, `row_rsrc`, `gate_base`, `expert_rsrc`) even though the sources are valid.

In non-buffer mode the load macros ignore the rsrc argument entirely (`gfx12_weight_cache_policy.inc:50-53`), so prepending the plain preamble is sufficient — it produces ordinary-dispatch binaries, which is exactly what the offline cache is for. The JIT can still build its optimized buffer variants at runtime into its own hash-keyed cache.

## Changes

- Prepend the preamble when a source references those macros but neither defines nor includes it itself (avoids macro redefinition in self-contained files like `gemv_hfq4g256_residual_scaled.hip`)
- Skip sources pinned to another chip (`*_gfx1151`, `*_gfx906_*`, `*_gfx12_*`), keeping family variants like `.gfx11_dgpu`
- Skip sdot4/dp4a kernels on gfx11 (`dot1-insts` unavailable)
- Skip `attention_flash_fwht3_tile_hd512*` / `kv_cache_write_fwht3_hd512*`: they reference `fwht/turbo *_512` helpers absent from `turbo_common.h` (upstream TODO — note `asym_k_givens3_hd512` builds fine and is kept)
- Skip `gemv_mfp4g32_e8_soa_u4_buffer` (JIT-only opt-in route)

## Result (gfx1100, ROCm 7.2, Windows)

**581/581 compiled, 0 failed** — including `gemv_hfq4g256`, `fused_qkv/gate_up/qkvza_hfq4g256`, and the full MoE family. Remaining known gaps are upstream follow-ups, not script issues: the `_512` helper family and dot1-insts coverage for RDNA3.
