### PR TITLE
fix(hw-gate): accept a decide verdict written as a markdown headline

### DIFF
--- a/scripts/hw-gate/review.py
+++ b/scripts/hw-gate/review.py
@@ -283,6 +283,12 @@ def omp_review(phase: str, prompt: str, system_prompt: str, checkout: str, model
                 continue
             raise ReviewError(last_error)
         obj = extract_json(last_text)
+        if obj is None and phase == "decide":
+            # Fable sometimes writes its verdict as a markdown headline instead
+            # of JSON (run 33905366422); accept the decide-phase headline.
+            obj = _markdown_decision(last_text)
+            if obj is not None:
+                return obj
         if obj is None:
             last_error = f"omp {phase}: no JSON object in assistant text: {last_text[:500]!r}"
             if attempt == 0:
@@ -426,6 +432,37 @@ def _parse_omp_stdout(stdout: str) -> tuple[str | None, dict | None]:
         return None, None
     obj = extract_json(last_text)
     return last_text, obj
+DECISION_WORDS = ("merge-staging", "hold", "block")
+
+
+def _markdown_decision(text: str) -> dict | None:
+    """Fallback for a seat that wrote prose instead of JSON.
+
+    Fable's decide output is occasionally a markdown report whose headline is
+    the verdict (`## hw-gate decide — PR #691: **merge-staging**` or
+    `**decision:** block`). Run 33905366422 (#691) had a complete, correct
+    investigation end in `no JSON object in assistant text` because of that.
+    Returns a minimal decision dict so the floor logic sees a real decision;
+    the full text is kept as announcement/rationale and in fable_raw.
+    """
+    import re as _re
+    head = text[:2000]
+    for pat in (
+        r"^#{1,4}\s+hw-gate\s+decide[^\n]*?\*\*(merge-staging|hold|block)\*\*",
+        r"\*\*decision:?\*\*\s*[:=]?\s*`?(merge-staging|hold|block)`?",
+        r"\bdecision:?\s*[:=]?\s*`?(merge-staging|hold|block)`?\s*(?:[.\n]|$)",
+    ):
+        m = _re.search(pat, head, _re.IGNORECASE | _re.MULTILINE)
+        if m:
+            word = m.group(1).lower()
+            return {
+                "decision": word,
+                "announcement": text[:6000],
+                "rationale": text[:6000],
+                "markdown_fallback": True,
+            }
+    return None
+
 
 
 def _list_registry_fixtures(checkout: str, models_dir: str) -> list[tuple[str, str]]:
@@ -1362,14 +1399,20 @@ def _run_decide(args) -> int:
                 else:
                     last_text, obj = _parse_omp_stdout(stdout_text)
                     if obj is None:
-                        fable_unavailable = True
-                        fable_error_reason = "omp decide: no JSON object in assistant text"
-                        sys.stderr.write(f"fable omp failed: {fable_error_reason}\n")
-                        sys.stderr.write(f"fable assistant text (tail): {(last_text or '')[-2000:]!r}\n")
-                        fable_raw = {"assistant_text_tail": (last_text or "")[-4000:], "stderr_tail": stderr_text[-4000:]}
-                        investigation = []
-                        unproven = []
-                        decision = None
+                        md = _markdown_decision(last_text or "")
+                        if md is not None:
+                            decision = md
+                            fable_raw = {"assistant_text_tail": (last_text or "")[-4000:], "stderr_tail": stderr_text[-4000:], "markdown_fallback": True}
+                            sys.stderr.write("fable decide: no JSON object; accepted markdown verdict from the report headline\n")
+                        else:
+                            fable_unavailable = True
+                            fable_error_reason = "omp decide: no JSON object in assistant text"
+                            sys.stderr.write(f"fable omp failed: {fable_error_reason}\n")
+                            sys.stderr.write(f"fable assistant text (tail): {(last_text or '')[-2000:]!r}\n")
+                            fable_raw = {"assistant_text_tail": (last_text or "")[-4000:], "stderr_tail": stderr_text[-4000:]}
+                            investigation = []
+                            unproven = []
+                            decision = None
                     else:
                         decision = obj
                         inv = obj.get("investigation")
@@ -1432,6 +1475,8 @@ def _run_decide(args) -> int:
             sys.stderr.write(f"fable omp failed: {e}\n")
             investigation = []
             unproven = []
+            # omp_review's error text carries the assistant tail; keep it in the artifact.
+            fable_raw = {"assistant_text_tail": str(e)[-4000:]}
             # evidence_dir_val remains as arg value if any
     # Ensure evidence_dir_val is set for decision.json even in non-investigate case
     if investigate and child_env and not evidence_dir_val:

--- a/scripts/hw-gate/tests/test_review.py
+++ b/scripts/hw-gate/tests/test_review.py
@@ -548,7 +548,7 @@ def test_verdict_unparseable_needs_human_exit1():
 # decide e2e
 # ---------------------------------------------------------------------------
 
-def _run_decide(tmp: Path, select_extra: dict | None = None, evidence_extra: dict | None = None, sol_final="greenlight", fable_response: dict | None = None, hw_run_result="success", merge_409=False, checkout_extra_files: dict | None = None):
+def _run_decide(tmp: Path, select_extra: dict | None = None, evidence_extra: dict | None = None, sol_final="greenlight", fable_response: dict | None = None, hw_run_result="success", merge_409=False, checkout_extra_files: dict | None = None, fable_text: str | None = None):
     checkout, base, head = _make_repo(tmp / "checkout_d", files=checkout_extra_files)
     select = {"schema":"hipfire.hw-gate.select","version":1,"needs_hw":True,"buckets":["load"],"policy_paths":[],"surfaces":{"load":["foo.rs"],"serve":[],"kernel":[],"policy":[],"other":[]},"request":None,"request_error":None}
     if select_extra:
@@ -575,10 +575,8 @@ def _run_decide(tmp: Path, select_extra: dict | None = None, evidence_extra: dic
     verdict_path.write_text(json.dumps(sol_verdict_file))
     system_prompt = tmp / "fable.md"
     system_prompt.write_text("fable prompt")
-    if fable_response is None:
-        fable_response = {"phase":"decide","decision":"merge-staging","agrees_with_sol":True,"override":None,"regressions":[],"further_evidence_wanted":[],"rationale":"fable rationale","announcement":"Fable merges."}
     resp_path = tmp / "resp.json"
-    resp_path.write_text(json.dumps([{"json": fable_response}]))
+    resp_path.write_text(json.dumps([{"text": fable_text}] if fable_text is not None else [{"json": fable_response}]))
     call_count = tmp / "omp_count"
     gh_log = tmp / "gh_log.jsonl"
     gh_comments = tmp / "gh_comments.json"
@@ -610,6 +608,31 @@ def test_decide_hard_floor_beats_merge():
     gh_calls = [json.loads(l)["args"] for l in gh_log.read_text().splitlines() if l.strip()]
     merges_calls = [a for a in gh_calls if ("merges" in a[1] if len(a)>1 else False)]
     assert len(merges_calls) == 0
+
+def test_decide_markdown_headline_is_a_decision():
+    # Run 33905366422 (#691): Fable returned a full markdown report whose
+    # headline carried the verdict ("## hw-gate decide — PR #691:
+    # **merge-staging**") and review.py reported "no JSON object in assistant
+    # text", decision=None, decision_final=hold. The fallback must turn that
+    # into the verdict the seat wrote.
+    tmp = Path(tempfile.mkdtemp())
+    md = ("## hw-gate decide — PR #1: **merge-staging**\n\n"
+          "Sol's `needs-human` rested on one claim; I resolved it and closed the gaps on hardware.\n\n"
+          "### Verified\n\n- batteries pass on both lanes\n- the rewrite is behaviour-preserving across 20 turns\n")
+    result, out_path, gh_log, gh_comments, omp_log, base, head, checkout = _run_decide(tmp, fable_text=md)
+    data = json.loads(out_path.read_text())
+    assert data["decision_final"] == "merge-staging", data
+    assert data["decision"]["decision"] == "merge-staging"
+    assert data["decision"]["markdown_fallback"] is True
+    assert data["merged"] is not None
+    # and a report without any verdict word still falls back to unavailable
+    tmp = Path(tempfile.mkdtemp())
+    result, out_path, *_ = _run_decide(tmp, fable_text="I investigated a lot and have findings but no headline.")
+    data = json.loads(out_path.read_text())
+    assert data["decision_final"] == "hold"
+    assert data["decision"] is None
+    assert data["fable_error"].startswith("omp decide: no JSON object in assistant text")
+    assert data["fable_raw"]["assistant_text_tail"]
 
 def test_decide_override_needs_human_to_merge():
     tmp = Path(tempfile.mkdtemp())


### PR DESCRIPTION
## Summary

[Run 33905366422](https://github.com/warpfront/hipfire/actions/runs/33905366422) (#691): Fable's decide phase returned a complete, correct investigation — **as a markdown report** headed `## hw-gate decide — PR #691: **merge-staging**` instead of a JSON object. `review.py` reported "no JSON object in assistant text", `decision=None`, `decision_final=hold` — red run on a green verdict, and the staging merge never happened.

(This class of failure is why the ladder loses a run: the seat did the work and the gate lost it at the serializer.)

## Change

- `_markdown_decision()` recognizes the decide headline / bold decision word (`**merge-staging**`, `**decision:** hold`, `decision: block`) within the report head and synthesizes the decision dict; the full text is kept as announcement/rationale and in `fable_raw.markdown_fallback`.
- Wired into both decide paths: `omp_investigate`'s no-JSON branch and `omp_review`'s retry loop (decide phase only).
- `fable_raw` is now also set on the non-investigate failure path (the omp_review error message carries the assistant tail).

## Evidence

`test_decide_markdown_headline_is_a_decision`: a headline verdict yields `decision_final=merge-staging` and the staging merge fires; prose without a verdict word yields `hold` with `fable_error` + raw tail in the artifact. Full suite: **104/104**.

## Which surface(s) does this touch?

- [x] **policy files** — `scripts/hw-gate/review.py` (hard floor: a human merges this)