### PR TITLE
hip-bridge: DeviceBuffer::byte_view, migrate kv/dispatch device views

### DIFF
--- a/crates/hip-bridge/src/lib.rs
+++ b/crates/hip-bridge/src/lib.rs
@@ -148,6 +148,46 @@ impl DeviceBuffer {
             ownership: DeviceBufferOwnership::Borrowed,
         }
     }
+
+    /// Non-owning byte-range view into this allocation: bytes
+    /// `[byte_offset, byte_offset + byte_len)`.
+    ///
+    /// This is the single home of the device-pointer reinterpretation that
+    /// used to be hand-rolled at every callsite (`as_ptr() as *mut u8`
+    /// + `add` + `DeviceBuffer::from_raw`). The range is validated against
+    /// the allocation size with checked arithmetic before any pointer
+    /// arithmetic runs, so the `add` below is always in-bounds.
+    ///
+    /// Like [`DeviceBuffer::alias`], the view is `Borrowed`: it must NOT be
+    /// freed, and it must not outlive the buffer it was cut from.
+    ///
+    /// # Safety
+    ///
+    /// The invariant that holds: `byte_offset + byte_len <= self.size()`,
+    /// enforced by the checked range test below, so the derived pointer
+    /// addresses only bytes of this live device allocation (`u8` has
+    /// alignment 1, so there is no alignment precondition beyond the
+    /// allocation itself). The caller must still ensure the view does not
+    /// outlive the owning buffer and is never passed to a free path.
+    pub fn byte_view(&self, byte_offset: usize, byte_len: usize) -> DeviceBuffer {
+        let end = byte_offset
+            .checked_add(byte_len)
+            .expect("DeviceBuffer::byte_view range overflow");
+        assert!(
+            end <= self.size,
+            "DeviceBuffer::byte_view [{byte_offset}, {end}) exceeds allocation of {} bytes",
+            self.size,
+        );
+        // SAFETY: `end <= self.size` (checked above), so `add(byte_offset)`
+        // stays in-bounds of the same allocation and names only live device
+        // bytes. The wrapper is Borrowed, so drop never frees it.
+        let ptr = unsafe { (self.ptr as *mut u8).add(byte_offset) as *mut std::ffi::c_void };
+        DeviceBuffer {
+            ptr,
+            size: byte_len,
+            ownership: DeviceBufferOwnership::Borrowed,
+        }
+    }
 }
 
 // DeviceBuffer is Send — GPU pointers can be sent between threads.

--- a/crates/hipfire-dispatch/src/pipeline/mod.rs
+++ b/crates/hipfire-dispatch/src/pipeline/mod.rs
@@ -149,12 +149,18 @@ fn find_fused(
 }
 
 /// Slice a subrange of a flat F32 GpuTensor by element offset + length.
-/// Mirrors qwen35::slice_f32_view — unsafe because it aliases device memory.
-unsafe fn slice_moe_f32_view(src: &GpuTensor, offset_elems: usize, len_elems: usize) -> GpuTensor {
-    let base = src.buf.as_ptr() as *mut u8;
-    let ptr = base.add(offset_elems * 4);
+/// The view aliases device memory owned by the source tensor: do NOT free
+/// it, and do NOT let it outlive the source. Out-of-range slices panic via
+/// the [`hip_bridge::DeviceBuffer::byte_view`] range check.
+fn slice_moe_f32_view(src: &GpuTensor, offset_elems: usize, len_elems: usize) -> GpuTensor {
+    let byte_offset = offset_elems
+        .checked_mul(4)
+        .expect("slice_moe_f32_view offset overflow");
+    let byte_len = len_elems
+        .checked_mul(4)
+        .expect("slice_moe_f32_view length overflow");
     GpuTensor {
-        buf: hip_bridge::DeviceBuffer::from_raw(ptr as *mut _, len_elems * 4),
+        buf: src.buf.byte_view(byte_offset, byte_len),
         shape: vec![len_elems],
         dtype: DType::F32,
     }
@@ -676,9 +682,9 @@ pub fn run_moe_decode(
     };
 
     // ── Gate-side GEMV ───────────────────────────────────────────────────────
-    // SAFETY: all slice views alias device memory owned by MoEParams' scratch tensors.
-    let shared_gate = unsafe { slice_moe_f32_view(p.gate_buf, 0, p.smi) };
-    let shared_up = unsafe { slice_moe_f32_view(p.up_buf, 0, p.smi) };
+    // NOTE: all slice views alias device memory owned by MoEParams' scratch tensors.
+    let shared_gate = slice_moe_f32_view(p.gate_buf, 0, p.smi);
+    let shared_up = slice_moe_f32_view(p.up_buf, 0, p.smi);
     if res.gate_fusable {
         let xr = x_rot_local.expect("gate_fusable implies x_rot_local (needs_x_rot_local)");
         // Exact-uniform V1 MQ4G256 gate quartet → one fused launch.
@@ -1081,7 +1087,7 @@ pub fn run_moe_decode(
             #[cfg(feature = "deltanet")]
             {
                 hip!(gpu.sigmoid_f32(p.scalar_buf))?;
-                let shared_hid = unsafe { slice_moe_f32_view(p.ffn_hidden, 0, p.smi) };
+                let shared_hid = slice_moe_f32_view(p.ffn_hidden, 0, p.smi);
                 hip!(gpu.silu_mul_f32(&shared_gate, &shared_up, &shared_hid))?;
                 static GEMV_DOWN: OnceLock<GemvFamily> = OnceLock::new();
                 let gemv = GEMV_DOWN.get_or_init(GemvFamily::new);
@@ -2021,7 +2027,7 @@ fn run_moe_decode_cpu_fallback(
         #[cfg(feature = "deltanet")]
         {
             hip!(gpu.sigmoid_f32(p.scalar_buf))?;
-            let shared_hid = unsafe { slice_moe_f32_view(p.ffn_hidden, 0, p.smi) };
+            let shared_hid = slice_moe_f32_view(p.ffn_hidden, 0, p.smi);
             hip!(gpu.silu_mul_f32(shared_gate, shared_up, &shared_hid))?;
             static GEMV_DOWN_FB: OnceLock<GemvFamily> = OnceLock::new();
             let gemv = GEMV_DOWN_FB.get_or_init(GemvFamily::new);
@@ -2076,11 +2082,11 @@ fn run_moe_decode_cpu_fallback(
         {
             gemv.run_auto(ctx, gpu, gate_up_w, p.x_norm, p.gate_up_buf)?;
         }
-        let gate_view = unsafe { slice_moe_f32_view(p.gate_up_buf, 0, mi) };
-        let up_view = unsafe { slice_moe_f32_view(p.gate_up_buf, mi, mi) };
+        let gate_view = slice_moe_f32_view(p.gate_up_buf, 0, mi);
+        let up_view = slice_moe_f32_view(p.gate_up_buf, mi, mi);
 
         // silu(gate)·up → ffn_hidden, then down GEMV, then weighted residual add.
-        let hid_view = unsafe { slice_moe_f32_view(p.ffn_hidden, 0, mi) };
+        let hid_view = slice_moe_f32_view(p.ffn_hidden, 0, mi);
         hip!(gpu.silu_mul_f32(&gate_view, &up_view, &hid_view))?;
         // GPTQ-on-E8 Hessian capture: hid_view = silu(g)*u is the RAW
         // PRE-rotation down input (run_auto below applies the FWHT internally),

--- a/crates/saddle-core/src/kv.rs
+++ b/crates/saddle-core/src/kv.rs
@@ -943,10 +943,8 @@ impl KvCache {
                     "q8_lane_view lane byte range exceeds parent buffer",
                 ));
             }
-            let ptr =
-                unsafe { (t.buf.as_ptr() as *mut u8).add(byte_offset) as *mut std::ffi::c_void };
             Ok(GpuTensor {
-                buf: unsafe { hip_bridge::DeviceBuffer::from_raw(ptr, lane_bytes) },
+                buf: t.buf.byte_view(byte_offset, lane_bytes),
                 shape: vec![lane_elems],
                 dtype: DType::F32,
             })


### PR DESCRIPTION
Slice 6(d): centralize the hand-rolled GPU-tensor byte reinterpretation.

- Adds safe `DeviceBuffer::byte_view(byte_offset, byte_len)` in crates/hip-bridge/src/lib.rs (checked range, Borrowed view, # Safety contract: allocation length in bytes, u8 alignment, must-not-outlive/must-not-free).
- Migrates saddle-core `q8_lane_view` closure and hipfire-dispatch `slice_moe_f32_view` (now a safe fn; 7 call sites lose their unsafe blocks). The dispatch helper also gains overflow-checked element-to-byte math plus a range assert it previously lacked.
- Same-shape sites left deliberately (outside this slice's compile gates, or different invariants): qwen35/weights.rs local byte_view closure, muse-glimmer batch.rs/forward_batch.rs/drafter.rs, maple/forward.rs, rdna-compute attention.rs, ds4-parent hessian.rs, plus all host-side from_raw_parts uploads (host memory, not device). Full list with reasons in the agent report.

Gates (from the slice worktree): cargo check -p hip-bridge -p saddle-core -p hipfire-dispatch clean apart from pre-existing warnings; cargo test -p saddle-core -p hipfire-dispatch: 237 passed (dispatch, 1 ignored) + 127 passed (saddle-core), 0 failed.