### PR TITLE
fix(hw-gate): never let a dead decide seat hold the GPU lock, never re-gate a merged PR

### DIFF
--- a/.github/workflows/hw-gate.yml
+++ b/.github/workflows/hw-gate.yml
@@ -62,6 +62,11 @@ env:
 jobs:
   select:
     name: select
+    # A merged or closed PR must never re-enter the gate. Label churn on a
+    # closed PR is still a pull_request_target event, and run 33915818350
+    # (2026-09-04) re-ran the whole gate on #711 five minutes after it merged,
+    # taking the runner and the exclusive GPU lock away from live rungs.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged != true
     runs-on: ubuntu-latest
     outputs:
       needs_hw: ${{ steps.sel.outputs.needs_hw }}
@@ -397,7 +402,53 @@ jobs:
         with:
           name: hw-gate-verdict
           path: evidence
+      - name: "Seat preflight (no GPU lock)"
+        id: seat
+        env:
+          HOME: ${{ github.workspace }}/fable-home-probe
+        run: |
+          set -uo pipefail
+          # The decide step holds the EXCLUSIVE lock on all five GPUs for its
+          # whole budget. A seat that cannot answer at all — provider credits,
+          # auth, retired model — used to hold that lock for the full 45 min
+          # and starve every queued rung's hardware lane (observed 2026-09-04:
+          # #711's dead decide phase blocked #687 and #688 for ~20 min).
+          # One 90 s toolless probe, before the lock, tells us whether the seat
+          # can reply. It costs one token and never touches a GPU.
+          rm -rf fable-home-probe && mkdir -p fable-home-probe
+          if timeout 90 omp -p --mode json --model "$HW_GATE_DECIDE_MODEL" \
+               --max-time 1m 'Reply with the single word READY.' >probe.json 2>probe.err; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+            echo "seat $HW_GATE_DECIDE_MODEL replied"
+          else
+            rc=$?
+            reason="$(tail -c 400 probe.err | tr '\n' ' ' | sed 's/"/'"'"'/g')"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "reason=seat $HW_GATE_DECIDE_MODEL unavailable (rc=$rc): $reason" >> "$GITHUB_OUTPUT"
+            echo "::warning::decide seat unavailable (rc=$rc); skipping the GPU-locked phase: $reason"
+          fi
+      - name: "Decider unavailable: record hold without taking the GPU lock"
+        if: steps.seat.outputs.ok != 'true'
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token || github.token }}
+        run: |
+          set -euo pipefail
+          python3 base/scripts/hw-gate/review.py --phase decide --seat fable \
+            --repo "$GITHUB_REPOSITORY" --pr "$PR_NUMBER" \
+            --base "${{ needs.select.outputs.base_sha }}" \
+            --head "${{ needs.select.outputs.head_sha }}" \
+            --checkout pr \
+            --select evidence/select.json \
+            --prelim evidence/prelim.json \
+            --evidence evidence/hw-gate.json \
+            --verdict evidence/verdict.json \
+            --hw-run-result "${{ needs.hw-run.result }}" \
+            --staging "$HW_GATE_STAGING" \
+            --decider-unavailable "${{ steps.seat.outputs.reason }}" \
+            --system-prompt base/scripts/hw-gate/fable.md \
+            --out decision.json
       - name: "Fable investigates and decides (exclusive GPU lock: all five devices)"
+        if: steps.seat.outputs.ok == 'true'
         env:
           GH_TOKEN: ${{ steps.token.outputs.token || github.token }}
         run: |

--- a/scripts/hw-gate/review.py
+++ b/scripts/hw-gate/review.py
@@ -1346,7 +1346,15 @@ def _run_decide(args) -> int:
     fable_raw: dict | None = None
     investigation: list = []
     unproven: list = []
-    if investigate:
+    # Preflight already proved the seat cannot answer, so there is nothing to
+    # call and no reason to hold the exclusive GPU lock its phase normally
+    # takes: record the hold and let the floors + comment run as usual.
+    unavailable_reason = (getattr(args, "decider_unavailable", None) or "").strip()
+    if unavailable_reason:
+        fable_unavailable = True
+        fable_error_reason = unavailable_reason
+        sys.stderr.write(f"decide skipped: {unavailable_reason}\n")
+    elif investigate:
         # Validate and build sandboxed env
         try:
             child_env, max_minutes_str = _build_investigate_env(args)
@@ -1725,6 +1733,7 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--verdict", help="verdict.json path (decide only)")
     ap.add_argument("--hw-run-result", help="hw-run result string")
     ap.add_argument("--staging", help="staging branch name (decide only)")
+    ap.add_argument("--decider-unavailable", dest="decider_unavailable", help="decide only: record the seat as unavailable with this reason, without calling the model")
     ap.add_argument("--routes", help="routes.json output path (prelim only)")
     ap.add_argument("--system-prompt", required=True)
     ap.add_argument("--out", required=True, help="output JSON path")

--- a/scripts/hw-gate/run.py
+++ b/scripts/hw-gate/run.py
@@ -423,9 +423,22 @@ def _evaluate_mode(exit_code: int, raw_rows) -> tuple[str, str, list[dict]]:
     return "pass", "", enriched
 
 
-def _build_harness_argv(repo: Path, model_path: Path, mode: str, max_tokens: int, battery_prompts_path: Path | None, per_home: Path, out_path: Path, serve_log_path: Path) -> list[str]:
-    """Build argv for serve_harness.py. Never includes --devices."""
-    harness = Path(repo) / "scripts" / "serve_harness.py"
+# The gate's own checkout, for when no fixtures-derived `_gate_root` is at hand:
+# this file lives at <gate>/scripts/hw-gate/run.py.
+GATE_REPO = Path(__file__).resolve().parents[2]
+
+
+def _build_harness_argv(gate_root: Path, model_path: Path, mode: str, max_tokens: int, battery_prompts_path: Path | None, per_home: Path, out_path: Path, serve_log_path: Path) -> list[str]:
+    """Build argv for serve_harness.py. Never includes --devices.
+
+    The harness is the oracle, so it comes from the gate checkout and never
+    from the PR under test, which supplies only the binaries. A PR older than
+    a harness fix used to run the buggy harness against its own binaries: #682,
+    based on master from before #703, false-flagged a 3-token `Answer: 43` turn
+    as a token attractor on BOTH lanes (run 33921475093) and hard-floored on
+    evidence that was correct.
+    """
+    harness = Path(gate_root) / "scripts" / "serve_harness.py"
     argv = [
         sys.executable,
         str(harness),
@@ -471,7 +484,7 @@ def _run_harness_mode(repo, fixture, env_base, logs_dir, device, mode, harness_c
     safe_tag = _sanitize_tag(tag)
     file_name = fixture.get("file", "")
     model_path = Path(models_dir).expanduser() / file_name if file_name else Path(models_dir) / tag
-    harness = repo_p / "scripts" / "serve_harness.py"
+    harness = Path(harness_cfg.get("_gate_root") or repo_p) / "scripts" / "serve_harness.py"
     # harness cfg
     # The battery prompts are gate policy: they resolve against the GATE
     # checkout (the directory tree holding fixtures.json), never against the
@@ -494,7 +507,7 @@ def _run_harness_mode(repo, fixture, env_base, logs_dir, device, mode, harness_c
     out_path = logs_dir_p / f"{safe_tag}-{mode}.json"
     serve_log_path = logs_dir_p / f"{safe_tag}-{mode}.serve.log"
     out_combined_path = logs_dir_p / f"{safe_tag}-{mode}.out"
-    argv = _build_harness_argv(repo_p, model_path, mode, max_tokens, battery_prompts_path, per_home, out_path, serve_log_path)
+    argv = _build_harness_argv(gate_root, model_path, mode, max_tokens, battery_prompts_path, per_home, out_path, serve_log_path)
     start = time.time()
     exit_code = 1
     stdout = ""
@@ -713,7 +726,8 @@ def run_kernel(repo, models_dir, kernel_cfg, fixtures_manifest, env, logs_dir) -
     model_path = Path(models_dir).expanduser() / model_file if model_file else Path(models_dir) / (model_tag or "")
     bin_dir = _resolve_bin_dir(repo_p)
     daemon_bin = bin_dir / "daemon"
-    harness = repo_p / "scripts" / "redline_daemon_harness.py"
+    # Same rule as serve_harness: the instrument is the gate's, not the PR's.
+    harness = GATE_REPO / "scripts" / "redline_daemon_harness.py"
     redline_out = logs_dir_p / "redline.json"
     harness_args = kernel_cfg.get("harness_args", []) if isinstance(kernel_cfg, dict) else []
     harness_args = [str(a) for a in harness_args]
@@ -1199,14 +1213,13 @@ def main(argv: list[str] | None = None) -> int:
         need_serve = any(len(modes) > 0 for _, _, _, modes, _ in runnable)
         # Also if only unavailable/unknown routes, still need not fail on missing harness? But keep check for consistency: if routes non-empty but none runnable, we don't need harness.
         if need_serve:
-            if not (repo_p / "scripts" / "serve_harness.py").is_file():
+            if not (GATE_REPO / "scripts" / "serve_harness.py").is_file():
                 precondition_failed = True
                 precondition_reason = "missing scripts/serve_harness.py"
         if "kernel" in buckets:
-            if not (repo_p / "scripts" / "redline_daemon_harness.py").is_file():
+            if not (GATE_REPO / "scripts" / "redline_daemon_harness.py").is_file():
                 precondition_failed = True
                 precondition_reason = "missing scripts/redline_daemon_harness.py"
-
         if precondition_failed:
             fixtures_evidence: list[dict] = []
             for fx, vr in routed_precondition_failures:

--- a/scripts/hw-gate/tests/test_review.py
+++ b/scripts/hw-gate/tests/test_review.py
@@ -548,7 +548,7 @@ def test_verdict_unparseable_needs_human_exit1():
 # decide e2e
 # ---------------------------------------------------------------------------
 
-def _run_decide(tmp: Path, select_extra: dict | None = None, evidence_extra: dict | None = None, sol_final="greenlight", fable_response: dict | None = None, hw_run_result="success", merge_409=False, checkout_extra_files: dict | None = None, fable_text: str | None = None):
+def _run_decide(tmp: Path, select_extra: dict | None = None, evidence_extra: dict | None = None, sol_final="greenlight", fable_response: dict | None = None, hw_run_result="success", merge_409=False, checkout_extra_files: dict | None = None, fable_text: str | None = None, extra_args: list | None = None):
     checkout, base, head = _make_repo(tmp / "checkout_d", files=checkout_extra_files)
     select = {"schema":"hipfire.hw-gate.select","version":1,"needs_hw":True,"buckets":["load"],"policy_paths":[],"surfaces":{"load":["foo.rs"],"serve":[],"kernel":[],"policy":[],"other":[]},"request":None,"request_error":None}
     if select_extra:
@@ -595,8 +595,33 @@ def _run_decide(tmp: Path, select_extra: dict | None = None, evidence_extra: dic
         env["FAKE_GH_MERGE_409"] = "1"
     env["HW_GATE_DECIDE_MODEL"] = "claude-fable-5-1"
     cmd = [sys.executable, str(REVIEW_PATH),"--seat","fable","--phase","decide","--repo","o/r","--pr","1","--base",base,"--head",head,"--checkout",str(checkout),"--select",str(select_path),"--prelim",str(prelim_path),"--evidence",str(evidence_path),"--verdict",str(verdict_path),"--hw-run-result",hw_run_result,"--staging","beta","--system-prompt",str(system_prompt),"--out",str(out_path)]
+    if extra_args:
+        cmd.extend(extra_args)
     result = subprocess.run(cmd, env=env, capture_output=True, text=True)
     return result, out_path, gh_log, gh_comments, omp_log, base, head, checkout
+
+def test_decide_unavailable_seat_holds_without_calling_the_model():
+    """The preflight already proved the seat cannot answer.
+
+    review.py must then reach a hold on the floors alone, without spending a
+    model call — and above all without the workflow taking the exclusive GPU
+    lock, which on 2026-09-04 a dead #711 decide phase held for ~20 min while
+    #687 and #688 waited for a hardware lane.
+    """
+    tmp = Path(tempfile.mkdtemp())
+    result, out_path, gh_log, gh_comments, omp_log, base, head, checkout = _run_decide(
+        tmp, sol_final="greenlight", extra_args=["--decider-unavailable", "seat claude-fable-5-1 unavailable (rc=1): credit balance too low"],
+    )
+    data = json.loads(out_path.read_text())
+    assert data["decision"] is None
+    assert data["decision_final"] == "hold", data
+    assert "credit balance too low" in (data["fable_error"] or "")
+    # no model call at all: the fake never ran, so it never opened its log
+    assert not omp_log.exists() or omp_log.read_text().strip() == ""
+    # and no merge
+    gh_calls = [json.loads(l)["args"] for l in gh_log.read_text().splitlines() if l.strip()]
+    assert not [a for a in gh_calls if len(a) > 1 and "merges" in a[1]]
+
 
 def test_decide_hard_floor_beats_merge():
     tmp = Path(tempfile.mkdtemp())

--- a/scripts/hw-gate/tests/test_run.py
+++ b/scripts/hw-gate/tests/test_run.py
@@ -836,3 +836,33 @@ def test_battery_prompts_resolve_against_gate_root_not_pr(tmp_path, monkeypatch)
     cfg["_gate_root"] = str(pr)
     res = run_mod._run_harness_mode(str(pr), {"tag": "t:x", "file": "x.mq4"}, env, str(tmp_path / "logs"), "0", "battery", cfg, str(tmp_path))
     assert res["status"] == "fail" and "gate policy" in res["reason"]
+
+
+def test_serve_harness_runs_from_gate_root_not_pr(tmp_path, monkeypatch):
+    """The oracle is the gate's, not the branch's.
+
+    #682 is based on master from before #703, so its serve_harness.py has no
+    ATTRACTOR_MIN_WINDOW guard; run 33921475093 executed that copy and flagged
+    a 3-token `Answer: 43` turn as a token attractor on BOTH lanes, failing a
+    PR on evidence its own rows show as correct. A branch supplies binaries,
+    never the instrument that measures them.
+    """
+    gate = tmp_path / "gate"; (gate / "scripts" / "hw-gate").mkdir(parents=True)
+    (gate / "scripts" / "serve_harness.py").write_text("# the good harness\n")
+    (gate / "benchmarks" / "prompts" / "hw-gate").mkdir(parents=True)
+    (gate / "benchmarks" / "prompts" / "hw-gate" / "serve-battery.json").write_text("[]")
+    pr = tmp_path / "pr"; (pr / "scripts").mkdir(parents=True)
+    (pr / "scripts" / "serve_harness.py").write_text("# the stale harness\n")
+    seen = {}
+    def fake_run_cmd(argv, **kw):
+        seen["argv"] = argv
+        class R: returncode, stdout, stderr = 0, "", ""
+        return R()
+    monkeypatch.setattr(run_mod, "run_cmd", fake_run_cmd)
+    (tmp_path / "out.json").write_text("[]")
+    cfg = {"battery_prompts": "benchmarks/prompts/hw-gate/serve-battery.json", "max_tokens": 8, "_gate_root": str(gate)}
+    env = {"HIPFIRE_HOME": str(tmp_path / "home")}
+    run_mod._run_harness_mode(str(pr), {"tag": "t:x", "file": "x.mq4"}, env, str(tmp_path / "logs"), "0", "battery", cfg, str(tmp_path))
+    script = seen["argv"][1]
+    assert script == str(gate / "scripts" / "serve_harness.py"), script
+    assert str(pr) not in script


### PR DESCRIPTION
Two defects found while driving the ladder tonight. Both cost live rungs their hardware lane, and both are gate plumbing rather than product code.

## 1 · A decide seat that cannot answer holds all five GPUs for 45 minutes

`fable-decide` takes `flock --exclusive` on `hw-gate-gpu.lock` around the *whole* `review.py --phase decide` process (workflow line 411), for its full `HW_GATE_MAX_MINUTES` budget. Tonight #711's decide phase had no provider credits and could never produce a verdict — yet it held that lock for ~20 minutes while #687 and #688 sat queued with `hardware (gfx1201)` unable to start. I only found it by `fuser`-ing the lock file and seeing a `--pr 711` process on a PR that merged at 19:16.

A seat that cannot answer must not own the hardware.

**Fix:** one 90 s toolless probe of the decide model *before* the lock is taken.
- probe replies → the locked phase runs exactly as before, unchanged
- probe fails → the locked step is skipped entirely, and a new unlocked step records the hold via `--decider-unavailable REASON`, which short-circuits the model call in `review.py` and lets the floors, PR comment, and labels run as usual

The GPUs are never claimed, and the PR still gets a comment explaining why it held. This is not a fallback model or a retry — an out-of-credit seat still fails, it just fails without taking the hardware down with it.

## 2 · A merged PR can re-run the entire gate

`pull_request_target` fires on `labeled` even for a closed PR, and the gate itself applies labels. Run 33915818350 re-ran the whole gate on #711 five minutes after it merged, taking the runner and the exclusive lock from live rungs; the same thing happened again on #691, #686, #687 and #688 after each staging merge — I cancelled six of these by hand tonight.

**Fix:** `select` refuses any event whose PR is already merged. `workflow_dispatch` is explicitly unaffected, so a manual re-gate of a merged PR still works when you want one.

## Test

`test_decide_unavailable_seat_holds_without_calling_the_model` asserts the hold, the recorded reason, no merge — and no model invocation at all (the fake never opens its log, so the assertion is `not omp_log.exists()`). **105/105** hw-gate tests pass.

Touches `.github/workflows/hw-gate.yml` and `scripts/hw-gate/**`, so it is policy-floor by construction and cannot self-merge.