### PR TITLE
bind(mesh): assert Ep topology on every EP load path

### DIFF
--- a/crates/hipfire-loader/src/lib.rs
+++ b/crates/hipfire-loader/src/lib.rs
@@ -27,6 +27,7 @@ use hipfire_arch_qwen35::Qwen35Bundle;
 use hipfire_arch_qwen35_vl::qwen35_vl;
 use hipfire_runtime::arch_model::ArchModel;
 use hipfire_runtime::cask::CaskCtx;
+use hipfire_runtime::device_mesh::DimKind;
 use hipfire_runtime::hfq::HfqFile;
 use hipfire_runtime::kv_backend::KvBackend;
 use hipfire_runtime::kv_mode;
@@ -3107,6 +3108,17 @@ fn load_model_ep_ds4(
             "init_ep gave {n} devices, expected tp={tp} (check ROCR_VISIBLE_DEVICES / HIP_VISIBLE_DEVICES)"
         ));
     }
+    // Bind the recorded mesh to the loaded topology: `init_ep` is the only
+    // thing distinguishing this `Gpus` from a TP one (identical devices,
+    // bands, and pre-flight), so fail loudly here — where both the mesh and
+    // the rank count are known — if a future constructor ever records the
+    // wrong axis instead of loading silently mislabeled.
+    let ep = gpus.mesh.size_of(DimKind::Ep);
+    if ep != n {
+        return Err(format!(
+            "init_ep mesh records Ep={ep} for {n} devices, expected tp={tp} (mesh axis out of sync with constructed ranks)"
+        ));
+    }
     eprintln!("[loader] EP load: tp={tp} arch=ds4 experts={n_exp} (rank r owns e%{tp}==r)");
     let shard = ShardConfig::new_uneven_experts(
         tp,
@@ -3335,6 +3347,17 @@ fn load_model_ep_minimax(path: &str, max_seq: usize, tp: usize) -> Result<Loaded
             "init_ep gave {n} devices, expected tp={tp} (check ROCR_VISIBLE_DEVICES / HIP_VISIBLE_DEVICES)"
         ));
     }
+    // Bind the recorded mesh to the loaded topology: `init_ep` is the only
+    // thing distinguishing this `Gpus` from a TP one (identical devices,
+    // bands, and pre-flight), so fail loudly here — where both the mesh and
+    // the rank count are known — if a future constructor ever records the
+    // wrong axis instead of loading silently mislabeled.
+    let ep = gpus.mesh.size_of(DimKind::Ep);
+    if ep != n {
+        return Err(format!(
+            "init_ep mesh records Ep={ep} for {n} devices, expected tp={tp} (mesh axis out of sync with constructed ranks)"
+        ));
+    }
     eprintln!("[loader] EP load: tp={tp} arch=minimax experts={n_exp} (rank r owns e%{tp}==r)");
     let shard = ShardConfig::new(
         tp,
@@ -3477,6 +3500,17 @@ fn load_model_ep_qwen35(
     if n != tp {
         return Err(format!(
             "init_ep gave {n} devices, expected tp={tp} (check ROCR_VISIBLE_DEVICES / HIP_VISIBLE_DEVICES)"
+        ));
+    }
+    // Bind the recorded mesh to the loaded topology: `init_ep` is the only
+    // thing distinguishing this `Gpus` from a TP one (identical devices,
+    // bands, and pre-flight), so fail loudly here — where both the mesh and
+    // the rank count are known — if a future constructor ever records the
+    // wrong axis instead of loading silently mislabeled.
+    let ep = gpus.mesh.size_of(DimKind::Ep);
+    if ep != n {
+        return Err(format!(
+            "init_ep mesh records Ep={ep} for {n} devices, expected tp={tp} (mesh axis out of sync with constructed ranks)"
         ));
     }
     for (idx, dev) in gpus.devices.iter().enumerate() {


### PR DESCRIPTION
Slice 6(a): bind-or-delete the mesh abstraction (loader half).

What: each of the three EP loaders in crates/hipfire-loader/src/lib.rs (load_model_ep_ds4, load_model_ep_minimax, load_model_ep_qwen35) now checks gpus.mesh.size_of(Ep) == n immediately after the existing devices-vs-tp check, returning Err loudly on mismatch. The mesh axis is the only thing distinguishing an EP Gpus from a TP one (identical devices, bands, pre-flight), so this makes the abstraction load-bearing at the one place that knows both values.

Proof: cargo check -p hipfire-loader clean (no new warnings); cargo test -p hipfire-loader: 34 passed, 0 failed.

Deliberately NOT changed: MeshEpoch / CollectiveHint::AllReduce / init_vram_weighted all live in crates/hipfire-runtime (device_mesh.rs, multi_gpu.rs) on this beta base - there is no crates/hipfire-hardware here - which is outside this slice's owner boundary. Findings for the runtime owner: AllReduce is never constructed (only BandXfer at device_mesh.rs:302); init_vram_weighted has no callers (def at multi_gpu.rs:229); MeshEpoch has live internal use (PartialEq at device_mesh.rs:129-135, squeezed at :349-360) though epoch()/as_u64 have no non-test callers. No GPU run (both devices busy); parent gates EP load on hardware.