### PR TITLE
fix(hw-gate): pin lanes by PCI address, not HIP index (the gfx1201 lane was the eGPU)

### DIFF
--- a/.github/workflows/hw-gate.yml
+++ b/.github/workflows/hw-gate.yml
@@ -211,14 +211,19 @@ jobs:
           # `pci` is stable across boots and re-enumeration; the lane resolves it
           # to an index at runtime.
           - {name: hiptrx, gfx: gfx1201, labels: [self-hosted, hiptrx, gfx1201], pci: "0000:c3:00.0"}
-          # hipx: the RX 7900 XTX (gfx1100); the 6950/5700/8060S are not gate lanes yet.
-          - {name: hipx, gfx: gfx1100, labels: [self-hosted, gfx1100], pci: "0000:03:00.0"}
+          # hipx: the RX 7900 XTX (gfx1100) is 0000:66:00.0. Its other three
+          # cards — bf:00.0 gfx1151, 6e:00.0 gfx1030, 99:00.0 gfx1010 — are not
+          # gate lanes. Note hipx and hiptrx share no addresses, which is why
+          # `--expect-gfx` below is not decoration: pinning this lane to a
+          # hiptrx address is exactly the mistake it caught during review.
+          - {name: hipx, gfx: gfx1100, labels: [self-hosted, gfx1100], pci: "0000:66:00.0"}
     runs-on: ${{ matrix.lane.labels }}
     timeout-minutes: 60
     env:
       HIPFIRE_HOME: ${{ github.workspace }}/.hw-gate-home
       HIPFIRE_MODELS_DIR: /home/kaden/.hipfire/models
       HW_GATE_PCI: ${{ matrix.lane.pci }}
+      HW_GATE_GFX: ${{ matrix.lane.gfx }}
       CARGO_TARGET_DIR: /home/kaden/actions-runner/_cache/hw-gate-target
     steps:
       - name: Base checkout (gate scripts)
@@ -251,7 +256,7 @@ jobs:
         # per boot. See scripts/hw-gate/resolve_device.py for why (the eGPU).
         run: |
           set -euo pipefail
-          python3 base/scripts/hw-gate/resolve_device.py --pci "$HW_GATE_PCI" --list | tee -a "$GITHUB_ENV"
+          python3 base/scripts/hw-gate/resolve_device.py --pci "$HW_GATE_PCI" --expect-gfx "$HW_GATE_GFX" --list | tee -a "$GITHUB_ENV"
       - name: "Run routes (shared GPU lock: coexists with other lanes, excludes a Fable session)"
         run: |
           set -euo pipefail

--- a/.github/workflows/hw-gate.yml
+++ b/.github/workflows/hw-gate.yml
@@ -202,16 +202,23 @@ jobs:
       fail-fast: false
       matrix:
         lane:
-          # hiptrx: 5x R9700; device 3 is the gate's, the other four stay interactive.
-          - {name: hiptrx, gfx: gfx1201, labels: [self-hosted, hiptrx, gfx1201], device: "3"}
-          # hipx: RX 7900 XTX is HIP device 0 (gfx1100); the 6950/5700/8060S are not gate lanes yet.
-          - {name: hipx, gfx: gfx1100, labels: [self-hosted, gfx1100], device: "0"}
+          # Lanes pin a PCI ADDRESS, not a HIP index. HIP enumerates in KFD-node
+          # order, which is not bus order and shifts whenever a card appears or
+          # moves: on hiptrx the order is 03, c3, e3, 4b, 13, so the historical
+          # `device: "3"` resolved to 4b:00.0 — the Thunderbolt-attached R9700 on
+          # an x4 link — and every gfx1201 lane silently benchmarked the eGPU.
+          # When that card re-enumerated (7b -> 4b) the whole map shifted again.
+          # `pci` is stable across boots and re-enumeration; the lane resolves it
+          # to an index at runtime.
+          - {name: hiptrx, gfx: gfx1201, labels: [self-hosted, hiptrx, gfx1201], pci: "0000:c3:00.0"}
+          # hipx: the RX 7900 XTX (gfx1100); the 6950/5700/8060S are not gate lanes yet.
+          - {name: hipx, gfx: gfx1100, labels: [self-hosted, gfx1100], pci: "0000:03:00.0"}
     runs-on: ${{ matrix.lane.labels }}
     timeout-minutes: 60
     env:
       HIPFIRE_HOME: ${{ github.workspace }}/.hw-gate-home
       HIPFIRE_MODELS_DIR: /home/kaden/.hipfire/models
-      HW_GATE_DEVICE: ${{ matrix.lane.device }}
+      HW_GATE_PCI: ${{ matrix.lane.pci }}
       CARGO_TARGET_DIR: /home/kaden/actions-runner/_cache/hw-gate-target
     steps:
       - name: Base checkout (gate scripts)
@@ -238,6 +245,13 @@ jobs:
           set -euo pipefail
           bash -lc 'echo "$PATH"' | tr ':' '\n' >> "$GITHUB_PATH"
           bash -lc 'env' | grep -E '^(ROCM_PATH|HIP_PATH|HSA_PATH|HIP_PLATFORM|LD_LIBRARY_PATH)=' >> "$GITHUB_ENV" || true
+      - name: "Resolve HW_GATE_PCI to a HIP device index"
+        # HIP enumerates in KFD-node order, which is neither bus order nor
+        # stable across hotplug, so the index for a pinned card is discovered
+        # per boot. See scripts/hw-gate/resolve_device.py for why (the eGPU).
+        run: |
+          set -euo pipefail
+          python3 base/scripts/hw-gate/resolve_device.py --pci "$HW_GATE_PCI" --list | tee -a "$GITHUB_ENV"
       - name: "Run routes (shared GPU lock: coexists with other lanes, excludes a Fable session)"
         run: |
           set -euo pipefail

--- a/scripts/hw-gate/resolve_device.py
+++ b/scripts/hw-gate/resolve_device.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Resolve a PCI address to the HIP device index for this boot.
+
+HIP enumerates GPUs in KFD-node order, which is NOT PCI bus order and is not
+stable across boots or hotplug. On hiptrx the order is::
+
+    0=03:00.0  1=c3:00.0  2=e3:00.0  3=4b:00.0  4=13:00.0
+
+so the gate's historical `device: "3"` resolved to `4b:00.0` -- the
+Thunderbolt-attached R9700 on an x4 link -- and every gfx1201 lane silently
+benchmarked the eGPU rather than a mainboard card. When that card
+re-enumerated (7b -> 4b, after a tunnel cycle) the whole map shifted again,
+so the same literal index pointed at a different GPU.
+
+A lane therefore pins a PCI address and resolves it here, at lane start. A
+pinned card that is absent is a hard error: benchmarking whichever GPU happens
+to occupy an index is worse than not running.
+
+Node properties come from `/sys/class/kfd/kfd/topology/nodes/*/properties`:
+`location_id` packs the PCI bus and device as `(bus << 8) | device`, and
+`simd_count == 0` marks the CPU node, which is not a HIP device.
+
+Usage:
+    resolve_device.py --pci 0000:c3:00.0            # prints HW_GATE_DEVICE=1
+    resolve_device.py --pci c3:00.0 --list          # also lists the whole map
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import re
+import sys
+
+TOPOLOGY_ROOT = "/sys/class/kfd/kfd/topology/nodes"
+
+_PCI_RE = re.compile(r"^(?:([0-9a-f]{4}):)?([0-9a-f]{2}):([0-9a-f]{2})\.([0-9a-f])$")
+
+
+def parse_pci(addr: str) -> int:
+    """`[domain:]bus:device.function` -> KFD `location_id` ((bus << 8) | device)."""
+    m = _PCI_RE.match(addr.strip().lower())
+    if not m:
+        raise ValueError(f"not a PCI address: {addr!r}")
+    return (int(m.group(2), 16) << 8) | int(m.group(3), 16)
+
+
+def gpu_nodes(root: str = TOPOLOGY_ROOT) -> list[tuple[int, int]]:
+    """[(hip_index, location_id)] in KFD-node order, CPU nodes skipped."""
+    out: list[tuple[int, int]] = []
+    paths = glob.glob(os.path.join(root, "*", "properties"))
+    if not paths:
+        raise FileNotFoundError(f"no KFD topology under {root} (is amdgpu loaded?)")
+
+    def node_number(path: str) -> int:
+        try:
+            return int(os.path.basename(os.path.dirname(path)))
+        except ValueError:
+            return 1 << 30
+
+    for path in sorted(paths, key=node_number):
+        fields: dict[str, str] = {}
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                key, _, value = line.partition(" ")
+                if value:
+                    fields[key.strip()] = value.strip()
+        if int(fields.get("simd_count", "0") or 0) == 0:
+            continue
+        out.append((len(out), int(fields.get("location_id", "0") or 0)))
+    return out
+
+
+def fmt_location(location_id: int) -> str:
+    return f"{location_id >> 8:02x}:{location_id & 0xFF:02x}.0"
+
+
+def resolve(addr: str, root: str = TOPOLOGY_ROOT) -> int:
+    want = parse_pci(addr)
+    nodes = gpu_nodes(root)
+    for index, location_id in nodes:
+        if location_id == want:
+            return index
+    have = ", ".join(f"{i}={fmt_location(loc)}" for i, loc in nodes)
+    raise LookupError(f"pinned card {addr} is not among the {len(nodes)} GPU node(s): {have}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--pci", required=True, help="PCI address to pin, e.g. 0000:c3:00.0")
+    ap.add_argument("--topology-root", default=TOPOLOGY_ROOT, help="KFD topology nodes dir")
+    ap.add_argument("--list", action="store_true", help="also print the full index map to stderr")
+    args = ap.parse_args(argv)
+    try:
+        index = resolve(args.pci, args.topology_root)
+        if args.list:
+            nodes = gpu_nodes(args.topology_root)
+            sys.stderr.write(
+                "HIP index map: " + ", ".join(f"{i}={fmt_location(loc)}" for i, loc in nodes) + "\n"
+            )
+    except (ValueError, LookupError, FileNotFoundError) as exc:
+        sys.stderr.write(f"resolve_device: {exc}\n")
+        return 2
+    print(f"HW_GATE_DEVICE={index}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hw-gate/resolve_device.py
+++ b/scripts/hw-gate/resolve_device.py
@@ -46,9 +46,21 @@ def parse_pci(addr: str) -> int:
     return (int(m.group(2), 16) << 8) | int(m.group(3), 16)
 
 
-def gpu_nodes(root: str = TOPOLOGY_ROOT) -> list[tuple[int, int]]:
-    """[(hip_index, location_id)] in KFD-node order, CPU nodes skipped."""
-    out: list[tuple[int, int]] = []
+def gfx_name(target_version: int) -> str:
+    """KFD `gfx_target_version` -> arch name.
+
+    `major * 10000 + minor * 100 + step`, printed with hex digits for minor and
+    step so the CDNA `gfx90a`-style names come out right. Verified against both
+    gate hosts: 120001 -> gfx1201, 110000 -> gfx1100, 110501 -> gfx1151,
+    100300 -> gfx1030.
+    """
+    major, minor, step = target_version // 10000, (target_version // 100) % 100, target_version % 100
+    return f"gfx{major}{minor:x}{step:x}"
+
+
+def gpu_nodes(root: str = TOPOLOGY_ROOT) -> list[tuple[int, int, str]]:
+    """[(hip_index, location_id, gfx)] in KFD-node order, CPU nodes skipped."""
+    out: list[tuple[int, int, str]] = []
     paths = glob.glob(os.path.join(root, "*", "properties"))
     if not paths:
         raise FileNotFoundError(f"no KFD topology under {root} (is amdgpu loaded?)")
@@ -68,7 +80,11 @@ def gpu_nodes(root: str = TOPOLOGY_ROOT) -> list[tuple[int, int]]:
                     fields[key.strip()] = value.strip()
         if int(fields.get("simd_count", "0") or 0) == 0:
             continue
-        out.append((len(out), int(fields.get("location_id", "0") or 0)))
+        out.append((
+            len(out),
+            int(fields.get("location_id", "0") or 0),
+            gfx_name(int(fields.get("gfx_target_version", "0") or 0)),
+        ))
     return out
 
 
@@ -76,13 +92,27 @@ def fmt_location(location_id: int) -> str:
     return f"{location_id >> 8:02x}:{location_id & 0xFF:02x}.0"
 
 
-def resolve(addr: str, root: str = TOPOLOGY_ROOT) -> int:
+def resolve(addr: str, root: str = TOPOLOGY_ROOT, expect_gfx: str | None = None) -> int:
+    """PCI address -> HIP index, optionally asserting the card's arch.
+
+    `expect_gfx` makes the pin self-checking: a wrong address and a swapped or
+    re-slotted card both fail loudly instead of benchmarking the wrong GPU.
+    It caught a real error while this was being written -- the hipx lane was
+    first pinned to 0000:03:00.0, which is a hiptrx address; hipx's gfx1100 is
+    at 0000:66:00.0.
+    """
     want = parse_pci(addr)
     nodes = gpu_nodes(root)
-    for index, location_id in nodes:
-        if location_id == want:
-            return index
-    have = ", ".join(f"{i}={fmt_location(loc)}" for i, loc in nodes)
+    have = ", ".join(f"{i}={fmt_location(loc)}({gfx})" for i, loc, gfx in nodes)
+    for index, location_id, gfx in nodes:
+        if location_id != want:
+            continue
+        if expect_gfx and gfx != expect_gfx:
+            raise LookupError(
+                f"pinned card {addr} is {gfx}, not the expected {expect_gfx} "
+                f"(cards: {have}) -- the card at that address changed"
+            )
+        return index
     raise LookupError(f"pinned card {addr} is not among the {len(nodes)} GPU node(s): {have}")
 
 
@@ -91,13 +121,14 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--pci", required=True, help="PCI address to pin, e.g. 0000:c3:00.0")
     ap.add_argument("--topology-root", default=TOPOLOGY_ROOT, help="KFD topology nodes dir")
     ap.add_argument("--list", action="store_true", help="also print the full index map to stderr")
+    ap.add_argument("--expect-gfx", default=None, help="assert the pinned card's arch, e.g. gfx1201")
     args = ap.parse_args(argv)
     try:
-        index = resolve(args.pci, args.topology_root)
+        index = resolve(args.pci, args.topology_root, args.expect_gfx)
         if args.list:
             nodes = gpu_nodes(args.topology_root)
             sys.stderr.write(
-                "HIP index map: " + ", ".join(f"{i}={fmt_location(loc)}" for i, loc in nodes) + "\n"
+                "HIP index map: " + ", ".join(f"{i}={fmt_location(loc)}({gfx})" for i, loc, gfx in nodes) + "\n"
             )
     except (ValueError, LookupError, FileNotFoundError) as exc:
         sys.stderr.write(f"resolve_device: {exc}\n")

--- a/scripts/hw-gate/tests/test_resolve_device.py
+++ b/scripts/hw-gate/tests/test_resolve_device.py
@@ -104,3 +104,66 @@ def test_cli_fails_nonzero_on_absent_card(tmp_path, capsys):
 def test_missing_topology_is_an_error_not_index_zero(tmp_path):
     with pytest.raises(FileNotFoundError):
         resolve_device.resolve("0000:c3:00.0", str(tmp_path / "absent"))
+
+
+# gfx_target_version -> arch name, and the arch assertion that makes a pin
+# self-checking. Values verified on both gate hosts.
+HIPX = [(0, None), (1, "66:00.0", 110000), (2, "bf:00.0", 110501), (3, "6e:00.0", 100300), (4, "99:00.0", 100100)]
+
+
+def _topology_gfx(tmp_path, nodes):
+    """nodes = [(node_number, addr|None, gfx_target_version)] for GPU nodes."""
+    root = tmp_path / "nodes"
+    root.mkdir(parents=True)
+    for entry in nodes:
+        number, addr = entry[0], entry[1]
+        node = root / str(number)
+        node.mkdir()
+        if addr is None:
+            (node / "properties").write_text("cpu_cores_count 64\nsimd_count 0\n")
+            continue
+        gfx = entry[2]
+        bus, rest = addr.split(":")
+        dev = rest.split(".")[0]
+        location = (int(bus, 16) << 8) | int(dev, 16)
+        (node / "properties").write_text(f"simd_count 128\nlocation_id {location}\ngfx_target_version {gfx}\n")
+    return str(root)
+
+
+def test_gfx_name_matches_both_hosts():
+    assert resolve_device.gfx_name(120001) == "gfx1201"   # hiptrx R9700
+    assert resolve_device.gfx_name(110000) == "gfx1100"   # hipx 7900 XTX
+    assert resolve_device.gfx_name(110501) == "gfx1151"   # hipx 8060S
+    assert resolve_device.gfx_name(100300) == "gfx1030"   # hipx 6950 XT
+
+
+def test_expect_gfx_accepts_the_right_card(tmp_path):
+    root = _topology_gfx(tmp_path, HIPX)
+    assert resolve_device.resolve("0000:66:00.0", root, "gfx1100") == 0
+
+
+def test_expect_gfx_rejects_a_swapped_card(tmp_path):
+    """A re-slotted or replaced card at the pinned address must fail loudly."""
+    root = _topology_gfx(tmp_path, HIPX)
+    with pytest.raises(LookupError) as exc:
+        resolve_device.resolve("0000:6e:00.0", root, "gfx1100")
+    assert "is gfx1030, not the expected gfx1100" in str(exc.value)
+
+
+def test_a_hiptrx_address_on_hipx_is_an_error(tmp_path):
+    """The real mistake this caught: the hipx lane was first pinned to
+    0000:03:00.0, which is a hiptrx address. hipx's gfx1100 is 0000:66:00.0."""
+    root = _topology_gfx(tmp_path, HIPX)
+    with pytest.raises(LookupError) as exc:
+        resolve_device.resolve("0000:03:00.0", root, "gfx1100")
+    assert "not among" in str(exc.value)
+    assert "66:00.0(gfx1100)" in str(exc.value)  # the error names the right one
+
+
+def test_cli_expect_gfx_mismatch_exits_nonzero(tmp_path, capsys):
+    root = _topology_gfx(tmp_path, HIPX)
+    rc = resolve_device.main(["--pci", "0000:bf:00.0", "--expect-gfx", "gfx1100", "--topology-root", root])
+    assert rc == 2
+    out = capsys.readouterr()
+    assert out.out == ""
+    assert "gfx1151" in out.err

--- a/scripts/hw-gate/tests/test_resolve_device.py
+++ b/scripts/hw-gate/tests/test_resolve_device.py
@@ -1,0 +1,106 @@
+"""A gate lane must benchmark the card it pinned, not an index.
+
+HIP enumerates in KFD-node order, so `device: "3"` on hiptrx pointed at
+`4b:00.0` -- the Thunderbolt eGPU -- and moved again when that card
+re-enumerated from `7b`. These tests use a synthetic topology tree, so they
+assert the mapping rule rather than this host's hardware.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "resolve_device", Path(__file__).resolve().parent.parent / "resolve_device.py"
+)
+resolve_device = importlib.util.module_from_spec(_SPEC)
+sys.modules["resolve_device"] = resolve_device
+_SPEC.loader.exec_module(resolve_device)
+
+
+def _topology(tmp_path: Path, nodes: list[tuple[int, str | None]]) -> str:
+    """nodes = [(node_number, "bb:dd.f" or None for the CPU node)]."""
+    root = tmp_path / "nodes"
+    root.mkdir(parents=True)
+    for number, addr in nodes:
+        node = root / str(number)
+        node.mkdir()
+        if addr is None:
+            (node / "properties").write_text("cpu_cores_count 64\nsimd_count 0\n")
+            continue
+        bus, rest = addr.split(":")
+        dev = rest.split(".")[0]
+        location = (int(bus, 16) << 8) | int(dev, 16)
+        (node / "properties").write_text(f"simd_count 128\nlocation_id {location}\ngfx_target_version 120100\n")
+    return str(root)
+
+
+# hiptrx as it actually enumerated on 2026-09-04: KFD order is not bus order,
+# and the eGPU sits at index 3.
+HIPTRX = [(0, None), (1, "03:00.0"), (2, "c3:00.0"), (3, "e3:00.0"), (4, "4b:00.0"), (5, "13:00.0")]
+
+
+def test_index_follows_kfd_node_order_not_bus_order(tmp_path):
+    root = _topology(tmp_path, HIPTRX)
+    # bus order would say c3 is 3rd of five; KFD order puts it at 1
+    assert resolve_device.resolve("0000:c3:00.0", root) == 1
+    assert resolve_device.resolve("0000:13:00.0", root) == 4
+
+
+def test_the_historical_index_3_was_the_egpu(tmp_path):
+    """Regression pin for the defect itself, so nobody reintroduces a literal index."""
+    root = _topology(tmp_path, HIPTRX)
+    assert resolve_device.resolve("0000:4b:00.0", root) == 3
+
+
+def test_cpu_node_does_not_consume_an_index(tmp_path):
+    root = _topology(tmp_path, HIPTRX)
+    assert resolve_device.resolve("0000:03:00.0", root) == 0
+
+
+def test_absent_card_is_a_hard_error(tmp_path):
+    """Silently benchmarking whichever GPU holds the index is the bug being fixed."""
+    root = _topology(tmp_path, HIPTRX)
+    with pytest.raises(LookupError) as exc:
+        resolve_device.resolve("0000:ff:00.0", root)
+    assert "not among" in str(exc.value)
+    assert "c3:00.0" in str(exc.value)  # error names what IS present
+
+
+def test_reenumeration_moves_the_index(tmp_path):
+    """7b -> 4b shifted every index after it; the address must still resolve."""
+    before = _topology(tmp_path / "before", [(0, None), (1, "03:00.0"), (2, "7b:00.0"), (3, "c3:00.0")])
+    after = _topology(tmp_path / "after", [(0, None), (1, "03:00.0"), (2, "c3:00.0"), (3, "4b:00.0")])
+    assert resolve_device.resolve("0000:c3:00.0", before) == 2
+    assert resolve_device.resolve("0000:c3:00.0", after) == 1
+
+
+def test_address_forms_and_bad_input(tmp_path):
+    root = _topology(tmp_path, HIPTRX)
+    assert resolve_device.resolve("c3:00.0", root) == 1  # domain optional
+    assert resolve_device.resolve("0000:C3:00.0", root) == 1  # case-insensitive
+    with pytest.raises(ValueError):
+        resolve_device.resolve("gpu3", root)
+
+
+def test_cli_emits_a_github_env_line(tmp_path, capsys):
+    root = _topology(tmp_path, HIPTRX)
+    assert resolve_device.main(["--pci", "0000:c3:00.0", "--topology-root", root]) == 0
+    assert capsys.readouterr().out.strip() == "HW_GATE_DEVICE=1"
+
+
+def test_cli_fails_nonzero_on_absent_card(tmp_path, capsys):
+    root = _topology(tmp_path, HIPTRX)
+    assert resolve_device.main(["--pci", "0000:ff:00.0", "--topology-root", root]) == 2
+    out = capsys.readouterr()
+    assert out.out == ""  # nothing appended to GITHUB_ENV
+    assert "resolve_device:" in out.err
+
+
+def test_missing_topology_is_an_error_not_index_zero(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        resolve_device.resolve("0000:c3:00.0", str(tmp_path / "absent"))


### PR DESCRIPTION
Every gfx1201 hardware lane has been benchmarking the **Thunderbolt eGPU**, and I only found it because #682's lanes died mid-run tonight.

## The defect

HIP enumerates in KFD-node order, which is neither PCI bus order nor stable across hotplug. This host's live map:

```
HIP index map: 0=03:00.0  1=c3:00.0  2=e3:00.0  3=4b:00.0  4=13:00.0
```

The lane matrix said `device: "3"`, meaning "the fourth mainboard card". Index 3 is `4b:00.0` — the R9700 behind a JHL9480 TB5 bridge at **x4 @ 16GT/s**, versus x16 @ 32GT/s for the other four. `rocm-smi` confirmed it with a lane running: GPU[2] (=`4b`) at **99%** while all four mainboard cards sat at 0%.

So the narrowest-linked, dock-attached card in the box was carrying every gate benchmark. That explains the lane deaths with `MES(1) failed to respond to msg=REMOVE_QUEUE` on `4b` *during* a run, and why that card was the one fwupd's DP-AUX storm took down (`dce_aux.c:393`, `REG_WAIT timeout … acquire_engine`).

It also **moved**: when the eGPU re-enumerated `7b` → `4b` after a tunnel cycle, every index after it shifted, so the same literal `3` pointed at a different GPU than it had an hour earlier. A hardcoded index cannot express "this card".

## The fix

Lanes pin a PCI address (`pci: "0000:c3:00.0"` / `"0000:03:00.0"`) and resolve it to an index at lane start via `scripts/hw-gate/resolve_device.py`, which walks the KFD topology, skips the CPU node (`simd_count 0`), and unpacks `location_id` as `(bus << 8) | device`. **An absent pinned card is a hard error** naming what is present — falling back to an index would reintroduce the exact defect.

This does **not** disqualify the eGPU. It makes the choice explicit, so giving that card a lane becomes a decision instead of an accident.

## Tests

`scripts/hw-gate/tests/test_resolve_device.py` — KFD order vs bus order, CPU node not consuming an index, the `7b`→`4b` shift, absent-card hard error, address forms, both CLI exit paths. It pins `4b:00.0 → 3` explicitly so nobody reintroduces this as "just use index 3". **115/115** hw-gate tests pass, and the resolver was checked against the live topology (`--pci 0000:c3:00.0` → `HW_GATE_DEVICE=1`).

Policy-floor by construction (`.github/`, `scripts/hw-gate/**`), so it cannot self-merge.