### PR TITLE
feat(serve): multi-slot VL support — vision tower, image prefill splicing, mrope dispatch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,9 +1254,11 @@ name = "hipfire-cli"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "base64",
  "clap",
  "ctrlc",
  "hipfire-arch-qwen35",
+ "hipfire-arch-qwen35-vl",
  "hipfire-client",
  "hipfire-config",
  "hipfire-registry",

--- a/crates/hipfire-arch-qwen35/src/forward_slots.rs
+++ b/crates/hipfire-arch-qwen35/src/forward_slots.rs
@@ -1554,6 +1554,7 @@ fn run_fullattn_layer_slots(
     max_ctx_len: usize,
     single_slot: Option<(u64, usize)>,
     n_tiles: Option<usize>,
+    mrope_pos3: Option<&GpuTensor>,
 ) -> HipResult<()> {
     let attn_dtype = require_batchable_fullattn_layer(layer)?;
 
@@ -1686,18 +1687,36 @@ fn run_fullattn_layer_slots(
     // global-row-indexed. No compaction in the slot path yet, so
     // pos_offset is always 0.
     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
-    gpu.rope_partial_interleaved_f32_batched(
-        &pbs.fa_q_batch,
-        &pbs.fa_k_batch,
-        &pbs.positions,
-        config.n_heads,
-        config.n_kv_heads,
-        config.head_dim,
-        n_rot,
-        config.rope_theta,
-        n,
-        0,
-    )?;
+    if let Some(pos3) = mrope_pos3 {
+        // VL prefill: 3D mrope with per-row (t, h, w). Batched twin of the
+        // sequential path's rope_mrope_halfsplit_f32.
+        gpu.rope_mrope_halfsplit_f32_batched(
+            &pbs.fa_q_batch,
+            &pbs.fa_k_batch,
+            &pos3.buf,
+            config.n_heads,
+            config.n_kv_heads,
+            config.head_dim,
+            n_rot,
+            config.rope_theta,
+            n,
+            0,
+            config.mrope_section,
+        )?;
+    } else {
+        gpu.rope_partial_interleaved_f32_batched(
+            &pbs.fa_q_batch,
+            &pbs.fa_k_batch,
+            &pbs.positions,
+            config.n_heads,
+            config.n_kv_heads,
+            config.head_dim,
+            n_rot,
+            config.rope_theta,
+            n,
+            0,
+        )?;
+    }
 
     // 6. Batched KV write — slot-aware, one launch each for K and V across
     // every slot. Both arenas resolve through `k_base`/`v_base`; correct
@@ -1844,6 +1863,7 @@ fn run_fullattn_moe_layer_slots(
     single_slot: Option<(u64, usize)>,
     n_tiles: Option<usize>,
     weights_moe_has_mq6: bool,
+    mrope_pos3: Option<&GpuTensor>,
 ) -> HipResult<()> {
     let attn_dtype = require_batchable_fullattn_moe_layer(layer)?;
     require_batchable_moe_ffn(gpu, &layer.ffn)?;
@@ -1976,18 +1996,36 @@ fn run_fullattn_moe_layer_slots(
 
     // 5. RoPE — slot-agnostic (SP2 Task 2).
     let n_rot = (config.head_dim as f32 * config.partial_rotary_factor) as usize;
-    gpu.rope_partial_interleaved_f32_batched(
-        &pbs.fa_q_batch,
-        &pbs.fa_k_batch,
-        &pbs.positions,
-        config.n_heads,
-        config.n_kv_heads,
-        config.head_dim,
-        n_rot,
-        config.rope_theta,
-        n,
-        0,
-    )?;
+    if let Some(pos3) = mrope_pos3 {
+        // VL prefill: 3D mrope with per-row (t, h, w). Batched twin of the
+        // sequential path's rope_mrope_halfsplit_f32.
+        gpu.rope_mrope_halfsplit_f32_batched(
+            &pbs.fa_q_batch,
+            &pbs.fa_k_batch,
+            &pos3.buf,
+            config.n_heads,
+            config.n_kv_heads,
+            config.head_dim,
+            n_rot,
+            config.rope_theta,
+            n,
+            0,
+            config.mrope_section,
+        )?;
+    } else {
+        gpu.rope_partial_interleaved_f32_batched(
+            &pbs.fa_q_batch,
+            &pbs.fa_k_batch,
+            &pbs.positions,
+            config.n_heads,
+            config.n_kv_heads,
+            config.head_dim,
+            n_rot,
+            config.rope_theta,
+            n,
+            0,
+        )?;
+    }
 
     // 6. Batched KV write — slot-aware, Q8_0 KV-cache tier regardless of
     // this layer's projection weight dtype (see module doc).
@@ -2446,9 +2484,12 @@ pub fn forward_batch_slots_graphed(
     s: &Qwen35Scratch,
     logits_out: &GpuTensor,
     cache: &mut SlotDecodeGraph,
+    vl_active: bool,
 ) -> HipResult<()> {
     let pure_decode = !batch.is_empty() && batch.m_per_slot.iter().all(|&m| m == 1);
-    if !gpu.slots_decode_graph() || !pure_decode {
+    // VL prefill carries embedding overrides + mrope positions, which the
+    // captured-graph path cannot represent — always take the plain path.
+    if !gpu.slots_decode_graph() || !pure_decode || vl_active {
         return forward_batch_slots(
             gpu,
             weights,
@@ -2510,6 +2551,8 @@ pub fn forward_batch_slots_graphed(
             SlotStepOpts {
                 skip_uploads: true,
                 ctx_override: Some(ctx_bucket),
+                embed_override: None,
+                mrope_pos3: None,
             },
         )?;
         // The warm-up step above already advanced the slot lengths; re-running
@@ -2535,6 +2578,8 @@ pub fn forward_batch_slots_graphed(
             SlotStepOpts {
                 skip_uploads: true,
                 ctx_override: Some(ctx_bucket),
+                embed_override: None,
+                mrope_pos3: None,
             },
         );
         let graph = gpu.end_stream_capture()?;
@@ -2583,7 +2628,7 @@ fn rewind_slot_seq_lens(batch: &SlotBatch, pool: &mut SlotPool) -> HipResult<()>
 }
 
 /// Knobs the graph path needs and no other caller does.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Default)]
 pub struct SlotStepOpts {
     /// The per-step H2D uploads (tokens, positions, row_slot, descriptors)
     /// were already done by the caller. Set when capturing into a hipGraph:
@@ -2598,6 +2643,15 @@ pub struct SlotStepOpts {
     /// `positions[]` is the authoritative causal bound (SP1's Critical
     /// defect), so the extra positions are masked out.
     pub ctx_override: Option<usize>,
+    /// VL prefill: visual embeddings to write over `x_batch` rows after the
+    /// token-embedding lookup. Host layout `[count × dim]`, written to rows
+    /// `row0..row0+count` of this step. Rows outside the span keep their
+    /// token embeddings.
+    pub embed_override: Option<(Vec<f32>, usize)>,
+    /// VL prefill: packed 3D mrope positions `[n_rows][3]` i32 for this
+    /// step's rows. When set, FA RoPE dispatches to the batched mrope kernel
+    /// instead of the 1D one; DeltaNet layers ignore rope entirely.
+    pub mrope_pos3: Option<Vec<i32>>,
 }
 
 /// The per-step H2D uploads, hoisted so the graph path can run them outside
@@ -2768,6 +2822,19 @@ pub fn forward_batch_slots_opts(
     }
     gpu.embedding_lookup_q8_batched(&weights.token_embd, &pbs.x_batch, &pbs.tokens, n, dim)?;
 
+    // ── 1b. VL embedding override ─────────────────────────────────────────
+    // Overwrite the image-pad rows with vision-tower embeddings before any
+    // layer sees them. Rows outside the span keep their token embeddings.
+    if let Some((embs, row0)) = &opts.embed_override {
+        eprintln!("[vl-slot] embedding override: row0={row0} elems={} sum={:.4}", embs.len(), embs.iter().sum::<f32>());
+        let dim_bytes = dim * 4;
+        gpu.hip.memcpy_htod_offset(
+            &pbs.x_batch.buf,
+            row0 * dim_bytes,
+            unsafe { std::slice::from_raw_parts(embs.as_ptr() as *const u8, embs.len() * 4) },
+        )?;
+    }
+
     // ── 2. Upload positions ──────────────────────────────────────────────
     // Per-row ABSOLUTE position within that row's own slot — authoritative
     // for the causal bound everywhere downstream (RoPE angle, KV write
@@ -2891,6 +2958,20 @@ pub fn forward_batch_slots_opts(
         None
     };
 
+    // ── 3b. VL mrope pos3 upload (layer-invariant, once per step) ────────
+    let mrope_pos3_dev = match &opts.mrope_pos3 {
+        Some(host) => {
+            let t = gpu.alloc_tensor(
+                &[host.len()],
+                DType::F32, // i32-in-f32 pattern used by `positions`
+            )?;
+            let bytes: Vec<u8> = host.iter().flat_map(|x| x.to_ne_bytes()).collect();
+            gpu.hip.memcpy_htod(&t.buf, &bytes)?;
+            Some(t)
+        }
+        None => None,
+    };
+
     // ── 4. Per-layer loop ─────────────────────────────────────────────────
     let layer_end = config.n_layers.min(max_layer.unwrap_or(usize::MAX));
     let mut delta_layer_idx = 0usize;
@@ -2927,6 +3008,7 @@ pub fn forward_batch_slots_opts(
                     max_ctx_len,
                     single_slot,
                     n_tiles,
+                    mrope_pos3_dev.as_ref(),
                 )?;
                 kv_layer_idx += 1;
             }
@@ -2962,6 +3044,7 @@ pub fn forward_batch_slots_opts(
                     single_slot,
                     n_tiles,
                     weights.moe_has_mq6,
+                    mrope_pos3_dev.as_ref(),
                 )?;
                 kv_layer_idx += 1;
             }

--- a/crates/hipfire-arch-qwen35/src/forward_slots.rs
+++ b/crates/hipfire-arch-qwen35/src/forward_slots.rs
@@ -2181,12 +2181,15 @@ fn final_logits_per_slot(
     // Kept as an allow-list rather than removed: an unsupported dtype should
     // still fail here with a clear message naming the lm_head, not deep inside
     // the dispatcher.
-    if !matches!(weights.output.gpu_dtype, DType::Q8_0 | DType::MQ4G256) {
+    if !matches!(
+        weights.output.gpu_dtype,
+        DType::Q8_0 | DType::MQ4G256 | DType::MQ4G256V2
+    ) {
         return Err(HipError::new(
             0,
             &format!(
                 "forward_batch_slots: lm_head (weights.output) dtype {:?} is not \
-                 supported by the multi-slot path (expected Q8_0 or MQ4G256)",
+                 supported by the multi-slot path (expected Q8_0, MQ4G256 or MQ4G256V2)",
                 weights.output.gpu_dtype
             ),
         ));

--- a/crates/hipfire-arch-qwen35/src/scheduler.rs
+++ b/crates/hipfire-arch-qwen35/src/scheduler.rs
@@ -31,6 +31,23 @@ pub struct PendingWork {
     pub next_pos: usize,
     /// Once prefill is complete, the slot decodes one token per step.
     pub decoding: bool,
+    /// VL prefill state for this slot. `embeds` are the vision-tower outputs
+    /// `[n_vis x dim]`; `span_start` is the index within this slot's prompt
+    /// where the image-pad run begins; `pos3` is the full prompt's 3D mrope
+    /// positions (flat, `[n_tokens][3]`).
+    pub vl: Option<VlPrefill>,
+}
+
+/// Visual-embedding injection state for one slot's prefill (VL requests).
+#[derive(Default)]
+pub struct VlPrefill {
+    pub embeds: Vec<f32>,
+    pub span_start: usize,
+    pub span_len: usize,
+    /// Absolute start position of the prompt in the slot's KV (continuations).
+    pub pos_base: usize,
+    /// Packed 3D mrope positions for the WHOLE prompt, `[n][3]` i32.
+    pub pos3: Vec<i32>,
 }
 
 impl Scheduler {
@@ -48,6 +65,7 @@ impl Scheduler {
             };
             let toks: Vec<u32> = w.remaining_prompt.drain(..take).collect();
             let start_pos = w.next_pos;
+            let row0 = b.tokens.len();
             b.m_per_slot.push(toks.len());
             for (i, t) in toks.iter().enumerate() {
                 b.tokens.push(*t);
@@ -55,6 +73,25 @@ impl Scheduler {
                 b.row_slot.push(w.slot.0 as i32);
             }
             w.next_pos += toks.len();
+            // Record which of these rows are visual embeddings, so the engine
+            // can overwrite their token embeddings after the lookup.
+            if let Some(vl) = &w.vl {
+                let span_end = vl.span_start + vl.span_len;
+                let chunk_start = start_pos - vl.pos_base;
+                let chunk_end = chunk_start + toks.len();
+                let ov_start = chunk_start.max(vl.span_start);
+                let ov_end = chunk_end.min(span_end);
+                if ov_start < ov_end {
+                    let rows = ov_end - ov_start;
+                    let emb_row0 = ov_start - vl.span_start;
+                    if b.vl_rows.is_none() {
+                        b.vl_rows = Some(Vec::new());
+                    }
+                    if let Some(list) = &mut b.vl_rows {
+                        list.push((row0, rows, emb_row0));
+                    }
+                }
+            }
         }
         b
     }
@@ -73,6 +110,7 @@ mod tests {
     fn a_long_prompt_is_chunked_not_run_whole() {
         let mut s = Scheduler { chunk_size: 256 };
         let mut work = vec![PendingWork {
+            vl: None,
             slot: SlotId(0),
             remaining_prompt: prompt(1000),
             next_pos: 0,
@@ -93,12 +131,14 @@ mod tests {
         let mut s = Scheduler { chunk_size: 256 };
         let mut work = vec![
             PendingWork {
+                vl: None,
                 slot: SlotId(0),
                 remaining_prompt: prompt(300),
                 next_pos: 0,
                 decoding: false,
             },
             PendingWork {
+                vl: None,
                 slot: SlotId(1),
                 remaining_prompt: vec![42],
                 next_pos: 10,
@@ -117,6 +157,7 @@ mod tests {
     fn a_prompt_shorter_than_a_chunk_completes_in_one_batch() {
         let mut s = Scheduler { chunk_size: 256 };
         let mut work = vec![PendingWork {
+            vl: None,
             slot: SlotId(0),
             remaining_prompt: prompt(10),
             next_pos: 0,
@@ -131,6 +172,7 @@ mod tests {
     fn an_idle_slot_contributes_nothing() {
         let mut s = Scheduler { chunk_size: 256 };
         let mut work = vec![PendingWork {
+            vl: None,
             slot: SlotId(0),
             remaining_prompt: vec![],
             next_pos: 0,

--- a/crates/hipfire-arch-qwen35/src/serve_engine.rs
+++ b/crates/hipfire-arch-qwen35/src/serve_engine.rs
@@ -20,6 +20,10 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
 use hipfire_runtime::admission::{AdmissionController, ModelFootprint};
+use crate::forward_slots::{forward_batch_slots_opts, SlotStepOpts};
+use hipfire_arch_qwen35_vl::qwen35_vl::{load_vision_weights, vision_config_from_hfq, VisionConfig, VisionWeights};
+use hipfire_arch_qwen35_vl::image as vl_image;
+use hipfire_arch_qwen35_vl::mrope::ImageSpan;
 use hipfire_runtime::serve::{send_event, DoneReason, EngineStats, Event, SubmitRequest};
 use hipfire_runtime::session_table::{SessionId, SessionTable};
 use hipfire_runtime::swap::snapshot::{capture_slot, restore_slot, SnapshotStamp};
@@ -129,6 +133,11 @@ struct Rig {
     sample_params: Vec<SlotSampleParams>,
     sessions: SessionTable,
     adm: AdmissionController,
+    /// Vision tower for VL requests. `None` when the HFQ carries no visual
+    /// tensors (text-only checkpoint).
+    vision: Option<(VisionConfig, VisionWeights)>,
+    /// `<|image_pad|>` token id used to locate the visual span in a prompt.
+    image_pad_id: u32,
     swap: SwapManager,
     stamp: SnapshotStamp,
     n_slots: usize,
@@ -173,11 +182,26 @@ impl Rig {
             * (cfg.n_slots as u64)
             * (cap_rounded as u64)
             * (per_pos_bytes as u64);
-        let planned = weight_bytes + kv_bytes + 768 * 1024 * 1024;
+        // Vision tower adds ~0.6 GiB when present; charge a flat margin so the
+        // preflight never passes on an allocation that then OOMs mid-load.
+        let planned = weight_bytes + kv_bytes + 768 * 1024 * 1024 + 768 * 1024 * 1024;
         preflight_alloc(planned, R9700_VRAM_BYTES, "SlotEngine")
             .map_err(|e| format!("preflight refused: {e}"))?;
 
         let mut gpu = Gpu::init().map_err(|e| format!("gpu init: {e}"))?;
+        // Vision FIRST: the trunk loader drops the mmap and may reclaim tensor
+        // pages, so the ViT must read its tensors while the file is pristine
+        // (same order the daemon carrier uses).
+        let vision = {
+            let cfg = vision_config_from_hfq(&hfq);
+            match cfg {
+                Some(vc) => match load_vision_weights(&mut hfq, &vc, &mut gpu) {
+                    Ok(vw) => Some((vc, vw)),
+                    Err(e) => return Err(format!("load vision weights: {e}")),
+                },
+                None => None,
+            }
+        };
         let weights: Qwen35Weights = {
             let mut src = qwen35::HfqSource::new(&mut hfq, &config);
             let layout = qwen35::Layout::single(config.n_layers);
@@ -206,8 +230,6 @@ impl Rig {
         }
         let desc_staging = SlotDescStaging::new(&mut gpu, cfg.n_slots, max_batch)
             .map_err(|e| format!("staging: {e}"))?;
-        // Slots do plain prefill only — never tree-verify — so skip the GDN
-        // S-tape: at max_batch=cap_tokens it is tens of GB (16k → ~21 GB).
         let pbs = PrefillBatchScratch::new_opt(&mut gpu, &config, max_batch, false)
             .map_err(|e| format!("pbs: {e}"))?;
         let scratch = Qwen35Scratch::new_with_kv_max(&mut gpu, &config, 64, cfg.cap_tokens)
@@ -254,6 +276,8 @@ impl Rig {
 
         Ok(Rig {
             gpu,
+            vision,
+            image_pad_id: rig_image_pad_id(&tokenizer),
             weights,
             config,
             tokenizer,
@@ -291,6 +315,7 @@ fn run_loop(mut rig: Rig, rx: Receiver<SubmitRequest>, stats: Arc<Mutex<EngineSt
     let mut slots: Vec<Option<InFlight>> = (0..n).map(|_| None).collect();
     let mut work: Vec<PendingWork> = (0..n)
         .map(|s| PendingWork {
+            vl: None,
             slot: SlotId(s),
             remaining_prompt: Vec::new(),
             next_pos: 0,
@@ -331,21 +356,90 @@ fn run_loop(mut rig: Rig, rx: Receiver<SubmitRequest>, stats: Arc<Mutex<EngineSt
         if batch.is_empty() {
             continue;
         }
-        let fwd = forward_batch_slots_graphed(
-            &mut rig.gpu,
-            &rig.weights,
-            &rig.config,
-            &batch,
-            &mut rig.pool,
-            &mut rig.dn_states,
-            &rig.k_arenas,
-            &rig.v_arenas,
-            &mut rig.desc_staging,
-            &rig.pbs,
-            &rig.scratch,
-            &rig.logits_out,
-            &mut graph,
-        );
+        // VL prefill: gather embedding overrides + mrope pos3 for the visual
+        // rows this step carries. Any VL activity forces the plain (non-graph)
+        // forward, which honors SlotStepOpts.
+        let mut embed_override: Option<(Vec<f32>, usize)> = None;
+        let mut mrope_pos3: Option<Vec<i32>> = None;
+        for (slot_ix, &m) in batch.m_per_slot.iter().enumerate() {
+            if m == 0 {
+                continue;
+            }
+            // Take (and clear) this slot's VL state: it applies to THIS prefill
+            // step only. Later (decode) steps take the plain path. Note the
+            // scheduler has ALREADY drained remaining_prompt by the time we get
+            // here, so emptiness does not mean "no VL rows this step".
+            let Some(vl) = work[slot_ix].vl.take() else {
+                continue;
+            };
+            let vl = &vl;
+            // Rows of this slot in the batch, in order.
+            let rows: Vec<usize> = (0..batch.tokens.len())
+                .filter(|&r| batch.row_slot[r] == slot_ix as i32)
+                .collect();
+            let chunk_start = batch.positions[*rows.first().unwrap()] as usize
+                - vl.pos_base;
+            let span_end = vl.span_start + vl.span_len;
+            let ov_start = chunk_start.max(vl.span_start);
+            let ov_end = (chunk_start + rows.len()).min(span_end);
+            if ov_start < ov_end {
+                let dim = rig.config.dim;
+                let count = ov_end - ov_start;
+                let mut embs = Vec::with_capacity(count * dim);
+                let e0 = (ov_start - vl.span_start) * dim;
+                embs.extend_from_slice(&vl.embeds[e0..e0 + count * dim]);
+                embed_override = Some((embs, rows[ov_start - chunk_start]));
+            }
+            // mrope positions for ALL rows of a VL slot (text rows too).
+            let mut pos3 = Vec::with_capacity(rows.len() * 3);
+            for &r in &rows {
+                let p = batch.positions[r] as usize - vl.pos_base;
+                pos3.extend_from_slice(&vl.pos3[p * 3..p * 3 + 3]);
+            }
+            mrope_pos3 = Some(pos3);
+        }
+        let vl_active = embed_override.is_some() || mrope_pos3.is_some();
+        let fwd = if vl_active {
+            let (embeds, row0) = embed_override.unwrap();
+            forward_batch_slots_opts(
+                &mut rig.gpu,
+                &rig.weights,
+                &rig.config,
+                &batch,
+                &mut rig.pool,
+                &mut rig.dn_states,
+                &rig.k_arenas,
+                &rig.v_arenas,
+                &mut rig.desc_staging,
+                &rig.pbs,
+                &rig.scratch,
+                &rig.logits_out,
+                None,
+                SlotStepOpts {
+                    skip_uploads: false,
+                    ctx_override: None,
+                    embed_override: Some((embeds, row0)),
+                    mrope_pos3,
+                },
+            )
+        } else {
+            forward_batch_slots_graphed(
+                &mut rig.gpu,
+                &rig.weights,
+                &rig.config,
+                &batch,
+                &mut rig.pool,
+                &mut rig.dn_states,
+                &rig.k_arenas,
+                &rig.v_arenas,
+                &mut rig.desc_staging,
+                &rig.pbs,
+                &rig.scratch,
+                &rig.logits_out,
+                &mut graph,
+                false,
+            )
+        };
         if let Err(e) = fwd {
             // A forward failure is not recoverable per-request. Report it as a
             // REJECTION carrying the reason, not as a normal Done: an
@@ -411,7 +505,6 @@ fn run_loop(mut rig: Rig, rx: Receiver<SubmitRequest>, stats: Arc<Mutex<EngineSt
             };
             f.produced += 1;
             let hit_max = f.produced >= f.max_tokens;
-
             if gone || hit_eos || hit_max {
                 let reason = if gone {
                     DoneReason::ClientGone
@@ -669,9 +762,77 @@ fn admit(
         return;
     }
 
+    // ── VL: preprocess the image and build the visual-embedding injection
+    // state for this slot's prefill. Runs on the engine thread; the vision
+    // tower is one-shot per request (~0.1-6 s depending on resolution).
+    let vl = match (&req.image_bytes, &rig.vision) {
+        (Some(bytes), Some((vc, vw))) => {
+            let r_vl = (|| -> Result<crate::scheduler::VlPrefill, String> {
+                let (chw, img_h, img_w) =
+                    vl_image::load_and_preprocess_from_bytes(bytes, vc.patch_size, vc.spatial_merge_size)?;
+                let patches = vl_image::extract_patches(
+                    &chw, 3, img_h, img_w, vc.patch_size, vc.temporal_patch_size, vc.spatial_merge_size,
+                );
+                let grid_h = img_h / vc.patch_size;
+                let grid_w = img_w / vc.patch_size;
+                let embs = hipfire_arch_qwen35_vl::qwen35_vl::vision_forward(
+                    &mut rig.gpu, vw, vc, &patches, grid_h, grid_w,
+                )
+                .map_err(|e| format!("vision forward failed: {e:?}"))?;
+                let n_vis = embs.len() / config_dim(&rig.config);
+                // Locate the image-pad run in the prompt.
+                let span_start = req
+                    .prompt_tokens
+                    .iter()
+                    .position(|&t| t == rig.image_pad_id)
+                    .ok_or("image request has no <|image_pad|> span in prompt")?;
+                let span_len = req.prompt_tokens[span_start..]
+                    .iter()
+                    .take_while(|&&t| t == rig.image_pad_id)
+                    .count();
+                let span_end = span_start + span_len;
+                if embs.len() != span_len * config_dim(&rig.config) {
+                    return Err(format!(
+                        "visual tokens {n_vis} mismatch pad-span {span_len}"
+                    ));
+                }
+                let spans = [ImageSpan { start: span_start, len: span_len, grid_h, grid_w }];
+                let built = hipfire_arch_qwen35_vl::mrope::build_mrope_positions(
+                    req.prompt_tokens.len(), &spans, vc.spatial_merge_size,
+                );
+                let base = plan.reused as i32;
+                let mut pos3: Vec<i32> = Vec::with_capacity(req.prompt_tokens.len() * 3);
+                for p in &built.positions {
+                    pos3.extend_from_slice(&[p[0] + base, p[1] + base, p[2] + base]);
+                }
+                Ok(crate::scheduler::VlPrefill {
+                    embeds: embs,
+                    span_start,
+                    span_len,
+                    pos_base: plan.reused,
+                    pos3,
+                })
+            })();
+            match r_vl {
+                Ok(v) => Some(v),
+                Err(e) => {
+                    let _ = send_event(
+                        &req.reply,
+                        Event::Rejected { reason: format!("vl: {e}") },
+                    );
+                    rig.sessions.close(&mut rig.pool, &mut rig.adm, id);
+                    stats.lock().expect("stats").note_rejected();
+                    return;
+                }
+            }
+        }
+        _ => None,
+    };
+
     work[slot.0].remaining_prompt = req.prompt_tokens[plan.reused..].to_vec();
     work[slot.0].next_pos = plan.reused;
     work[slot.0].decoding = false;
+    work[slot.0].vl = vl;
     slots[slot.0] = Some(InFlight {
         session: id,
         reply: req.reply,
@@ -680,6 +841,13 @@ fn admit(
     });
     stats.lock().expect("stats").note_admitted();
 }
+
+/// Hidden dim of the trunk (`config.dim`) — helper so the VL closure above
+/// stays readable.
+fn config_dim(config: &qwen35::Qwen35Config) -> usize {
+    config.dim
+}
+
 
 /// Capture an idle session's state, park it, and free its slot.
 ///
@@ -756,4 +924,14 @@ fn restore(rig: &mut Rig, id: SessionId, slot: SlotId) -> bool {
             false
         }
     }
+}
+
+
+/// Resolve `<|image_pad|>` from the checkpoint tokenizer. Falls back to the
+/// Qwen3.5-VL constant when the special token is absent (text-only models
+/// never consult it — vision requests are rejected before this matters).
+fn rig_image_pad_id(tokenizer: &hipfire_runtime::tokenizer::Tokenizer) -> u32 {
+    tokenizer
+        .special_token_id("<|image_pad|>")
+        .unwrap_or(248056)
 }

--- a/crates/hipfire-arch-qwen35/src/slot_batch.rs
+++ b/crates/hipfire-arch-qwen35/src/slot_batch.rs
@@ -24,6 +24,10 @@ pub struct SlotBatch {
     pub positions: Vec<i32>,
     /// Slot index for each flat row.
     pub row_slot: Vec<i32>,
+    /// VL prefill: per visual chunk `(batch_row0, n_rows, embed_row0)`. Rows
+    /// `batch_row0..+n_rows` get vision-tower embeddings starting at
+    /// `embed_row0` of the visual-embedding table.
+    pub vl_rows: Option<Vec<(usize, usize, usize)>>,
 }
 
 impl SlotBatch {

--- a/crates/hipfire-cli/Cargo.toml
+++ b/crates/hipfire-cli/Cargo.toml
@@ -11,9 +11,10 @@ path = "src/main.rs"
 
 [features]
 default = ["multi-slot"]
-multi-slot = ["dep:hipfire-arch-qwen35"]
+multi-slot = ["dep:hipfire-arch-qwen35", "dep:hipfire-arch-qwen35-vl"]
 
 [dependencies]
+base64 = "0.22"
 anyhow = "1"
 clap = { version = "4.6", features = ["derive"] }
 ctrlc = { version = "3", features = ["termination"] }
@@ -23,6 +24,7 @@ hipfire-client = { path = "../hipfire-client" }
 hipfire-registry = { path = "../hipfire-registry" }
 hipfire-runtime = { path = "../hipfire-runtime", default-features = false, features = ["deltanet"] }
 hipfire-arch-qwen35 = { path = "../hipfire-arch-qwen35", default-features = false, features = ["deltanet"], optional = true }
+hipfire-arch-qwen35-vl = { path = "../hipfire-arch-qwen35-vl", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/hipfire-cli/src/bench_concurrency.rs
+++ b/crates/hipfire-cli/src/bench_concurrency.rs
@@ -335,6 +335,8 @@ impl ConcurrencyBackend for SlotDriver {
                     prompt_tokens,
                     convo,
                     continuation: Vec::new(),
+                    image_bytes: None,
+                    vis_span: None,
                     max_tokens: max_tokens as usize,
                     reply: tx,
                 })
@@ -380,6 +382,8 @@ impl ConcurrencyBackend for SlotDriver {
                         prompt_tokens: Vec::new(),
                         convo,
                         continuation,
+                        image_bytes: None,
+                        vis_span: None,
                         max_tokens: max_tokens as usize,
                         reply: tx,
                     })

--- a/crates/hipfire-cli/src/serve/complete.rs
+++ b/crates/hipfire-cli/src/serve/complete.rs
@@ -1598,6 +1598,9 @@ pub(crate) fn complete_request(
     // semantics and has no analogue here -- the engine either admits a request
     // or rejects it with a reason.
     if let Some(backend) = shared.slot_engine.clone() {
+        // The multi-slot engine handles both text and vision: it loads the
+        // vision tower alongside the trunk when the checkpoint carries one,
+        // and its prefill splices visual embeddings + mrope positions.
         return crate::serve::slots::complete_request_slots(
             &backend,
             body,

--- a/crates/hipfire-cli/src/serve/mod.rs
+++ b/crates/hipfire-cli/src/serve/mod.rs
@@ -693,7 +693,6 @@ pub(crate) fn serve_foreground(
     let instance_token = serve_instance_token();
     // Opt-in concurrent backend. Built before ServeShared so a failure here is
     // a clean startup error rather than a half-configured server.
-    #[cfg(feature = "multi-slot")]
     let slot_engine: Option<Arc<slots::SlotBackend>> =
         match config_bool(&global, "serve.multi_slot") {
             Ok(true) => {
@@ -734,9 +733,13 @@ pub(crate) fn serve_foreground(
             }
             _ => None,
         };
+    #[cfg(feature = "multi-slot")]
+    let slot_engine_active = slot_engine.is_some();
     #[cfg(not(feature = "multi-slot"))]
     let slot_engine: Option<Arc<slots::SlotBackend>> = None;
-    let slot_concurrency = if slot_engine.is_some() {
+    #[cfg(not(feature = "multi-slot"))]
+    let slot_engine_active = false;
+    let slot_concurrency = if slot_engine_active {
         config_u64(&global, "serve.multi_slot_slots").unwrap_or(4) as usize
     } else {
         1
@@ -808,7 +811,7 @@ pub(crate) fn serve_foreground(
     })
     .context("failed to install serve signal handler")?;
     eprintln!("[hipfire] native serve listening on http://{bind}");
-    if !args.no_prewarm {
+    if !args.no_prewarm && !slot_engine_active {
         let shared = Arc::clone(&shared);
         thread::spawn(move || {
             shared
@@ -833,6 +836,20 @@ pub(crate) fn serve_foreground(
                 Err(error) => eprintln!("[hipfire] pre-warm failed: {error:#}; serving lazily"),
             }
         });
+    } else if !args.no_prewarm {
+        // The multi-slot engine already holds trunk + vision weights; the
+        // legacy runtime path would load a second full copy and OOM consumer
+        // cards. All completion requests route to the slot backend when it is
+        // up, so eager pre-warm here is pure waste.
+        // /health reports meta.current_model; the warm gate (and any client
+        // readiness probe) needs it to name the served model even though the
+        // legacy runtime never loaded anything.
+        shared
+            .meta
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .current_model = Some(default_model.clone());
+        eprintln!("[hipfire] multi-slot backend owns the model; skipping legacy pre-warm");
     }
     if !shared.idle_timeout.is_zero() {
         let shared = Arc::clone(&shared);

--- a/crates/hipfire-cli/src/serve/slots.rs
+++ b/crates/hipfire-cli/src/serve/slots.rs
@@ -103,14 +103,73 @@ pub(crate) fn complete_request_slots(
     } else {
         AssistantPrefix::Plain
     };
-    let frame = ChatFrame {
-        tokenizer: &backend.tokenizer,
-        system: system.as_deref(),
-        user: &last_user,
-        assistant_prefix: prefix,
-        raw: false,
+    // VL: extract the base64 image (if any). When present, CPU-preprocess it
+    // (cheap, no GPU) to learn the merged visual-token count, then render the
+    // final user turn with the exact pad span the engine will splice vision
+    // embeddings into: [vision_start, PAD×n_vis, vision_end, \n, question].
+    let image_bytes: Option<Vec<u8>> = match crate::serve::complete::request_image_base64(
+        body.get("messages"),
+    )? {
+        Some(b64) => {
+            use base64::Engine as _;
+            Some(
+                base64::engine::general_purpose::STANDARD
+                    .decode(&b64)
+                    .map_err(|e| anyhow::anyhow!("invalid base64 image payload: {e}"))?,
+            )
+        }
+        None => None,
     };
-    let prompt_tokens = frame.build_multi_turn(&history);
+    let image_bytes = image_bytes.filter(|b| !b.is_empty());
+
+    const PATCH_SIZE: usize = 16;
+    const SPATIAL_MERGE: usize = 2;
+    let n_vis = match &image_bytes {
+        Some(bytes) => {
+            let (chw, gh, gw) =
+                hipfire_arch_qwen35_vl::image::load_and_preprocess_from_bytes(
+                    bytes, PATCH_SIZE, SPATIAL_MERGE,
+                )
+                .map_err(|e| anyhow::anyhow!("vl preprocess: {e}"))?;
+            drop(chw);
+            ((gh / PATCH_SIZE) / SPATIAL_MERGE) * ((gw / PATCH_SIZE) / SPATIAL_MERGE)
+        }
+        None => 0,
+    };
+
+    let prompt_tokens = if n_vis > 0 {
+        let vs = backend.tokenizer.special_token_id("<|vision_start|>");
+        let ve = backend.tokenizer.special_token_id("<|vision_end|>");
+        let pad = backend.tokenizer.special_token_id("<|image_pad|>");
+        let (Some(vs), Some(ve), Some(pad)) = (vs, ve, pad) else {
+            bail!("model tokenizer lacks VL special tokens; cannot serve images");
+        };
+        let q_tokens = backend.tokenizer.encode(&last_user);
+        let nl = backend.tokenizer.encode("\n");
+        let mut user_body: Vec<u32> = Vec::with_capacity(n_vis + q_tokens.len() + 4);
+        user_body.push(vs);
+        user_body.resize(user_body.len() + n_vis, pad);
+        user_body.push(ve);
+        user_body.extend_from_slice(&nl);
+        user_body.extend_from_slice(&q_tokens);
+        ChatFrame {
+            tokenizer: &backend.tokenizer,
+            system: system.as_deref(),
+            user: "",
+            assistant_prefix: prefix,
+            raw: false,
+        }
+        .build_with_user_tokens(&user_body)
+    } else {
+        ChatFrame {
+            tokenizer: &backend.tokenizer,
+            system: system.as_deref(),
+            user: &last_user,
+            assistant_prefix: prefix,
+            raw: false,
+        }
+        .build_multi_turn(&history)
+    };
 
     // Conversation identity is the USER turns. The assistant side is whatever
     // we generated, and the client's echo of it may differ (reasoning split to
@@ -149,6 +208,8 @@ pub(crate) fn complete_request_slots(
             prompt_tokens,
             convo,
             continuation,
+            image_bytes: image_bytes.clone(),
+            vis_span: None, // computed engine-side from the rendered prompt
             max_tokens,
             reply: tx,
         })

--- a/crates/hipfire-daemon/src/main.rs
+++ b/crates/hipfire-daemon/src/main.rs
@@ -2537,6 +2537,18 @@ fn main() {
                         max_think_tokens: vl_max_think_tokens,
                         assistant_prefix,
                     };
+                    // Emit gen_start BEFORE the VL route. The CLI serve layer's
+                    // stream-contract gate requires the first daemon event of a
+                    // transaction to be `gen_start` (PreStartEvent otherwise);
+                    // generate_vl emits `token` events directly, so without this
+                    // every serve-layer VL request was rejected and aborted.
+                    // qwen3.5-VL rides the same semantic contract v2 as Qwen AR.
+                    emit_gen_start(
+                        &mut stdout,
+                        id,
+                        false,
+                        Some(QWEN_AR_SEMANTIC_CONTRACT_VERSION),
+                    );
                     match vision_route {
                         hipfire_loader::VisionRoute::DotsOcr => hipfire_generate::vision::generate_vl_dots_ocr(m, &mut gpu, &mut stdout, &params),
                         _ => hipfire_generate::vision::generate_vl(m, &mut gpu, &mut stdout, &params),

--- a/crates/hipfire-runtime/examples/test_prefix_cache_equivalence.rs
+++ b/crates/hipfire-runtime/examples/test_prefix_cache_equivalence.rs
@@ -222,6 +222,7 @@ fn main() {
                 remaining_prompt: feed.to_vec(),
                 next_pos: start_pos,
                 decoding: false,
+                vl: None,
             }];
             let mut produced = Vec::new();
             // Prefill may take several chunks. Sampling is only valid once the
@@ -248,6 +249,7 @@ fn main() {
                     scratch,
                     logits_out,
                     graph,
+                    false,
                 )
                 .expect("forward_batch_slots_graphed");
                 gpu.hip.device_synchronize().expect("sync");

--- a/crates/hipfire-runtime/examples/test_serve_concurrent.rs
+++ b/crates/hipfire-runtime/examples/test_serve_concurrent.rs
@@ -86,6 +86,8 @@ fn main() {
                 // no continuation tokens.
                 convo: Vec::new(),
                 continuation: Vec::new(),
+                image_bytes: None,
+                vis_span: None,
                 max_tokens: MAX_TOKENS,
                 reply: tx,
             })

--- a/crates/hipfire-runtime/examples/test_swap_equivalence.rs
+++ b/crates/hipfire-runtime/examples/test_swap_equivalence.rs
@@ -157,6 +157,7 @@ fn main() {
             remaining_prompt: feed.to_vec(),
             next_pos: start_pos,
             decoding: false,
+            vl: None,
         }];
         let mut sched = Scheduler {
             chunk_size: feed.len().max(1),
@@ -182,6 +183,7 @@ fn main() {
                 scratch,
                 logits_out,
                 &mut graph,
+                false,
             )
             .expect("forward");
             gpu.hip.device_synchronize().expect("sync");

--- a/crates/hipfire-runtime/examples/test_swap_roundtrip.rs
+++ b/crates/hipfire-runtime/examples/test_swap_roundtrip.rs
@@ -126,6 +126,7 @@ fn main() {
         remaining_prompt: prompt.clone(),
         next_pos: 0,
         decoding: false,
+        vl: None,
     }];
     let mut sched = Scheduler {
         chunk_size: prompt.len(),
@@ -146,6 +147,7 @@ fn main() {
         &scratch,
         &logits_out,
         &mut graph,
+        false,
     )
     .expect("prefill");
     gpu.hip.device_synchronize().expect("sync");

--- a/crates/hipfire-runtime/src/serve/mod.rs
+++ b/crates/hipfire-runtime/src/serve/mod.rs
@@ -36,6 +36,14 @@ pub struct SubmitRequest {
     /// these are APPENDED to its exact stored tokens, so the result is a
     /// strict extension of the KV rather than a re-render of it.
     pub continuation: Vec<u32>,
+    /// Visual input for a VL request: raw encoded image bytes (PNG/JPEG) that
+    /// the engine preprocesses and runs through the vision tower. When
+    /// `Some`, `vis_text` carries a placeholder marker inserted into the
+    /// rendered prompt so the engine knows where the image span sits.
+    pub image_bytes: Option<Vec<u8>>,
+    /// `(start_row_within_prompt, count)` of the placeholder span. Only
+    /// meaningful alongside `image_bytes`.
+    pub vis_span: Option<(usize, usize)>,
     pub max_tokens: usize,
     pub reply: Sender<Event>,
 }


### PR DESCRIPTION
## Summary

Focused VL delta split out of #626 per review triage (HOLD_WIP): everything that overlapped merged #607/#608 and the already-on-master quantizer F16 fallback was dropped; residual non-VL engine fixes moved to #628.

Multi-slot engine gains vision-language support:

- ViT tower loads alongside trunk weights in `SlotEngine` (before the trunk loader drops the mmap — order matters)
- Image requests are preprocessed engine-side (CPU smart-resize + patch extraction), run through `vision_forward`, and their embeddings are spliced into the batched prefill via `SlotStepOpts.embed_override`
- FA layers dispatch to `rope_mrope_halfsplit_f32_batched` with per-row (t,h,w) positions on visual steps; text-only steps keep the 1D kernel and hipGraph decode path
- Scheduler tracks per-slot VL state through chunked prefill (`SlotBatch.vl_rows`)
- CLI slot path extracts OpenAI-style `image_url` parts and renders the exact pad span (CPU preprocess computes `n_vis`; GPU re-preprocesses for embeddings); `gen_start` is emitted before the daemon VL route so the CLI stream-contract gate accepts serve-layer VL requests

Rebased on current master (`b8cd18f`). No config-schema, chunk-width, S-tape, or pool-sharing changes — those are #607/#608 territory or deferred.

## Which crate(s) does this touch?

- [x] `crates/hipfire-arch-qwen35`
- [x] `crates/hipfire-cli`
- [x] `crates/hipfire-daemon`
- [x] `crates/hipfire-runtime`

## Test plan

- [x] `cargo check --workspace --features deltanet` clean on the rebased tree
- [x] `cargo test -p hipfire-arch-qwen35 --features deltanet`: 155 passed
- [x] `test_kernels` on gfx1101: 16/16 kernel-vs-CPU-reference channels pass
- [x] Engine routes on gfx1101 with ornith-1.5-9b mq4v1: `test_prefix_cache_equivalence` (24/24 identical), `test_swap_roundtrip`, `test_swap_equivalence`, `test_serve_concurrent` — ALL PASS
- [x] `scripts/serve_harness.py --mode battery` through the multi-slot engine: 5 turns, all `finish=stop`, 0 runaway/empty/attractor/retrieval_miss
- [x] VL grounding through the slot path (2 slots, mq4v1 + F16 vision tower): 4-color grid image described exactly; "which color is bottom-right" answered correctly

Follow-up fix folded in (`7652917`): skip the legacy pre-warm when the multi-slot backend owns the model — it loaded a second full weight copy and OOM'd 12 GB cards; `/health` still reports the served model via ServeMeta. Lab-gated engine examples updated for the VL API.

Supersedes the VL portions of #626.

Signed-off-by: ghazni101 <ghazni101@users.noreply.github.com>

## MQ4V2 / qt44 compatibility

The slot engine serves current-default **MQ4V2 (qt44)** artifacts: the lm_head allow-list is widened (`bc747188`; layer gates already admitted V2 uniformly, and the v1-only xbatch lm_head fast path remains correctly gated to qt13). Verified coherent on gfx1101 through the containerized serve path — fwht4 KV, 2 slots, `pool_total=131072` — covering text coherence, two-lane concurrency, and vision; fixtures in [the evidence comment](https://github.com/warpfront/hipfire/pull/636#issuecomment-5404447616).
