### PR TITLE
perf(gfx12): disable slow default DFlash verify graph

### DIFF
--- a/crates/hipfire-arch-qwen35/src/speculative.rs
+++ b/crates/hipfire-arch-qwen35/src/speculative.rs
@@ -208,10 +208,10 @@ fn dflash_moe_draft_ffn_graph_eligible(
 /// `verify_graph_ok` shares that eligibility via `prefill_batch_pbs_eligible`.
 /// Graph-off direct and forced-blob direct full-model V2 fixtures pass on
 /// gfx1100, but two graph-on V2 campaigns lost the endpoint. This is a
-/// default-off graph capability quarantine for exact gfx1100 + V2 only;
-/// direct batched WMMA remains on. `HIPFIRE_VERIFY_GRAPH=1` opts back in
-/// diagnostically; `=0` force-offs everywhere; gfx1151/gfx12 and non-V2
-/// gfx1100 stay default-on.
+/// default-off graph capability quarantine for gfx1100 + V2 and the measured
+/// gfx1201 legacy MQ4 workload; direct batched HIP remains on.
+/// `HIPFIRE_VERIFY_GRAPH=1` opts back in diagnostically; `=0` force-offs
+/// everywhere; other gfx12 shapes stay default-on.
 fn dflash_verify_graph_env_eligible(
     arch: &str,
     output_dtype: rdna_compute::DType,
@@ -229,6 +229,11 @@ fn dflash_verify_graph_env_eligible(
             | rdna_compute::DType::MQ2G256V2
     );
     if arch == "gfx1100" && is_mq_v2 {
+        return env_value == Some("1");
+    }
+    if arch == "gfx1201" && output_dtype == rdna_compute::DType::MQ4G256 {
+        // Paired 11.5K DFlash runs on R9700 show graph replay slower than the
+        // direct tiled-flash path; keep it available as an explicit diagnostic.
         return env_value == Some("1");
     }
     true
@@ -7631,6 +7636,16 @@ mod tests {
             "gfx1201",
             DType::MQ3G256V2,
             None
+        ));
+        assert!(!dflash_verify_graph_env_eligible(
+            "gfx1201",
+            DType::MQ4G256,
+            None
+        ));
+        assert!(dflash_verify_graph_env_eligible(
+            "gfx1201",
+            DType::MQ4G256,
+            Some("1")
         ));
     }
 


### PR DESCRIPTION
## Summary

Disable the default DFlash verifier HipGraph route for `gfx1201 + MQ4G256`.

Paired long-context runs on an R9700 showed the captured verifier graph slower than the direct tiled-flash verifier path. The graph remains available through the explicit diagnostic opt-in:

```bash
HIPFIRE_VERIFY_GRAPH=1
```

Other architectures and quantization shapes retain their existing behavior.

## Which surface(s) does this touch?

- [x] **serve** — speculative DFlash verifier routing
- [x] **arch crate(s):** `hipfire-arch-qwen35`

## Implementation

`dflash_verify_graph_env_eligible()` is default-off only for `gfx1201 + MQ4G256`. Explicit behavior remains:

- `HIPFIRE_VERIFY_GRAPH=0`: force graph off
- `HIPFIRE_VERIFY_GRAPH=1`: diagnostic graph opt-in

The direct batched tiled-flash verifier path remains enabled.

## Tests

- `cargo test -p hipfire-arch-qwen35 --lib dflash_verify_graph_env -- --nocapture`
- `cargo build --release -p hipfire-cli -p hipfire-daemon`
- Full 6-request thinking E2E on local R9700 / gfx1201
- `max-seq=32768`, `max-tokens=1024`, approximately 11.5K-token prompts
- `HIP_VISIBLE_DEVICES=0`
- Qwen3.6 27B MQ4 + DFlash MQ4

E2E result:

```text
turns=6 runaway=0 empty=0 retrieval_miss=0
avg_prefill=594.0 tok/s avg_decode=48.4 tok/s
per-request decode: 61.2, 67.8, 11.7, 63.2, 72.9, 13.3 tok/s
```

All requests completed with `finish=stop`; no attractor or empty-output failures were reported.

Battery output: `/tmp/hf693-gfx12-latest-e2e.json`

## Graph opt-in validation

A separate one-request run with `HIPFIRE_VERIFY_GRAPH=1` confirmed:

```text
[verify-graph] warmup for B=16 complete
[verify-graph] captured for B=16 with 1154 blobs
```

The opt-in request produced the same output identity as the default route (`request_md5=8460b63690bf124ed759f90efdb777f3`, 299 tokens, `tau=4.84`, `finish=stop`).

## Artifacts

```text
daemon md5: 5340f68e16e91548eec4a47eddd49948
target sha256: 86a5f80fd29d545abb1093dead242725ced6d68b8607c6d566d897b1a82442dc
draft sha256: bd8c4f07ae80fe1385bf2606af9a7ba0daa18ca8daec50916f2a489054c44e70
```

<!-- hw-gate-request -->
```json
{"routes":[{"mode":"battery","tag":"qwen3.6:27b"}],"claim":"On gfx1201 with Qwen3.6 27B MQ4 DFlash, the legacy MQ4 verifier Graph is disabled by default while the direct tiled-flash verifier remains active; HIPFIRE_VERIFY_GRAPH=1 still captures the diagnostic graph."}
```
