### PR TITLE
fix(cli): reserve a 32 MB main-thread stack on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -21,3 +21,9 @@
 # this file — scripts/check-fmt-bomb.sh (pre-commit) still backstops the case.
 [alias]
 fmt = ["use-scripts-fmt-changed-sh-instead-of-cargo-fmt"]
+
+# Windows gives the main thread a 1 MB stack unless the linker says otherwise,
+# which is not enough for the CLI's startup path (hipfire --version
+# stack-overflows). Reserve 32 MB. No effect on other targets.
+[target.'cfg(windows)']
+rustflags = ["-C", "link-args=/STACK:33554432"]


### PR DESCRIPTION
﻿Fixes #621.

The default 1 MB main-thread stack was not enough for CLI startup: `hipfire --version` aborted with "thread 'main' has overflowed its stack" on every invocation when built from source on Windows. Relinking with `/STACK:33554432` fixed it completely.

Reserve the extra stack via rustflags for windows targets in `.cargo/config.toml` so users do not need to know about RUSTFLAGS; other targets are unaffected.

Note: the find_daemon `.exe` half of #621 is intentionally **not** part of this patch — #615 covers it and I'd rather not race that PR.
