### PR TITLE
fix(hw-gate): resolve --checkout to an absolute path before launching a seat

### DIFF
--- a/scripts/hw-gate/review.py
+++ b/scripts/hw-gate/review.py
@@ -1668,6 +1668,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--base-bin", dest="base_bin", help="HW_GATE_BASE_BIN for investigate (optional)")
     ap.add_argument("--round", type=int, default=1, help="HW_GATE_ROUND for investigate (default 1)")
     args = ap.parse_args(argv)
+    # The workflow passes `--checkout pr` relative to the job workspace. Every seat
+    # launch runs omp with cwd=checkout AND `--cwd checkout`; a relative path is
+    # resolved twice (`pr/pr`) and omp exits 1 before the seat ever reads the diff.
+    args.checkout = os.path.abspath(args.checkout)
 
     # Validate seat/phase combo per authority model
     if args.seat == "fable" and args.phase in ("prelim", "verdict"):

--- a/scripts/hw-gate/tests/fake_omp.py
+++ b/scripts/hw-gate/tests/fake_omp.py
@@ -27,6 +27,16 @@ def _emit(assistant_text: str):
 
 def main():
     args = sys.argv[1:]
+    # Real omp chdirs to `--cwd` relative to its own working directory and exits 1
+    # if the target does not exist. Mirror that so a doubled relative path
+    # (`pr/pr`) fails here exactly as it failed on the runner.
+    if "--cwd" in args:
+        target = args[args.index("--cwd") + 1]
+        try:
+            os.chdir(target)
+        except OSError as e:
+            sys.stderr.write(f"Error: Cannot change working directory to {target}: {e.strerror}: chdir '{os.getcwd()}' -> '{os.path.join(os.getcwd(), target)}'\n")
+            sys.exit(1)
     # Dump env keys if requested (for investigate mode tests)
     env_dump_path = os.environ.get("FAKE_OMP_ENV_DUMP")
     if env_dump_path:

--- a/scripts/hw-gate/tests/test_review.py
+++ b/scripts/hw-gate/tests/test_review.py
@@ -361,6 +361,54 @@ def test_prelim_run_hardware_false_on_garbage():
     comments = json.loads(gh_comments.read_text())
     assert any("sol prelim unavailable" in b.lower() or "run_hardware" in b.lower() for b in [c["body"] for c in comments])
 
+def test_prelim_relative_checkout_reaches_the_seat():
+    # The workflow runs `review.py --checkout pr` from the job workspace. The
+    # first live run on #686 died before Sol read anything: omp was launched
+    # with cwd=pr and `--cwd pr`, resolved `pr/pr`, and exited 1.
+    tmp = Path(tempfile.mkdtemp())
+    models_dir = tmp / "models"
+    models_dir.mkdir()
+    checkout, base, head = _make_repo(tmp / "pr")
+    select = {"schema":"hipfire.hw-gate.select","version":1,"needs_hw":True,"buckets":["load"],"policy_paths":[],"surfaces":{"load":[],"serve":[],"kernel":[],"policy":[],"other":[]},"request":None,"request_error":None}
+    select_path = tmp / "select.json"
+    select_path.write_text(json.dumps(select))
+    fixtures_path = tmp / "fixtures.json"
+    fixtures_path.write_text(json.dumps(_fixtures_content(models_dir)))
+    sol_response = {
+        "phase": "prelim","summary":"s","surfaces":["load"],"suspected_regressions":[],
+        "run_hardware": True,"run_hardware_reasons":["touches the loader"],
+        "routes":[],"unavailable_routes":[],"claim_assessment":"","questions_for_author":[]
+    }
+    resp_path = tmp / "resp.json"
+    resp_path.write_text(json.dumps([{"json": sol_response}]))
+    gh_comments = tmp / "gh_comments.json"
+    gh_comments.write_text("[]")
+    out_path = tmp / "prelim.json"
+    routes_path = tmp / "routes.json"
+    system_prompt = tmp / "sol.md"
+    system_prompt.write_text("prompt")
+    omp_log = tmp / "omp_log.jsonl"
+    env = os.environ.copy()
+    env["HW_GATE_OMP_BIN"] = str(FAKE_OMP)
+    env["HW_GATE_GH_BIN"] = str(FAKE_GH)
+    env["FAKE_OMP_RESPONSES"] = str(resp_path)
+    env["FAKE_OMP_CALL_COUNT"] = str(tmp / "omp_count")
+    env["FAKE_GH_LOG"] = str(tmp / "gh_log.jsonl")
+    env["FAKE_GH_COMMENTS"] = str(gh_comments)
+    env["FAKE_OMP_LOG"] = str(omp_log)
+    env["HIPFIRE_MODELS_DIR"] = str(models_dir)
+    rel_checkout = os.path.relpath(checkout, tmp)  # "pr/checkout", as the workflow's "pr"
+    cmd = [sys.executable, str(REVIEW_PATH),"--seat","sol","--phase","prelim","--repo","o/r","--pr","1","--base",base,"--head",head,"--checkout",rel_checkout,"--select",str(select_path),"--fixtures",str(fixtures_path),"--system-prompt",str(system_prompt),"--out",str(out_path),"--routes",str(routes_path)]
+    result = subprocess.run(cmd, env=env, capture_output=True, text=True, cwd=tmp)
+    assert result.returncode == 0, result.stderr
+    data = json.loads(out_path.read_text())
+    assert data["prelim"] is not None, gh_comments.read_text()
+    assert data["run_hardware"] is True
+    launches = [json.loads(l) for l in omp_log.read_text().splitlines() if l.strip()]
+    assert launches, "seat was never launched"
+    cwd_arg = launches[0]["args"][launches[0]["args"].index("--cwd") + 1]
+    assert os.path.isabs(cwd_arg) and Path(cwd_arg) == checkout.resolve()
+
 # ---------------------------------------------------------------------------
 # verdict e2e
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First live run of the rung — `workflow_dispatch` on #686, [run 33848923893](https://github.com/warpfront/hipfire/actions/runs/33848923893) — never reached Sol. `review.py` launches omp with `cwd=checkout` **and** `--cwd checkout`; the workflow passes `--checkout pr` relative to the job workspace, so omp resolved `pr/pr` and exited 1 before reading the diff:

> Sol prelim unavailable: omp prelim failed (1): Error: Cannot change working directory to pr: ENOENT … chdir '/home/kaden/actions-runner/_work/hipfire/hipfire/pr' -> '…/pr/pr'

`prelim.json` came back `null`, both hardware lanes were skipped, and `hw-gate` went red with "sol prelim unavailable". The bot identity, secrets, runners, and comment posting all worked — [the seat posted its own failure](https://github.com/warpfront/hipfire/pull/686#issuecomment-5537217262) as `hipfire-sol[bot]`.

The #679 dry runs did not catch it because the fake omp ignored `--cwd` and every test passed an absolute checkout.

## Changes

- `scripts/hw-gate/review.py`: `abspath` the checkout once after `parse_args`; all three seat launches and the git helpers inherit it.
- `scripts/hw-gate/tests/fake_omp.py`: `chdir` to `--cwd` like the real binary, exit 1 with the same error shape when it does not exist.
- `scripts/hw-gate/tests/test_review.py`: `test_prelim_relative_checkout_reaches_the_seat` — prelim invoked with a relative `--checkout` from the parent directory must reach the seat and pass an absolute `--cwd`.

## Which surface(s) does this touch?

- [x] **policy files** — gate scripts (hard floor: a human merges this)

## Evidence

- Regression test **fails on the old script** with the runner's exact error (`Cannot change working directory to pr/checkout … -> pr/checkout/pr/checkout`) and passes with the fix.
- `python3 -m pytest scripts/hw-gate/tests -q` → **103 passed**.

## After merge

Re-dispatch on #686: `gh workflow run hw-gate.yml -f pr=686`. Gate scripts come from the base branch (`pull_request_target`), so the fix has to be on `master` before any PR can get a real prelim.