### PR TITLE
fix(serve/quantize): context-cap decode guard; MoE expert-3d guard; standalone quantizer image

### DIFF
--- a/crates/hipfire-arch-qwen35/src/serve_engine.rs
+++ b/crates/hipfire-arch-qwen35/src/serve_engine.rs
@@ -411,8 +411,16 @@ fn run_loop(mut rig: Rig, rx: Receiver<SubmitRequest>, stats: Arc<Mutex<EngineSt
             };
             f.produced += 1;
             let hit_max = f.produced >= f.max_tokens;
+            // Context-cap guard: stop before the slot's KV length would pass
+            // its cap. Without this, a long multi-turn session overflows
+            // set_seq_len and kills the whole batched step.
+            let hit_ctx_cap = rig
+                .sessions
+                .get(session)
+                .map(|sess| sess.tokens.len() + 1 >= rig.cap_tokens)
+                .unwrap_or(false);
 
-            if gone || hit_eos || hit_max {
+            if gone || hit_eos || hit_max || hit_ctx_cap {
                 let reason = if gone {
                     DoneReason::ClientGone
                 } else if hit_eos {

--- a/crates/hipfire-quantize/src/pipeline.rs
+++ b/crates/hipfire-quantize/src/pipeline.rs
@@ -3895,6 +3895,16 @@ fn handle_moe_expert_3d(
     let arch_id = ctx.arch_id;
     let is_vision = ctx.is_vision;
 
+    // Guard: this handler is only valid for stacked 3D MoE expert tensors
+    // ([n_experts, ..., ...] named *.experts.{gate_up,down}_proj). Anything
+    // else (e.g. dense rank-2 tensors like lm_head on multimodal qwen3_5
+    // checkpoints) must fall through to the standard quantization path.
+    if meta.shape.len() < 3
+        || !(name.ends_with("experts.gate_up_proj") || name.ends_with("experts.down_proj"))
+    {
+        return false;
+    }
+
     let n_experts = meta.shape[0];
     let inner_n: usize = meta.shape[1..].iter().product();
     let elem_size = match meta.dtype.as_str() {

--- a/docker/quantizer.Dockerfile
+++ b/docker/quantizer.Dockerfile
@@ -1,0 +1,14 @@
+# Quantizer image: gate-runner base + patched source + prebuilt binary.
+FROM hipfire-gate
+
+SHELL ["/bin/bash", "-c"]
+# Overlay the CURRENT checkout (the base image froze an older snapshot),
+# then build so the fix is actually compiled in.
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+RUN source /root/.cargo/env && cd /hipfire && \
+    touch crates/hipfire-quantize/src/pipeline.rs && \
+    cargo build --release --locked -p hipfire-quantize && \
+    cp target/release/hipfire-quantize /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/hipfire-quantize"]


### PR DESCRIPTION
## Summary

Residual engine fixes that survived the #626 rebase — i.e. the pieces NOT already covered by merged #607/#608 or current master:

- **Context-cap decode guard** (`serve_engine`): a slot whose session reaches `cap_tokens` now stops cleanly (client sees `MaxTokens`) instead of overflowing `set_seq_len` and killing the entire batched step.
- **MoE expert-3d guard** (quantize pipeline): `handle_moe_expert_3d` only accepts stacked 3D `*.experts.{gate_up,down}_proj` tensors; dense rank-2 tensors (e.g. `lm_head.weight` on multimodal qwen3_5 checkpoints) fall through to the standard path instead of panicking on `inner_shape[1]`.
- **docker/quantizer.Dockerfile**: standalone CPU quantizer image.

The F16-fallback fix from the original PR is already on master and is not repeated here.

## Which crate(s) does this touch?

- [x] `crates/hipfire-arch-qwen35`
- [x] `crates/hipfire-quantize`

## Test plan

- [x] `cargo check -p hipfire-arch-qwen35 -p hipfire-quantize --features deltanet` clean
- [x] `cargo test -p hipfire-arch-qwen35 --features deltanet`: 155 passed
- [x] `cargo test -p hipfire-quantize`: only failure is `quant_fwht::tests::mq6v2_mq5v2_wire_layout`, verified pre-existing on pristine master

Supersedes the non-VL portions of #626.

Signed-off-by: ghazni101 <ghazni101@users.noreply.github.com>