### PR TITLE
fix(hw-gate): the status job reads the verdict from decision_final

### DIFF
--- a/.github/workflows/hw-gate.yml
+++ b/.github/workflows/hw-gate.yml
@@ -496,7 +496,11 @@ jobs:
         if: env.skip != 'true'
         run: |
           set -euo pipefail
-          decision=$(jq -r '.decision // "hold"' decision/decision.json)
+          # review.py writes the seat's full object under `.decision` and the
+          # floor-applied verdict under `.decision_final`; `.decision` is a JSON
+          # object, so the old jq yielded "[object]" and every run — including
+          # a successful merge-staging (#689, run 33889229683) — went red.
+          decision=$(jq -r '.decision_final // .decision.decision // "hold"' decision/decision.json)
           hard=$(jq -r '(.floor.hard // []) | join(", ")' decision/decision.json)
           echo "decision=$decision hard_floor=[$hard] human_reviewed=${{ needs.select.outputs.human_reviewed }}"
           case "$decision" in


### PR DESCRIPTION
## Summary

`review.py` writes the seat's full object under `.decision` and the floor-applied verdict under `.decision_final`. The status step read `.decision`, got a JSON **object**, fell into the `*)` arm, and went red on every run — including #689's successful staging merge ([run 33889229683](https://github.com/warpfront/hipfire/actions/runs/33889229683): Fable merged `8f3a9b6c5` to `beta` as `3149be7de`, label `merged-staging` applied, status `blocked ()`).

Fix: `jq -r '.decision_final // .decision.decision // "hold"'`.

## Evidence

On the real artifacts: #689 → `merge-staging` (green); #702's no-decision run → `block` (red). Workflow YAML parses. No change to the floor or the seats.

## Which surface(s) does this touch?

- [x] **policy files** — `hw-gate.yml` (hard floor: a human merges this)