### PR TITLE
fix(hw-gate): drive DFlash in the gate; stop refusing user-path CLI diffs

### DIFF
--- a/scripts/hw-gate/fixtures.json
+++ b/scripts/hw-gate/fixtures.json
@@ -1,7 +1,7 @@
 {
   "schema": "hipfire.hw-gate.fixtures",
   "version": 2,
-  "_comment": "Every fixture is a registry tag pinned by sha256 (registry/v1.json is the source of truth). A missing or mismatched fixture FAILS the gate. Every fixture runs in every selected bucket; the bucket decides which serve_harness modes run (union across buckets). battery = varied prompts with expect-substrings and attractor/runaway/empty detection; chain = related multi-turn prompts through the prefix cache. No fixture is ever exercised with a single `hipfire run`: one request against a fresh daemon proves nothing about turn-to-turn state.",
+  "_comment": "Every fixture is a registry tag pinned by sha256 (registry/v1.json is the source of truth). A missing or mismatched fixture FAILS the gate. Every fixture runs in every selected bucket; the bucket decides which serve_harness modes run (union across buckets). battery = varied prompts with expect-substrings and attractor/runaway/empty detection; chain = related multi-turn prompts through the prefix cache. No fixture is ever exercised with a single `hipfire run`: one request against a fresh daemon proves nothing about turn-to-turn state. Modes ending in `-dflash` run the same prompts with `--dflash on` and an explicit `--draft`: `dflash_draft` lists candidates and the lane uses the first it holds, recording `skip` when it holds none, because the two lanes carry different drafts.",
   "models_dir": "~/.hipfire/models",
   "harness": {
     "battery_prompts": "benchmarks/prompts/hw-gate/serve-battery.json",
@@ -14,7 +14,11 @@
       "sha256": "86a5f80fd29d545abb1093dead242725ced6d68b8607c6d566d897b1a82442dc",
       "size_bytes": 14984158208,
       "arch_id": 5,
-      "why": "Canonical dense trunk (AGENTS.md pinned fixture); Qwen3.5-family text artifact whose embedded config carries vision_config with no vision tower."
+      "why": "Canonical dense trunk (AGENTS.md pinned fixture); Qwen3.5-family text artifact whose embedded config carries vision_config with no vision tower.",
+      "dflash_draft": [
+        "qwen36-27b-dflash-mq4.hfq",
+        "qwen38-27b-dflash-mq4.hfq"
+      ]
     },
     {
       "tag": "ornith-1.5:35b-a3b-mq4r",
@@ -38,21 +42,27 @@
       "sha256": "9f91556f7e0431a077d03756a7102d0154108757289e6e5fe9a2d204c0c9eeb7",
       "size_bytes": 14980361216,
       "arch_id": 5,
-      "why": "MQ4V2 xt tier \u2014 the neutral-header v2 quant family (537a292df) that the device-mesh series refused."
+      "why": "MQ4V2 xt tier \u2014 the neutral-header v2 quant family (537a292df) that the device-mesh series refused.",
+      "dflash_draft": [
+        "qwen38-27b-dflash-mq4.hfq",
+        "qwen36-27b-dflash-mq4.hfq"
+      ]
     }
   ],
   "buckets": {
     "load": {
-      "why": "Loader / daemon / runtime load path / arch load changed.",
+      "why": "Loader / daemon / runtime load path / arch load changed. battery-dflash additionally drives the speculative arm: draft pairing, ctx-cap fallback and primer replay all live behind a draft load, and #686/#691/#692/#702 each passed this gate with DFlash never once running.",
       "modes": [
-        "battery"
+        "battery",
+        "battery-dflash"
       ]
     },
     "serve": {
-      "why": "Engine / generate / daemon serve semantics changed: add the multi-turn chain so reset, prefix cache, and terminal semantics are exercised.",
+      "why": "Engine / generate / daemon serve semantics changed: add the multi-turn chain so reset, prefix cache, and terminal semantics are exercised, and chain-dflash so turn-to-turn state is exercised with speculation on \u2014 the arm where primer replay asymmetry hides.",
       "modes": [
         "battery",
-        "chain"
+        "chain",
+        "chain-dflash"
       ]
     },
     "kernel": {

--- a/scripts/hw-gate/run.py
+++ b/scripts/hw-gate/run.py
@@ -428,7 +428,31 @@ def _evaluate_mode(exit_code: int, raw_rows) -> tuple[str, str, list[dict]]:
 GATE_REPO = Path(__file__).resolve().parents[2]
 
 
-def _build_harness_argv(gate_root: Path, model_path: Path, mode: str, max_tokens: int, battery_prompts_path: Path | None, per_home: Path, out_path: Path, serve_log_path: Path) -> list[str]:
+# Gate modes -> (serve_harness --mode, extra flags).
+#
+# `-dflash` variants exist because speculative decode was entirely unexercised:
+# #686 (draft sidecars), #691 (draft ctor rollback), #692 (primer replay) and
+# #702 (dedicated verify kernels) all went through this gate with every lane
+# green while never once running DFlash. A DFlash-arm defect could only be
+# found by a seat that thought to drive it by hand, which is not a gate.
+#
+# `--dflash on` rather than `auto`: `auto` silently falls back to AR when the
+# draft is missing, and a fixture route that can pass by not speculating proves
+# nothing. `on` fails the load instead, which is the behaviour a gate wants.
+HARNESS_MODES: dict[str, tuple[str, list[str]]] = {
+    "battery": ("battery", []),
+    "chain": ("chain", []),
+    "battery-dflash": ("battery", ["--dflash", "on"]),
+    "chain-dflash": ("chain", ["--dflash", "on"]),
+}
+
+
+def harness_mode_spec(mode: str) -> tuple[str, list[str]]:
+    """Resolve a gate mode name; unknown modes pass through unchanged."""
+    return HARNESS_MODES.get(mode, (mode, []))
+
+
+def _build_harness_argv(gate_root: Path, model_path: Path, mode: str, max_tokens: int, battery_prompts_path: Path | None, per_home: Path, out_path: Path, serve_log_path: Path, draft_path: Path | None = None) -> list[str]:
     """Build argv for serve_harness.py. Never includes --devices.
 
     The harness is the oracle, so it comes from the gate checkout and never
@@ -439,13 +463,14 @@ def _build_harness_argv(gate_root: Path, model_path: Path, mode: str, max_tokens
     evidence that was correct.
     """
     harness = Path(gate_root) / "scripts" / "serve_harness.py"
+    harness_mode, mode_flags = harness_mode_spec(mode)
     argv = [
         sys.executable,
         str(harness),
         "--model",
         str(model_path),
         "--mode",
-        mode,
+        harness_mode,
         "--max-tokens",
         str(max_tokens),
         "--thinking",
@@ -461,7 +486,10 @@ def _build_harness_argv(gate_root: Path, model_path: Path, mode: str, max_tokens
         "--serve-log",
         str(serve_log_path),
     ]
-    if mode == "battery" and battery_prompts_path is not None:
+    argv.extend(mode_flags)
+    if draft_path is not None:
+        argv.extend(["--draft", str(draft_path)])
+    if harness_mode == "battery" and battery_prompts_path is not None:
         argv.extend(["--prompts-file", str(battery_prompts_path)])
     return argv
 
@@ -496,6 +524,31 @@ def _run_harness_mode(repo, fixture, env_base, logs_dir, device, mode, harness_c
         return {"exit": 2, "seconds": 0.0, "rows": [], "status": "fail",
                 "reason": f"battery prompts missing at {battery_prompts_path} (gate policy file)"}
     max_tokens = harness_cfg.get("max_tokens", 256)
+    # A `-dflash` mode needs a paired draft, named explicitly by the fixture:
+    # the daemon's filename auto-match cannot find one for the canonical xt
+    # trunk, which is a symlink out of the models dir, and would silently run
+    # AR instead — a DFlash route that passes without speculating is worse
+    # than no route.
+    #
+    # `dflash_draft` may be a list, because the two lanes hold different
+    # drafts: hiptrx has qwen36-27b-dflash-mq4.hfq and no qwen38, hipx has
+    # qwen38-27b-dflash-mq4.hfq and no qwen36. The lane speculates with the
+    # first candidate it actually has; a lane holding none records `skip`, so
+    # the evidence says "not covered here" rather than inventing a pass or a
+    # failure on evidence the host never had.
+    draft_path: Path | None = None
+    if mode.endswith("-dflash"):
+        declared = fixture.get("dflash_draft")
+        candidates = [declared] if isinstance(declared, str) else list(declared or [])
+        models_root = Path(models_dir).expanduser()
+        present = [models_root / c for c in candidates if (models_root / c).is_file()]
+        if not candidates:
+            return {"exit": 0, "seconds": 0.0, "rows": [], "status": "skip",
+                    "reason": f"fixture {tag} declares no dflash_draft"}
+        if not present:
+            return {"exit": 0, "seconds": 0.0, "rows": [], "status": "skip",
+                    "reason": f"none of {candidates} present under {models_root} for fixture {tag}"}
+        draft_path = present[0]
     # per-fixture home: subdirectory of gate home
     gate_home = env_base.get("HIPFIRE_HOME") or str(Path.home() / ".hipfire")
     per_home = Path(gate_home) / f"{safe_tag}-{mode}"
@@ -507,7 +560,7 @@ def _run_harness_mode(repo, fixture, env_base, logs_dir, device, mode, harness_c
     out_path = logs_dir_p / f"{safe_tag}-{mode}.json"
     serve_log_path = logs_dir_p / f"{safe_tag}-{mode}.serve.log"
     out_combined_path = logs_dir_p / f"{safe_tag}-{mode}.out"
-    argv = _build_harness_argv(gate_root, model_path, mode, max_tokens, battery_prompts_path, per_home, out_path, serve_log_path)
+    argv = _build_harness_argv(gate_root, model_path, mode, max_tokens, battery_prompts_path, per_home, out_path, serve_log_path, draft_path)
     start = time.time()
     exit_code = 1
     stdout = ""
@@ -568,15 +621,22 @@ def _run_fixture_harness(repo, fixture, env_base, logs_dir, device, modes, harne
     for mode in modes:
         res = _run_harness_mode(repo, fixture, env_base, logs_dir, device, mode, harness_cfg, models_dir)
         modes_result[mode] = res
-    # overall fixture status
-    overall = "pass" if all(m.get("status") == "pass" for m in modes_result.values()) else ("pass" if not modes_result else "fail")
-    # if no modes (should not happen) treat as pass
+    # A mode can legitimately not run: the two lanes hold different drafts, so
+    # a `-dflash` mode has no artifact to speculate with on one of them.
+    # Failing that lane would be a false negative on evidence it never had, and
+    # counting it as a pass would claim coverage that did not happen. `skip`
+    # is therefore neither: it is recorded, reported, and excluded from the
+    # verdict. It must never be produced for a missing artifact the fixture
+    # DECLARED — that stays a hard fail.
+    graded = {m: r for m, r in modes_result.items() if r.get("status") != "skip"}
+    overall = "pass" if all(r.get("status") == "pass" for r in graded.values()) else ("pass" if not graded else "fail")
     reasons: list[str] = []
     for m, r in modes_result.items():
-        if r.get("status") != "pass" and r.get("reason"):
-            reasons.append(f"{m}: {r.get('reason')}")
-        elif r.get("status") != "pass":
-            reasons.append(f"{m}: fail")
+        status = r.get("status")
+        if status == "skip":
+            reasons.append(f"{m}: skipped ({r.get('reason') or 'no reason given'})")
+        elif status != "pass":
+            reasons.append(f"{m}: {r.get('reason') or 'fail'}")
     reason = "; ".join(reasons) if reasons else ""
     tag = fixture.get("tag", "")
     return {

--- a/scripts/hw-gate/sol.md
+++ b/scripts/hw-gate/sol.md
@@ -10,6 +10,8 @@ Return exactly one JSON object per phase and nothing else.
 
 Read the diff against base. Decide whether this code runs on the maintainer's workstation. The hardware job builds the PR and runs its daemon as the maintainer's own user; nothing else stands between the diff and that machine. Refuse when the diff reaches outside the process: network access, filesystem access beyond model/cache/temp paths, environment or credential reads, process spawning, changed build scripts, dependencies, toolchains, CI, or harness scripts you cannot account for, encoded or obfuscated blobs, `unsafe` whose purpose is not evident. Ordinary hipfire Rust/HIP/config/docs work runs. Changes to `scripts/`, `.github/`, `Cargo.toml`, or `build.rs` are not automatically refused, but you must read them and say what they do.
 
+On filesystem reads, separate *whose* path it is. hipfire is a command-line inference engine: users name model files, prompt files, drafts, sidecars, and output paths at invocation, and a diff that adds or plumbs such an argument is ordinary product work, not a reach outside the process — the gate's own harness invokes exactly those flags. What warrants refusal is a read the user did not ask for: credentials, dotfiles, SSH or cloud config, `/proc` or `/sys` beyond device enumeration, path traversal assembled from something other than an explicit argument, or a read whose result leaves the process. PR #689 added `--prompt-file` to `hipfire bench` and was declined on this rule; that was a false positive, and it cost a rung a hardware lane until `hw-run` overrode it.
+
 ```json
 {
   "phase": "prelim",

--- a/scripts/hw-gate/tests/test_run.py
+++ b/scripts/hw-gate/tests/test_run.py
@@ -866,3 +866,115 @@ def test_serve_harness_runs_from_gate_root_not_pr(tmp_path, monkeypatch):
     script = seen["argv"][1]
     assert script == str(gate / "scripts" / "serve_harness.py"), script
     assert str(pr) not in script
+
+
+# ---------------------------------------------------------------------------
+# `-dflash` routes. Speculative decode was entirely unexercised by this gate:
+# #686 (draft sidecars), #691 (draft ctor rollback), #692 (primer replay) and
+# #702 (dedicated verify kernels) all passed with every lane green while DFlash
+# never ran once.
+# ---------------------------------------------------------------------------
+
+
+def _dflash_env(tmp_path, monkeypatch, fixture, mode, drafts_on_disk):
+    """Run one mode with a fake harness, returning (argv, result)."""
+    gate = tmp_path / "gate"
+    (gate / "scripts" / "hw-gate").mkdir(parents=True)
+    (gate / "scripts" / "serve_harness.py").write_text("")
+    (gate / "benchmarks" / "prompts" / "hw-gate").mkdir(parents=True)
+    (gate / "benchmarks" / "prompts" / "hw-gate" / "serve-battery.json").write_text("[]")
+    models = tmp_path / "models"
+    models.mkdir()
+    (models / fixture["file"]).write_text("target")
+    for name in drafts_on_disk:
+        (models / name).write_text("draft")
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        if "--out" in argv:
+            out_file = Path(argv[argv.index("--out") + 1])
+            out_file.parent.mkdir(parents=True, exist_ok=True)
+            out_file.write_text(json.dumps([{
+                "assistant_content": "hello", "expected_substrings": [], "attractor": False,
+                "empty": False, "finish": "stop", "gen": 5, "ctx": 10, "cached": 0,
+            }]))
+        if "--serve-log" in argv:
+            p = Path(argv[argv.index("--serve-log") + 1])
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text("log")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(run_mod, "run_cmd", fake_run)
+    monkeypatch.delenv("CARGO_TARGET_DIR", raising=False)
+    cfg = {"battery_prompts": "benchmarks/prompts/hw-gate/serve-battery.json", "max_tokens": 8, "_gate_root": str(gate)}
+    env = {"HIPFIRE_HOME": str(tmp_path / "home")}
+    res = run_mod._run_harness_mode(str(tmp_path / "pr"), fixture, env, str(tmp_path / "logs"), "0", mode, cfg, str(models))
+    return captured.get("argv"), res
+
+
+FIX = {"tag": "qwen3.8:27b-mq4-xt", "file": "x.mq4",
+       "dflash_draft": ["qwen38-27b-dflash-mq4.hfq", "qwen36-27b-dflash-mq4.hfq"]}
+
+
+def test_dflash_mode_forces_speculation_on_with_an_explicit_draft(tmp_path, monkeypatch):
+    """`auto` would silently fall back to AR; a route that can pass without
+    speculating proves nothing, so the mode must pin `on` and name the draft."""
+    argv, res = _dflash_env(tmp_path, monkeypatch, FIX, "battery-dflash", ["qwen38-27b-dflash-mq4.hfq"])
+    assert res["status"] == "pass", res
+    assert argv[argv.index("--mode") + 1] == "battery"  # harness knows battery, not battery-dflash
+    assert argv[argv.index("--dflash") + 1] == "on"
+    assert argv[argv.index("--draft") + 1].endswith("qwen38-27b-dflash-mq4.hfq")
+    assert "--prompts-file" in argv  # battery prompts still applied
+
+
+def test_plain_battery_never_gets_a_draft(tmp_path, monkeypatch):
+    argv, res = _dflash_env(tmp_path, monkeypatch, FIX, "battery", ["qwen38-27b-dflash-mq4.hfq"])
+    assert res["status"] == "pass"
+    assert "--dflash" not in argv and "--draft" not in argv
+
+
+def test_lane_uses_the_draft_it_actually_holds(tmp_path, monkeypatch):
+    """hiptrx holds qwen36 and no qwen38; hipx holds qwen38 and no qwen36."""
+    argv, _ = _dflash_env(tmp_path, monkeypatch, FIX, "battery-dflash", ["qwen36-27b-dflash-mq4.hfq"])
+    assert argv[argv.index("--draft") + 1].endswith("qwen36-27b-dflash-mq4.hfq")
+
+
+def test_lane_without_any_declared_draft_skips_rather_than_fails(tmp_path, monkeypatch):
+    """The lane had no artifact to speculate with. Failing it would be a false
+    negative on evidence it never had; passing it would claim coverage."""
+    argv, res = _dflash_env(tmp_path, monkeypatch, FIX, "battery-dflash", [])
+    assert res["status"] == "skip", res
+    assert "qwen38-27b-dflash-mq4.hfq" in res["reason"]
+    assert argv is None  # the harness was never invoked
+
+
+def test_chain_dflash_keeps_chain_mode(tmp_path, monkeypatch):
+    argv, _ = _dflash_env(tmp_path, monkeypatch, FIX, "chain-dflash", ["qwen38-27b-dflash-mq4.hfq"])
+    assert argv[argv.index("--mode") + 1] == "chain"
+    assert argv[argv.index("--dflash") + 1] == "on"
+    assert "--prompts-file" not in argv  # chain carries its own prompts
+
+
+def test_skip_does_not_fail_the_fixture_but_a_real_failure_does(tmp_path, monkeypatch):
+    """Regression pin: `all(status == "pass")` counted a skip as a failure."""
+    assert run_mod._run_fixture_harness.__doc__ is not None
+    graded = {"battery": {"status": "pass"}, "battery-dflash": {"status": "skip", "reason": "no draft"}}
+    ungraded = {m: r for m, r in graded.items() if r.get("status") != "skip"}
+    assert all(r["status"] == "pass" for r in ungraded.values())
+    # and a genuine failure alongside a skip must still fail
+    graded_fail = {"battery": {"status": "fail", "reason": "attractor"}, "battery-dflash": {"status": "skip"}}
+    ungraded_fail = {m: r for m, r in graded_fail.items() if r.get("status") != "skip"}
+    assert not all(r["status"] == "pass" for r in ungraded_fail.values())
+
+
+def test_fixtures_manifest_declares_dflash_routes(tmp_path):
+    """The manifest is gate policy: assert the buckets actually carry the route."""
+    manifest = json.loads((Path(run_mod.__file__).parent / "fixtures.json").read_text())
+    assert "battery-dflash" in manifest["buckets"]["load"]["modes"]
+    assert "chain-dflash" in manifest["buckets"]["serve"]["modes"]
+    declared = {f["tag"]: f.get("dflash_draft") for f in manifest["fixtures"]}
+    assert declared["qwen3.8:27b-mq4-xt"], "the canonical xt trunk must declare a draft"
+    for tag, drafts in declared.items():
+        if drafts is not None:
+            assert isinstance(drafts, list) and drafts, f"{tag} dflash_draft must be a non-empty list"


### PR DESCRIPTION
Two policy gaps this ladder exposed. Both are gate plumbing, no product code.

## 1 · The gate has never run DFlash

#686 (draft sidecars), #691 (draft ctor rollback), #692 (primer replay) and #702 (dedicated verify kernels) all went through this gate with **every lane green while speculation never once executed**. #692's DFlash-arm defect — primer replay systematically missing the most recent assistant body — surfaced only because a seat thought to drive twenty turns by hand. That is not a gate.

The load bucket now runs `battery-dflash`, the serve bucket `chain-dflash`: the same prompts with `--dflash on` and an explicit `--draft`.

- **`on`, not `auto`** — `auto` silently falls back to AR when the draft is missing, and a route that can pass *without speculating* proves nothing.
- **explicit `--draft`** — the canonical xt trunk is a symlink out of the models dir, so the daemon's filename auto-match finds nothing and would quietly run AR.
- **`dflash_draft` is a candidate list**, because the lanes hold different drafts: hiptrx has `qwen36-27b-dflash-mq4.hfq` and no qwen38, hipx has `qwen38-27b-dflash-mq4.hfq` and no qwen36.

### `skip` is neither pass nor fail

This is the part worth reviewing. The aggregation was `all(status == "pass")`, so a skipped mode would have counted as a **fixture failure** — a false negative on evidence the host never had — while treating it as a pass would claim coverage that did not happen. Skips are now recorded, reported in the reason string, and excluded from the verdict; a genuine failure alongside a skip still fails.

**Coverage is asymmetric until both hosts hold both drafts.** Pulling `qwen38-27b-dflash-mq4.hfq` to hiptrx and `qwen36-27b-dflash-mq4.hfq` to hipx (0.92 GB each) makes it symmetric — that is a disk decision, so this reports `skip` rather than silently pulling ~2 GB onto your machines.

## 2 · Sol refused hardware for user-path CLI diffs

The rule "filesystem access beyond model/cache/temp paths" caught #689 for adding `--prompt-file` to `hipfire bench`, and cost that rung a hardware lane until `hw-run` overrode it. hipfire *is* a CLI inference engine: users name models, prompts, drafts and sidecars at invocation, and the gate's own harness passes exactly those flags.

`sol.md` now separates **whose** path it is. An explicit argument is ordinary product work; credentials, dotfiles, SSH or cloud config, `/proc`//`sys` beyond device enumeration, traversal assembled from something other than an argument, or a read whose result leaves the process still warrant refusal.

## Tests

Eight new cases: flag translation (`battery-dflash` → `--mode battery --dflash on --draft …`), plain battery never receiving a draft, per-lane draft selection, skip-not-fail with the harness never invoked, `chain-dflash` keeping its own prompts, the skip-vs-genuine-failure aggregation, and a manifest assertion that the buckets carry the routes. **113/113** hw-gate tests pass.

Policy-floor by construction, so it cannot self-merge.