### PR TITLE
fix(serve_harness): a short answer is not a token attractor

### DIFF
--- a/scripts/serve_harness.py
+++ b/scripts/serve_harness.py
@@ -2034,11 +2034,20 @@ def gram3(toks):
     from collections import Counter
     c = Counter(g); return sum(v for v in c.values() if v > 1) / len(g)
 
+# An attractor is *repetition*: the frequency tests below are meaningless on a
+# window too short to repeat in. A one-"word" answer (`Paris`, compact JSON
+# `{"name":"Alice","age":34}`, a bare number) has maxfreq == 1.0 by
+# construction and used to fail every short-answer battery turn at random —
+# the gate hard-floors on it (hw-gate run 33862054891, qwen3.8 format turn,
+# recall 6/6). Runaway/empty cover the degenerate short cases.
+ATTRACTOR_MIN_WINDOW = 8
+
 def _token_attractor(toks):
     first, last, half = toks[:128], toks[-128:], toks[len(toks)//2:]
+    short = len(toks) < ATTRACTOR_MIN_WINDOW
     return (
-        (bool(first) and (uniq(first) < 0.15 or maxfreq(first) > 0.50))
-        or (bool(last) and (uniq(last) < 0.30 or maxfreq(last) > 0.50))
+        (not short and (uniq(first) < 0.15 or maxfreq(first) > 0.50))
+        or (not short and (uniq(last) < 0.30 or maxfreq(last) > 0.50))
         or gram3(half) > 0.50
     )
 
@@ -2059,6 +2068,12 @@ def _self_test_attractor_channels():
     assert _token_attractor(combined), "fixture must reproduce the old false positive"
     assert not _response_has_attractor(reasoning, visible)
     assert _response_has_attractor("loop " * 200, "")
+    # Short answers cannot repeat enough to be attractors: one token, a
+    # compact JSON object, a bare number, a two-word echo.
+    for short in ('{"name":"Alice","age":34,"city":"Lisbon"}', "Paris", "43", "yes yes"):
+        assert not _response_has_attractor("", short), f"false positive on short answer {short!r}"
+    # ...but a genuinely degenerate short window still trips once it can repeat.
+    assert _response_has_attractor("", " ".join(["the"] * ATTRACTOR_MIN_WINDOW))
     print("serve_harness: attractor-channel self-test OK", flush=True)
 
 def _project_mtp_ngram_timings(timings):


### PR DESCRIPTION
## Summary

`_token_attractor` splits the visible answer on whitespace and fails the turn when `maxfreq(first) > 0.50`. A one-"word" answer — compact JSON `{"name":"Alice","age":34,"city":"Lisbon"}`, `Paris`, `43` — is a single token, so `maxfreq` is 1.0 by construction and the turn is flagged `!ATTRACTOR`.

The battery is sampled, so the same fixture passes when the model spaces its JSON and fails when it doesn't. **hw-gate run [33862054891](https://github.com/warpfront/hipfire/actions/runs/33862054891) (#686 re-run) failed the `qwen3.8:27b-mq4-xt` battery on a correct, recall-6/6, 17-token JSON answer**; the same daemon md5 passed the same fixture two hours earlier with `{"name": "Alice", ...}`. The gate hard-floors on any attractor, so this is a random red on every PR whose battery draws a compact answer.

## Change

The frequency tests (`uniq`, `maxfreq` on the first/last 128 tokens) now require a window of at least `ATTRACTOR_MIN_WINDOW = 8` tokens — repetition needs room to repeat in; `runaway`/`empty` already cover degenerate short output. `gram3` is unchanged (already needs 6). One function, one constant.

## Evidence

| input | before | after |
|---|---|---|
| `{"name":"Alice","age":34,"city":"Lisbon"}` | attractor | ok |
| `Paris` | attractor | ok |
| `yes yes` | attractor | ok |
| `the` ×8 | attractor | attractor |
| `the` ×40 | attractor | attractor |
| `a b c` ×20 (gram3 loop) | attractor | attractor |
| 12-word normal sentence | ok | ok |

The harness self-test (`_self_test_attractor_channels`, run at startup) gains the short-answer cases and an 8×-repeat that must still trip; passes.

## Which surface(s) does this touch?

- [x] docs / CI / scripts — `scripts/serve_harness.py` only. No Rust, no kernels.

Note for the gate: `run.py` executes the harness from the PR checkout, so PRs pick this up on rebase.