### PR TITLE
fix(hw-gate): isolate each Fable session's evidence dir; keep the seat's raw output on a no-decision

### DIFF
--- a/.github/workflows/hw-gate.yml
+++ b/.github/workflows/hw-gate.yml
@@ -402,6 +402,11 @@ jobs:
           GH_TOKEN: ${{ steps.token.outputs.token || github.token }}
         run: |
           set -euo pipefail
+          # The runner reuses its workspace: without the rm, Fable inherits the
+          # previous PR's evidence files and home (run 33866758629 on #702
+          # carried #700's fable-summary.md and #686's route outputs) and can
+          # cite them as its own. Every session starts empty.
+          rm -rf fable-evidence fable-home
           mkdir -p fable-evidence fable-home
           exec 9>/home/kaden/actions-runner/_cache/hw-gate-gpu.lock
           flock --exclusive --timeout 3600 9

--- a/scripts/hw-gate/review.py
+++ b/scripts/hw-gate/review.py
@@ -1288,6 +1288,10 @@ def _run_decide(args) -> int:
     decision = None
     fable_unavailable = False
     fable_error_reason: str | None = None
+    # What the seat actually said/emitted when it did not produce a decision.
+    # Run 33866758629 (#702) ended "no JSON object in assistant text" after 10 s
+    # and the artifact carried nothing to diagnose it with.
+    fable_raw: dict | None = None
     investigation: list = []
     unproven: list = []
     if investigate:
@@ -1346,6 +1350,8 @@ def _run_decide(args) -> int:
                         fable_unavailable = True
                         fable_error_reason = "omp decide: no JSON object in assistant text"
                         sys.stderr.write(f"fable omp failed: {fable_error_reason}\n")
+                        sys.stderr.write(f"fable assistant text (tail): {(last_text or '')[-2000:]!r}\n")
+                        fable_raw = {"assistant_text_tail": (last_text or "")[-4000:], "stderr_tail": stderr_text[-4000:]}
                         investigation = []
                         unproven = []
                         decision = None
@@ -1625,6 +1631,8 @@ def _run_decide(args) -> int:
         "investigation": investigation,
         "unproven": unproven,
         "evidence_dir": evidence_dir_val,
+        "fable_error": fable_error_reason,
+        "fable_raw": fable_raw,
     }
     try:
         Path(args.out).parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Two defects from the campaign PR's first gate pass ([run 33866758629](https://github.com/warpfront/hipfire/actions/runs/33866758629) on #702):

1. **Fable inherits the previous PR's evidence.** The decide step does `mkdir -p fable-evidence fable-home` in a reused runner workspace. The `hw-gate-decision` artifact for #702 contained **#700's `fable-summary.md` and #686's route outputs** (`explicit-draft-wins-qwen3.8-27b-mq4-xt-pr.*`, `attempt1-hipfire-home-leak/`). The seat can read and cite another PR's evidence as its own. Fix: `rm -rf fable-evidence fable-home` before the `mkdir`.
2. **A no-decision is undiagnosable.** The step ended in 10 s with `omp decide: no JSON object in assistant text`, and `review.py` discarded the assistant text it had already extracted. `decision.json` now records `fable_error` and `fable_raw {assistant_text_tail, stderr_tail}`; the step log gets the tail too.

## Which surface(s) does this touch?

- [x] **policy files** — `hw-gate.yml`, `scripts/hw-gate/review.py` (hard floor: a human merges this)

## Evidence

- `python3 -m pytest scripts/hw-gate/tests -q` → **103 passed**.
- Workflow YAML parses.

No change to seat prompts, routes, or the hard floor.