### PR TITLE
overhaul(s6c): pin hipfire-reap serde_json + consumer default-features

### DIFF
--- a/crates/hipfire-arch-deepseek4/Cargo.toml
+++ b/crates/hipfire-arch-deepseek4/Cargo.toml
@@ -19,7 +19,7 @@ rdna-compute = { path = "../rdna-compute" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 hipfire-dispatch = { path = "../hipfire-dispatch", features = ["from-hip-error"] }
-hipfire-reap = { path = "../hipfire-reap" }
+hipfire-reap = { path = "../hipfire-reap", default-features = false }
 saddle-core = { path = "../saddle-core" }
 memmap2 = "0.9"
 

--- a/crates/hipfire-arch-lfm2moe/Cargo.toml
+++ b/crates/hipfire-arch-lfm2moe/Cargo.toml
@@ -12,7 +12,7 @@ hipfire-runtime = { path = "../hipfire-runtime" }
 hipfire-dispatch = { path = "../hipfire-dispatch", features = ["from-hip-error"] }
 rdna-compute = { path = "../rdna-compute" }
 hip-bridge = { path = "../hip-bridge" }
-hipfire-reap = { path = "../hipfire-reap" }
+hipfire-reap = { path = "../hipfire-reap", default-features = false }
 # VL: the bundle carries the optional SigLIP2-NaFlex tower + projector when
 # an lfm2_vl artifact was loaded with --include-vision. Acyclic — lfm2-vl
 # never depends back on this crate.

--- a/crates/hipfire-arch-minimax/Cargo.toml
+++ b/crates/hipfire-arch-minimax/Cargo.toml
@@ -21,7 +21,7 @@ hipfire-runtime = { path = "../hipfire-runtime" }
 hipfire-dispatch = { path = "../hipfire-dispatch", features = ["from-hip-error"] }
 hip-bridge = { path = "../hip-bridge" }
 rdna-compute = { path = "../rdna-compute" }
-hipfire-reap = { path = "../hipfire-reap" }
+hipfire-reap = { path = "../hipfire-reap", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/crates/hipfire-arch-qwen35/Cargo.toml
+++ b/crates/hipfire-arch-qwen35/Cargo.toml
@@ -19,7 +19,7 @@ hipfire-arch-qwen35-vl = { path = "../hipfire-arch-qwen35-vl" }
 hipfire-dispatch = { path = "../hipfire-dispatch", features = ["from-hip-error"] }
 hip-bridge = { path = "../hip-bridge" }
 rdna-compute = { path = "../rdna-compute" }
-hipfire-reap = { path = "../hipfire-reap" }
+hipfire-reap = { path = "../hipfire-reap", default-features = false }
 saddle-core = { path = "../saddle-core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/hipfire-reap/Cargo.toml
+++ b/crates/hipfire-reap/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 [dependencies]
 hipfire-config = { path = "../hipfire-config" }
 hipfire-runtime = { path = "../hipfire-runtime" }
-serde_json = { version = "1", features = ["preserve_order"] }
+serde_json = { version = "1", default-features = false, features = ["preserve_order"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary

Slice 6(c) of the QOL/crate overhaul: explicit features for `hipfire-reap` and its arch consumers.

- `crates/hipfire-reap`: `serde_json` now `default-features = false, features = ["preserve_order"]` (code uses `Value` / `from_str` / `json!` only — no `serde` derive/rc). `preserve_order` enables `std`.
- Four arch crates pin `hipfire-reap = { path = "…", default-features = false }` (deepseek4, lfm2moe, minimax, qwen35). Crate map lists four reverse deps; report said "3 arch".
- **Not changed:** `hipfire-runtime` kept with defaults. `default-features = false` fails to compile runtime itself — unconditional `use crate::{ddtree,dflash}` while those modules are `cfg(feature = "deltanet")`. Required feature: **`deltanet`**.
- **Not touched:** `hipfire-quantize` (depends on reap but outside arch boundary); no code restructure / serde-typed plan rewrite (out of this mechanical slice).

## Proof

```
cargo check -p hipfire-reap                          # Finished
cargo check -p hipfire-arch-deepseek4 \
  -p hipfire-arch-lfm2moe -p hipfire-arch-minimax \
  -p hipfire-arch-qwen35                             # Finished
cargo test -p hipfire-reap
# test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`Cargo.lock` unchanged.

## Before / after

```
# hipfire-reap
-serde_json = { version = "1", features = ["preserve_order"] }
+serde_json = { version = "1", default-features = false, features = ["preserve_order"] }

# each of 4 arch crates
-hipfire-reap = { path = "../hipfire-reap" }
+hipfire-reap = { path = "../hipfire-reap", default-features = false }
```