### PR TITLE
fix(serve_harness): the per-run home wins over an inherited HIPFIRE_HOME

### DIFF
--- a/scripts/serve_harness.py
+++ b/scripts/serve_harness.py
@@ -1951,7 +1951,14 @@ def spawn_serve(cfg, home, log):
     # Honor a caller-provided per-GPU daemon binary (a renamed copy → distinct
     # process comm → the CLI's reapOrphans `pkill -x <name>` stays scoped to THIS
     # instance). HIPFIRE_DAEMON_NAME/ID pass through from os.environ untouched.
-    env = dict(os.environ, HOME=home, HIP_VISIBLE_DEVICES=os.environ.get("HIP_VISIBLE_DEVICES","0"),
+    # The isolated home MUST be what the daemon resolves. ConfigPaths::discover
+    # prefers HIPFIRE_HOME over $HOME/.hipfire, so an inherited HIPFIRE_HOME
+    # (hw-gate exports one per lane) silently replaced this run's config.toml
+    # with the parent's: [speculation] mtp="off" never reached the daemon, the
+    # schema default `auto` auto-attached a sibling .mtp head, and the two gate
+    # lanes diverged on host state (hw-gate run 33900101473, #691).
+    env = dict(os.environ, HOME=home, HIPFIRE_HOME=os.path.join(home, ".hipfire"),
+               HIP_VISIBLE_DEVICES=os.environ.get("HIP_VISIBLE_DEVICES","0"),
                HIPFIRE_DAEMON_BIN=os.environ.get(
                    "HIPFIRE_DAEMON_BIN",
                    os.path.join(REPO, "target", "release", "daemon" + (".exe" if os.name == "nt" else ""))),


### PR DESCRIPTION
## Summary

`spawn_serve` isolates the daemon with `HOME=<run home>` + `<run home>/.hipfire/config.toml`, but inherits `os.environ` — and `ConfigPaths::discover` prefers **`HIPFIRE_HOME`** over `$HOME/.hipfire`. hw-gate exports `HIPFIRE_HOME` per lane (`hw-gate.yml:207`), so every gate daemon read the lane's pinned config (no `[speculation]` section) instead of the harness's `mtp = "off"`; the schema default `auto` then auto-attached a sibling `.mtp` head wherever one existed.

On #691's run ([33900101473](https://github.com/warpfront/hipfire/actions/runs/33900101473)) the lanes diverged on **host state**: hiptrx has `qwen3.8-27b.mq4v2.xt.mtp` beside the symlink target → chain ran under MTP (`drafter=mtp`, one degenerate turn → fixture fail); hipx has no sidecar → AR, clean. The pre-flight printed `mtp_mode: off` on both — the harness's intent, not what the daemon resolved.

## Evidence (hiptrx, base daemon `17ba7dfa`, identical `config.toml` with `mtp="off"`)

| env | result |
|---|---|
| `HIPFIRE_HOME=<gate lane home>` (inherited) | `MTP head loaded` ×1 |
| `HIPFIRE_HOME=<run home>/.hipfire` (this fix) | no head |

## Change

One env entry: `HIPFIRE_HOME=os.path.join(home, ".hipfire")` in `spawn_serve`'s daemon env. Scripts-only; `run.py` runs the harness from the PR checkout, so ladder PRs pick it up on rebase. Also removes a class of "which config did the daemon actually read" ambiguity from every harness user, not just the gate.

## Which surface(s) does this touch?

- [x] docs / CI / scripts — `scripts/serve_harness.py` only