### PR TITLE
fix(hw-gate): import the runner user's login toolchain before building

### DIFF
--- a/.github/workflows/hw-gate.yml
+++ b/.github/workflows/hw-gate.yml
@@ -224,6 +224,15 @@ jobs:
         with:
           name: hw-gate-prelim
           path: prelim
+      - name: Login-shell toolchain (the runner service PATH has neither cargo nor ROCm)
+        # Both runners are systemd services: PATH is the distro default, so
+        # `cargo` and `hipcc` are not found (run 33849478193 failed both lanes in
+        # 40 s with "[Errno 2] No such file or directory: 'cargo'"). The runner
+        # user's login shell has the toolchain; import it for the steps below.
+        run: |
+          set -euo pipefail
+          bash -lc 'echo "$PATH"' | tr ':' '\n' >> "$GITHUB_PATH"
+          bash -lc 'env' | grep -E '^(ROCM_PATH|HIP_PATH|HSA_PATH|HIP_PLATFORM|LD_LIBRARY_PATH)=' >> "$GITHUB_ENV" || true
       - name: "Run routes (shared GPU lock: coexists with other lanes, excludes a Fable session)"
         run: |
           set -euo pipefail
@@ -352,6 +361,11 @@ jobs:
           ref: ${{ needs.select.outputs.head_sha }}
           path: pr
           fetch-depth: 0
+      - name: Login-shell toolchain (the runner service PATH has neither cargo nor ROCm)
+        run: |
+          set -euo pipefail
+          bash -lc 'echo "$PATH"' | tr ':' '\n' >> "$GITHUB_PATH"
+          bash -lc 'env' | grep -E '^(ROCM_PATH|HIP_PATH|HSA_PATH|HIP_PLATFORM|LD_LIBRARY_PATH)=' >> "$GITHUB_ENV" || true
       - name: Build PR head and base branch
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Second live run on #686 ([33849478193](https://github.com/warpfront/hipfire/actions/runs/33849478193)): Sol read the diff and authorized hardware, both lanes started, both failed inside 40 s — **no GPU was ever touched**:

```
"build_error": "[Errno 2] No such file or directory: 'cargo'"
```

Both runners are systemd services. `actions-runner/.path` was written at install (2026-07-11) and is the distro default; the service environment has no `~/.cargo/bin`, no `/opt/rocm/core/bin`, no `ROCM_PATH`. The #679 evidence runs were driven by hand from a login shell, which is why this never surfaced. Nothing on either host changed.

## Changes

`hw-run` and `fable-decide` gain one step before their build: import the runner user's login `PATH` (→ `GITHUB_PATH`) and the ROCm variables `ROCM_PATH`, `HIP_PATH`, `HSA_PATH`, `HIP_PLATFORM`, `LD_LIBRARY_PATH` (→ `GITHUB_ENV`) via `bash -lc`. Host-agnostic; no runner reconfiguration.

## Which surface(s) does this touch?

- [x] **policy files** — `hw-gate.yml` (hard floor: a human merges this)

## Evidence

Step body executed under a bare service environment on hiptrx (`env -i PATH=<distro default>`): yields `ROCM_PATH=/opt/rocm/core`, `HIP_PATH=/opt/rocm/core`, `LD_LIBRARY_PATH=/opt/rocm/core/lib`, and `cargo` / `hipcc` / `omp` resolve on the resulting PATH. hipx's login shell carries the same variables (`/opt/rocm/core/bin`, `~/.cargo/bin`). Workflow YAML parses.

## After merge

Re-dispatch on #686: `gh workflow run hw-gate.yml -f pr=686` (gate workflow comes from base).