### PR TITLE
revert: serve_harness HIPFIRE_HOME override (#709)

### DIFF
--- a/scripts/serve_harness.py
+++ b/scripts/serve_harness.py
@@ -1951,14 +1951,7 @@ def spawn_serve(cfg, home, log):
     # Honor a caller-provided per-GPU daemon binary (a renamed copy → distinct
     # process comm → the CLI's reapOrphans `pkill -x <name>` stays scoped to THIS
     # instance). HIPFIRE_DAEMON_NAME/ID pass through from os.environ untouched.
-    # The isolated home MUST be what the daemon resolves. ConfigPaths::discover
-    # prefers HIPFIRE_HOME over $HOME/.hipfire, so an inherited HIPFIRE_HOME
-    # (hw-gate exports one per lane) silently replaced this run's config.toml
-    # with the parent's: [speculation] mtp="off" never reached the daemon, the
-    # schema default `auto` auto-attached a sibling .mtp head, and the two gate
-    # lanes diverged on host state (hw-gate run 33900101473, #691).
-    env = dict(os.environ, HOME=home, HIPFIRE_HOME=os.path.join(home, ".hipfire"),
-               HIP_VISIBLE_DEVICES=os.environ.get("HIP_VISIBLE_DEVICES","0"),
+    env = dict(os.environ, HOME=home, HIP_VISIBLE_DEVICES=os.environ.get("HIP_VISIBLE_DEVICES","0"),
                HIPFIRE_DAEMON_BIN=os.environ.get(
                    "HIPFIRE_DAEMON_BIN",
                    os.path.join(REPO, "target", "release", "daemon" + (".exe" if os.name == "nt" else ""))),


### PR DESCRIPTION
Reverts #709. Overriding `HIPFIRE_HOME` wholesale takes over the daemon's entire home (catalog, profiles, models.toml), not just the one file the harness writes — more churn than the MTP auto-attach it was chasing. The harness keeps its original contract: the `[speculation]` TOML it writes is the request; the daemon's own `mtp` policy stands.