### PR TITLE
overhaul/s4: FeatureFlags consolidation (P0 primitives, P1 fields, P2 migration)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,6 +1154,7 @@ name = "hipfire-arch-gemma4"
 version = "0.3.0"
 dependencies = [
  "hip-bridge",
+ "hipfire-config",
  "hipfire-dispatch",
  "hipfire-runtime",
  "rdna-compute",
@@ -1231,6 +1232,7 @@ name = "hipfire-arch-muse-glimmer"
 version = "0.3.0"
 dependencies = [
  "hip-bridge",
+ "hipfire-config",
  "hipfire-dispatch",
  "hipfire-runtime",
  "rdna-compute",
@@ -1272,6 +1274,7 @@ name = "hipfire-arch-qwen35-vl"
 version = "0.3.0"
 dependencies = [
  "hip-bridge",
+ "hipfire-config",
  "hipfire-runtime",
  "image",
  "rdna-compute",

--- a/crates/hipfire-arch-deepseek4/src/forward.rs
+++ b/crates/hipfire-arch-deepseek4/src/forward.rs
@@ -152,7 +152,7 @@ fn dense_activation_dump() -> Result<Option<&'static std::sync::Mutex<DenseActiv
 
     static DUMP: OnceLock<Result<Option<Mutex<DenseActivationDump>>, String>> = OnceLock::new();
     match DUMP.get_or_init(|| {
-        let Some(path) = std::env::var_os("HIPFIRE_DS4_DENSE_ACT_DIR") else {
+        let Some(path) = hipfire_config::developer_var_os("HIPFIRE_DS4_DENSE_ACT_DIR") else {
             return Ok(None);
         };
         if path.is_empty() {
@@ -5857,7 +5857,7 @@ fn dump_moe_route_if_enabled(
 
     static DUMP: OnceLock<Option<Mutex<std::io::BufWriter<std::fs::File>>>> = OnceLock::new();
     let dump = DUMP.get_or_init(|| {
-        let path = std::env::var("HIPFIRE_DS4_ROUTE_DUMP").ok()?;
+        let path = hipfire_config::developer_var("HIPFIRE_DS4_ROUTE_DUMP").ok()?;
         let file = std::fs::File::create(&path)
             .unwrap_or_else(|e| panic!("create HIPFIRE_DS4_ROUTE_DUMP {path}: {e}"));
         let mut writer = std::io::BufWriter::new(file);

--- a/crates/hipfire-arch-gemma4/Cargo.toml
+++ b/crates/hipfire-arch-gemma4/Cargo.toml
@@ -16,6 +16,7 @@ default = ["deltanet"]
 deltanet = ["hipfire-runtime/deltanet", "rdna-compute/deltanet"]
 
 [dependencies]
+hipfire-config = { path = "../hipfire-config" }
 hipfire-runtime = { path = "../hipfire-runtime" }
 hip-bridge = { path = "../hip-bridge" }
 rdna-compute = { path = "../rdna-compute" }

--- a/crates/hipfire-arch-gemma4/src/config.rs
+++ b/crates/hipfire-arch-gemma4/src/config.rs
@@ -240,7 +240,7 @@ impl Gemma4Config {
             .collect::<Result<_, _>>()?;
         validate_layer_metadata(n_layers, num_kv_shared_layers, &layer_types)?;
 
-        let norm_plus_one = std::env::var("HIPFIRE_GEMMA4_NORM_PLUS_ONE")
+        let norm_plus_one = hipfire_config::developer_var("HIPFIRE_GEMMA4_NORM_PLUS_ONE")
             .ok()
             .as_deref()
             == Some("1");

--- a/crates/hipfire-arch-gemma4/src/drafter.rs
+++ b/crates/hipfire-arch-gemma4/src/drafter.rs
@@ -187,7 +187,7 @@ impl Gemma4DrafterConfig {
                 v
             });
 
-        let norm_plus_one = std::env::var("HIPFIRE_GEMMA4_NORM_PLUS_ONE")
+        let norm_plus_one = hipfire_config::developer_var("HIPFIRE_GEMMA4_NORM_PLUS_ONE")
             .ok()
             .as_deref()
             == Some("1");

--- a/crates/hipfire-arch-gemma4/src/forward.rs
+++ b/crates/hipfire-arch-gemma4/src/forward.rs
@@ -68,7 +68,7 @@ use rdna_compute::{DType, Gpu, GpuTensor};
 /// must therefore use the same arithmetic family as eager decode rather than
 /// numerically-close fused/WMMA variants whose small drift accumulates in KV.
 fn eagle_strict_enabled() -> bool {
-    std::env::var("HIPFIRE_GEMMA4_EAGLE").ok().as_deref() == Some("1")
+    hipfire_config::developer_var("HIPFIRE_GEMMA4_EAGLE").ok().as_deref() == Some("1")
 }
 
 /// Master switch for the qwen35-mirror fused-projection FFN path
@@ -78,7 +78,7 @@ fn eagle_strict_enabled() -> bool {
 /// pre-FWHT-rotated input).
 fn fused_ffn_enabled() -> bool {
     !matches!(
-        std::env::var("HIPFIRE_GEMMA4_FUSED_FFN").ok().as_deref(),
+        hipfire_config::developer_var("HIPFIRE_GEMMA4_FUSED_FFN").ok().as_deref(),
         Some("0") | Some("off") | Some("false")
     )
 }
@@ -91,7 +91,7 @@ fn fused_ffn_enabled() -> bool {
 /// fused kernel is byte-equivalent to two separate Q8 GEMVs).
 fn fused_qk_enabled() -> bool {
     !matches!(
-        std::env::var("HIPFIRE_GEMMA4_FUSED_QK").ok().as_deref(),
+        hipfire_config::developer_var("HIPFIRE_GEMMA4_FUSED_QK").ok().as_deref(),
         Some("0") | Some("off") | Some("false")
     )
 }
@@ -105,7 +105,7 @@ fn fused_qk_enabled() -> bool {
 fn fused_postnorm_enabled() -> bool {
     !eagle_strict_enabled()
         && !matches!(
-            std::env::var("HIPFIRE_GEMMA4_FUSED_POSTNORM")
+            hipfire_config::developer_var("HIPFIRE_GEMMA4_FUSED_POSTNORM")
                 .ok()
                 .as_deref(),
             Some("0") | Some("off") | Some("false")
@@ -121,7 +121,7 @@ fn fused_postnorm_enabled() -> bool {
 fn fused_qk_rope_enabled() -> bool {
     !eagle_strict_enabled()
         && !matches!(
-            std::env::var("HIPFIRE_GEMMA4_FUSED_QK_ROPE")
+            hipfire_config::developer_var("HIPFIRE_GEMMA4_FUSED_QK_ROPE")
                 .ok()
                 .as_deref(),
             Some("0") | Some("off") | Some("false")
@@ -169,7 +169,7 @@ fn qk_proj(
 /// the exact same math as `rmsnorm_f32` + rotation-doing `weight_gemv`, fused.
 fn fused_attn_norm_enabled() -> bool {
     !matches!(
-        std::env::var("HIPFIRE_GEMMA4_FUSED_ATTN_NORM")
+        hipfire_config::developer_var("HIPFIRE_GEMMA4_FUSED_ATTN_NORM")
             .ok()
             .as_deref(),
         Some("0") | Some("off") | Some("false")
@@ -311,7 +311,7 @@ pub fn decode_step_with_graph(
     static GRAPH_ENV: OnceLock<Option<bool>> = OnceLock::new();
     let env_override =
         *GRAPH_ENV.get_or_init(
-            || match std::env::var("HIPFIRE_GEMMA4_GRAPH").ok().as_deref() {
+            || match hipfire_config::developer_var("HIPFIRE_GEMMA4_GRAPH").ok().as_deref() {
                 Some("1") => Some(true),
                 Some("0") => Some(false),
                 _ => None,
@@ -1069,7 +1069,7 @@ fn attn_q8_swa(
     }
     // DIAG: HIPFIRE_GEMMA4_BASELINE_ATTN routes through the proven baseline
     // attention_q8_0_kv (no window) to isolate the new _swa kernel.
-    if std::env::var_os("HIPFIRE_GEMMA4_BASELINE_ATTN").is_some() {
+    if hipfire_config::developer_var_os("HIPFIRE_GEMMA4_BASELINE_ATTN").is_some() {
         return gpu
             .attention_q8_0_kv(
                 q,

--- a/crates/hipfire-arch-gemma4/src/lowered.rs
+++ b/crates/hipfire-arch-gemma4/src/lowered.rs
@@ -41,14 +41,14 @@ use rdna_compute::{DType, Gpu, GpuTensor};
 /// to the scalar GEMV path. Set HIPFIRE_WMMA_PREFILL=1 to opt in.
 pub fn wmma_prefill_enabled() -> bool {
     static GATE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *GATE.get_or_init(|| std::env::var("HIPFIRE_WMMA_PREFILL").map_or(false, |v| v == "1"))
+    *GATE.get_or_init(|| hipfire_config::developer_var("HIPFIRE_WMMA_PREFILL").map_or(false, |v| v == "1"))
 }
 
 /// Env gate for batched prefill (v2). Independent from WMMA.
 /// Set HIPFIRE_BATCHED_PREFILL=1 to use batched projections + per-token attention.
 pub fn batched_prefill_enabled() -> bool {
     static GATE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *GATE.get_or_init(|| std::env::var("HIPFIRE_BATCHED_PREFILL").map_or(false, |v| v == "1"))
+    *GATE.get_or_init(|| hipfire_config::developer_var("HIPFIRE_BATCHED_PREFILL").map_or(false, |v| v == "1"))
 }
 
 /// Batched GEMM for prefill projections.
@@ -283,7 +283,7 @@ fn run_prefill_gemm_inner(
         .map_err(|e| hip_bridge::HipError::new(0, &e.to_string()))?;
     // Debug parity hook: re-run token 0 through the per-token GEMV path
     // (raw input; weight_gemv rotates internally) and diff against the GEMM.
-    if std::env::var("HIPFIRE_GEMMA4_GEMM_VERIFY").ok().as_deref() == Some("1") {
+    if hipfire_config::developer_var("HIPFIRE_GEMMA4_GEMM_VERIFY").ok().as_deref() == Some("1") {
         let x_tok = gpu.alloc_tensor(&[w.k], DType::F32)?;
         let y_tok = gpu.alloc_tensor(&[w.m], DType::F32)?;
         gpu.hip
@@ -312,7 +312,7 @@ fn run_prefill_gemm_inner(
 /// Set HIPFIRE_GEMMA4_DUMP=1 to enable. Prints first 4 floats + sum + nan/inf count.
 #[allow(dead_code)]
 fn dbg_dump(gpu: &mut Gpu, label: &str, t: &GpuTensor, take: usize) {
-    if std::env::var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() != Some("1") {
+    if hipfire_config::developer_var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() != Some("1") {
         return;
     }
     let data = match gpu.download_f32(t) {
@@ -811,7 +811,7 @@ fn load_f32_vec(hfq: &HfqFile, name: &str, expected_n: usize) -> HipResult<Vec<f
             &format!("shape mismatch for {name}: expected {expected_n}, got {n}"),
         ));
     }
-    if std::env::var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1")
+    if hipfire_config::developer_var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1")
         && data.len() <= 4
         && name.contains("layer_scalar")
     {
@@ -1715,7 +1715,7 @@ impl Gemma4Scratch {
         // match the cross-arch baseline.
         const FALLBACK_KV_SEQ: usize = 32768;
         const TILE_SIZE: usize = 128;
-        let max_kv_seq: usize = std::env::var("HIPFIRE_KV_SEQ")
+        let max_kv_seq: usize = hipfire_config::developer_var("HIPFIRE_KV_SEQ")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
             .filter(|&n| n >= 128 && n <= 524_288)
@@ -2395,7 +2395,7 @@ fn apply_moe_branch_batched(
     // more parallelism than is recovered from launch-overhead savings
     // (180k blocks vs 1.4M). Default OFF; kept behind opt-in for future
     // tuning (smaller MAX_GROUPS, LDS staging, fewer launch_bounds waves).
-    let use_bucketed = std::env::var("HIPFIRE_MOE_BUCKETED")
+    let use_bucketed = hipfire_config::developer_var("HIPFIRE_MOE_BUCKETED")
         .ok()
         .map(|v| v == "1")
         .unwrap_or(false);
@@ -2623,7 +2623,7 @@ pub fn forward_scratch(
     //     for the same reason as Qwen35 — bail to direct in that case.
     static GRAPH_OVERRIDE_ENV: std::sync::OnceLock<Option<bool>> = std::sync::OnceLock::new();
     let graph_override =
-        *GRAPH_OVERRIDE_ENV.get_or_init(|| match std::env::var("HIPFIRE_GRAPH").ok().as_deref() {
+        *GRAPH_OVERRIDE_ENV.get_or_init(|| match hipfire_config::developer_var("HIPFIRE_GRAPH").ok().as_deref() {
             Some("0") => Some(false),
             Some("1") => Some(true),
             _ => None,
@@ -2721,7 +2721,7 @@ fn forward_scratch_inner(
     let mut full_kv_idx = 0usize;
     for (layer_idx, layer_type) in config.layer_types.iter().copied().enumerate() {
         // Diagnostic: dump residual before layer
-        if std::env::var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1") && layer_idx < 2 {
+        if hipfire_config::developer_var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1") && layer_idx < 2 {
             let data = gpu.download_f32(&scratch.x).unwrap_or_default();
             let sum: f64 = data.iter().map(|&v| v as f64).sum();
             let min = data.iter().fold(f32::INFINITY, |a, &b| a.min(b));
@@ -2746,7 +2746,7 @@ fn forward_scratch_inner(
             }
         }
         // Diagnostic: dump residual after layer
-        if std::env::var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1") {
+        if hipfire_config::developer_var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1") {
             let data = gpu.download_f32(&scratch.x).unwrap_or_default();
             let sum: f64 = data.iter().map(|&v| v as f64).sum();
             let min = data.iter().fold(f32::INFINITY, |a, &b| a.min(b));
@@ -2765,7 +2765,7 @@ fn forward_scratch_inner(
     )?;
 
     // Diagnostic: dump hidden state before lm_head
-    if std::env::var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1") {
+    if hipfire_config::developer_var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1") {
         let data = gpu.download_f32(&scratch.tmp).unwrap_or_default();
         let sum: f64 = data.iter().map(|&v| v as f64).sum();
         let min = data.iter().fold(f32::INFINITY, |a, &b| a.min(b));
@@ -2798,7 +2798,7 @@ fn forward_scratch_inner(
     }
 
     // Diagnostic: dump logits
-    if std::env::var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1") {
+    if hipfire_config::developer_var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1") {
         let data = gpu.download_f32(&scratch.logits).unwrap_or_default();
         let top5: Vec<(usize, f32)> = {
             let mut indexed: Vec<(usize, f32)> =
@@ -2900,7 +2900,7 @@ fn sliding_layer_decode_impl(
         gpu.hip
             .memcpy_dtod(&scratch.residual.buf, &scratch.x.buf, dim_bytes)?;
     }
-    let _dump_on = std::env::var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1")
+    let _dump_on = hipfire_config::developer_var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1")
         && (pos == 0 || pos == 1)
         && kv_layer_idx == 0;
     if _dump_on {
@@ -3235,7 +3235,7 @@ fn sliding_layer_decode_impl(
     // apply_moe_branch (which adds the parallel MoE branch + sandwich norms
     // 1 and 2 before this outer norm); on dense layers we just call the
     // standalone post_feedforward_layernorm.
-    let moe_bypass = std::env::var("HIPFIRE_MOE_BYPASS").ok().as_deref() == Some("1");
+    let moe_bypass = hipfire_config::developer_var("HIPFIRE_MOE_BYPASS").ok().as_deref() == Some("1");
     match (lw.moe.as_ref(), moe_bypass) {
         (Some(moe), false) => apply_moe_branch(
             gpu,
@@ -3349,7 +3349,7 @@ fn full_layer_decode_impl(
         config.norm_eps,
     )?;
 
-    let _fdump = std::env::var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1")
+    let _fdump = hipfire_config::developer_var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1")
         && pos == 1
         && kv_layer_idx == 0;
     if _fdump {
@@ -3554,7 +3554,7 @@ fn full_layer_decode_impl(
     }
 
     // Sandwich post-FFN norm. Same MoE dispatch as sliding_layer_decode.
-    let moe_bypass = std::env::var("HIPFIRE_MOE_BYPASS").ok().as_deref() == Some("1");
+    let moe_bypass = hipfire_config::developer_var("HIPFIRE_MOE_BYPASS").ok().as_deref() == Some("1");
     match (lw.moe.as_ref(), moe_bypass) {
         (Some(moe), false) => apply_moe_branch(
             gpu,
@@ -4618,7 +4618,7 @@ fn forward_prefill_batch_v2(
                 let ctx = DispatchCtx::new(gpu);
                 execute_steps(gpu, &ctx, &[Step::Attend { plan, io }])
                     .map_err(|e| hip_bridge::HipError::new(0, &e.to_string()))?;
-                if std::env::var("HIPFIRE_GEMMA4_ATTN_VERIFY").ok().as_deref() == Some("1") {
+                if hipfire_config::developer_var("HIPFIRE_GEMMA4_ATTN_VERIFY").ok().as_deref() == Some("1") {
                     let batched_out = gpu.download_f32(&scratch.pb_attn_q)?;
                     for i in 0..n_batch {
                         let pos = start_pos + i;
@@ -4952,7 +4952,7 @@ fn forward_prefill_batch_v2(
         // MoE branch (or dense fallback). HIPFIRE_MOE_BYPASS=1 forces dense
         // path even on MoE layers (parity with v1 — used to isolate whether
         // a regression lives in apply_moe_branch_batched vs the dense path).
-        let moe_bypass = std::env::var("HIPFIRE_MOE_BYPASS").ok().as_deref() == Some("1");
+        let moe_bypass = hipfire_config::developer_var("HIPFIRE_MOE_BYPASS").ok().as_deref() == Some("1");
         match (moe_opt, moe_bypass) {
             (Some(moe), false) => {
                 apply_moe_branch_batched(gpu, config, scratch, moe, post_ffn_norm_ref, n_batch)?;
@@ -4972,7 +4972,7 @@ fn forward_prefill_batch_v2(
                 gpu.scale_f32(&scratch.pb_residual, layer_scalar)?;
             }
         }
-        if std::env::var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1") {
+        if hipfire_config::developer_var("HIPFIRE_GEMMA4_DUMP").ok().as_deref() == Some("1") {
             let data = gpu.download_f32(&scratch.pb_residual).unwrap_or_default();
             let last = &data[(n_batch - 1) * dim..n_batch * dim];
             let sum: f64 = last.iter().map(|&v| v as f64).sum();
@@ -5800,7 +5800,7 @@ fn forward_lowered_enabled() -> bool {
     *F.get_or_init(|| {
         // Default ON (byte-parity validated 2026-06-08).
         // Set HIPFIRE_FORWARD_LOWERED=0 to force legacy hand path.
-        std::env::var("HIPFIRE_FORWARD_LOWERED").ok().as_deref() != Some("0")
+        hipfire_config::developer_var("HIPFIRE_FORWARD_LOWERED").ok().as_deref() != Some("0")
     })
 }
 

--- a/crates/hipfire-arch-maple/src/forward.rs
+++ b/crates/hipfire-arch-maple/src/forward.rs
@@ -287,7 +287,7 @@ fn decode_step_body(
 /// per (layer, token) on the hot path and the disabled case must not allocate.
 fn router_dump_prefix() -> Option<&'static str> {
     static P: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
-    P.get_or_init(|| std::env::var("HIPFIRE_MAPLE_DUMP_ROUTER").ok())
+    P.get_or_init(|| hipfire_config::developer_var("HIPFIRE_MAPLE_DUMP_ROUTER").ok())
         .as_deref()
 }
 
@@ -368,7 +368,7 @@ fn dump_router_records(
 /// Destination for the per-layer residual dump, or `None` when disabled.
 fn dump_hidden_path() -> Option<String> {
     static P: std::sync::OnceLock<Option<String>> = std::sync::OnceLock::new();
-    P.get_or_init(|| std::env::var("HIPFIRE_MAPLE_DUMP_HIDDEN").ok())
+    P.get_or_init(|| hipfire_config::developer_var("HIPFIRE_MAPLE_DUMP_HIDDEN").ok())
         .clone()
 }
 
@@ -609,7 +609,7 @@ enum DownMode {
 fn down_mode() -> DownMode {
     static M: std::sync::OnceLock<DownMode> = std::sync::OnceLock::new();
     *M.get_or_init(
-        || match std::env::var("HIPFIRE_MAPLE_DOWN").ok().as_deref() {
+        || match hipfire_config::developer_var("HIPFIRE_MAPLE_DOWN").ok().as_deref() {
             Some("atomic") => DownMode::Atomic,
             Some("expanded-nocombine") => DownMode::ExpandedNoCombine,
             _ => DownMode::Expanded,

--- a/crates/hipfire-arch-muse-glimmer/Cargo.toml
+++ b/crates/hipfire-arch-muse-glimmer/Cargo.toml
@@ -14,6 +14,7 @@ default = ["deltanet"]
 deltanet = ["hipfire-runtime/deltanet", "rdna-compute/deltanet"]
 
 [dependencies]
+hipfire-config = { path = "../hipfire-config" }
 hipfire-runtime = { path = "../hipfire-runtime" }
 hip-bridge = { path = "../hip-bridge" }
 rdna-compute = { path = "../rdna-compute" }

--- a/crates/hipfire-arch-muse-glimmer/src/drafter.rs
+++ b/crates/hipfire-arch-muse-glimmer/src/drafter.rs
@@ -169,7 +169,7 @@ use rdna_compute::{DType, Gpu, GpuTensor};
 // ─── Shared rotation gate (mirrors forward.rs) ───────────────────────────
 // HIPFIRE_GLIMMER_SHARED_ROT default ON (=1 or unset), =0 selects old path.
 fn shared_rot_enabled() -> bool {
-    std::env::var("HIPFIRE_GLIMMER_SHARED_ROT").as_deref() != Ok("0")
+    hipfire_config::developer_var("HIPFIRE_GLIMMER_SHARED_ROT").as_deref() != Ok("0")
 }
 
 // ─── Batched projection dispatch (mirrors forward.rs::proj_gemm_batched) ──

--- a/crates/hipfire-arch-muse-glimmer/src/forward.rs
+++ b/crates/hipfire-arch-muse-glimmer/src/forward.rs
@@ -165,7 +165,7 @@ fn run_prefill_residual_muse_or_key(
 /// Default ON. Since the kernel is bit-identical to the shared one, this knob
 /// is a perf A/B switch, not a correctness escape hatch.
 fn muse_gemm_enabled() -> bool {
-    std::env::var("HIPFIRE_GLIMMER_MUSE_GEMM")
+    hipfire_config::developer_var("HIPFIRE_GLIMMER_MUSE_GEMM")
         .map(|v| v != "0" && !v.is_empty())
         .unwrap_or(true)
 }
@@ -173,7 +173,7 @@ fn muse_gemm_enabled() -> bool {
 // Opt-out for fusing the FFN activation and MagnumQuant G256 rotation.
 #[inline]
 fn fused_silu_rotate_supported(w: &WeightTensor) -> bool {
-    std::env::var("HIPFIRE_GLIMMER_FUSED_SILU_ROTATE").as_deref() != Ok("0")
+    hipfire_config::developer_var("HIPFIRE_GLIMMER_FUSED_SILU_ROTATE").as_deref() != Ok("0")
         && matches!(w.gpu_dtype, DType::MQ4G256 | DType::MQ6G256)
         && w.k % 256 == 0
 }
@@ -220,12 +220,12 @@ fn run_prefill_fused_qkvza_key(
 // HIPFIRE_GLIMMER_SHARED_ROT default ON (=1 or unset), =0 selects old path.
 // Mirrors Gemma4's attn_input_qkv and Qwen35's run_fa_layer_body precedent.
 fn shared_rot_enabled() -> bool {
-    std::env::var("HIPFIRE_GLIMMER_SHARED_ROT").as_deref() != Ok("0")
+    hipfire_config::developer_var("HIPFIRE_GLIMMER_SHARED_ROT").as_deref() != Ok("0")
 }
 
 fn batched_lm_head_enabled() -> bool {
     !matches!(
-        std::env::var("HIPFIRE_GLIMMER_BATCHED_LM_HEAD")
+        hipfire_config::developer_var("HIPFIRE_GLIMMER_BATCHED_LM_HEAD")
             .ok()
             .as_deref(),
         Some("0") | Some("off") | Some("false")
@@ -237,7 +237,7 @@ fn batched_lm_head_enabled() -> bool {
 /// `HIPFIRE_GLIMMER_FUSED_POSTNORM=0|off|false|no` (case-insensitive).
 /// Decode-only; not byte-identical (residual add rounds in-kernel).
 fn fused_postnorm_enabled() -> bool {
-    match std::env::var("HIPFIRE_GLIMMER_FUSED_POSTNORM") {
+    match hipfire_config::developer_var("HIPFIRE_GLIMMER_FUSED_POSTNORM") {
         Ok(v) => !matches!(
             v.trim().to_ascii_lowercase().as_str(),
             "0" | "off" | "false" | "no"
@@ -254,7 +254,7 @@ fn fused_postnorm_enabled() -> bool {
 /// layers pass `n_rot_pairs=0` (norm+scale, no RoPE). Not eligible when
 /// any of NO_QK_NORM / NO_QK_SCALE / ROPE_INTERLEAVED ablations are on.
 fn fused_qk_rope_enabled() -> bool {
-    match std::env::var("HIPFIRE_GLIMMER_FUSED_QK_ROPE") {
+    match hipfire_config::developer_var("HIPFIRE_GLIMMER_FUSED_QK_ROPE") {
         Ok(v) => !matches!(
             v.trim().to_ascii_lowercase().as_str(),
             "0" | "off" | "false"
@@ -279,7 +279,7 @@ fn fused_qk_rope_enabled() -> bool {
 ///   within budget but closer to limit; B=128 is more conservative.
 ///   Both defaults (192 and 256) sit well inside that headroom.
 pub fn glimmer_prefill_chunk_size(prompt_len: usize) -> usize {
-    if let Some(v) = std::env::var("HIPFIRE_GLIMMER_PREFILL_CHUNK")
+    if let Some(v) = hipfire_config::developer_var("HIPFIRE_GLIMMER_PREFILL_CHUNK")
         .ok()
         .and_then(|v| v.trim().parse::<usize>().ok())
     {
@@ -757,7 +757,7 @@ fn glimmer_layer_decode(
     //
     // `HIPFIRE_GLIMMER_FLASH_DECODE` overrides the threshold in tokens; 0
     // disables flash decode entirely.
-    let flash_min = std::env::var("HIPFIRE_GLIMMER_FLASH_DECODE")
+    let flash_min = hipfire_config::developer_var("HIPFIRE_GLIMMER_FLASH_DECODE")
         .ok()
         .and_then(|v| v.trim().parse::<usize>().ok())
         .unwrap_or(1280);
@@ -2167,7 +2167,7 @@ fn verify_block_capture_impl(
     let restore_pos = position as usize;
     let device = matches!(&capture, CaptureBackend::Device);
     let t_verify_start = std::time::Instant::now();
-    let do_timing = std::env::var("HIPFIRE_GLIMMER_TIMING").ok().as_deref() == Some("1");
+    let do_timing = hipfire_config::developer_var("HIPFIRE_GLIMMER_TIMING").ok().as_deref() == Some("1");
 
     // Host: sorted capture index + position-major buf. Device: validate cursor
     // and clone layer_to_slot; begin_verify runs after scratch alloc succeeds.
@@ -2494,7 +2494,7 @@ fn verify_block_capture_impl(
             // same query-tiled WMMA kernels prefill already uses (one WMMA B
             // fragment reused across 16 query rows: O(ctx)).
             let wmma_full = b > 1
-                && std::env::var("HIPFIRE_GLIMMER_WMMA_FULL")
+                && hipfire_config::developer_var("HIPFIRE_GLIMMER_WMMA_FULL")
                     .map(|v| v != "0" && !v.is_empty())
                     .unwrap_or(true);
             let mut wmma_done = false;
@@ -3349,10 +3349,10 @@ fn prefill_chunk_batched(
             // So it costs ~0.2% (inside noise) below the window and is the
             // difference between working and not above it. `=0` restores the
             // batched path and reintroduces the ceiling.
-            let flash_full = std::env::var("HIPFIRE_GLIMMER_FLASH_FULL")
+            let flash_full = hipfire_config::developer_var("HIPFIRE_GLIMMER_FLASH_FULL")
                 .map(|v| v != "0" && !v.is_empty())
                 .unwrap_or(true);
-            let use_flash = std::env::var("HIPFIRE_GLIMMER_NO_FLASH").as_deref() != Ok("1")
+            let use_flash = hipfire_config::developer_var("HIPFIRE_GLIMMER_NO_FLASH").as_deref() != Ok("1")
                 && ((window != 0 && seq_len > window)
                     || (window == 0 && flash_full && seq_len > 2048));
             if use_flash {
@@ -3425,7 +3425,7 @@ fn prefill_chunk_batched(
                 // get the parent. Both are Q8 WMMA, so all 52 layers are now on
                 // matrix hardware instead of 13 of them.
                 let wmma_full = b > 1
-                    && std::env::var("HIPFIRE_GLIMMER_WMMA_FULL")
+                    && hipfire_config::developer_var("HIPFIRE_GLIMMER_WMMA_FULL")
                         .map(|v| v != "0" && !v.is_empty())
                         .unwrap_or(true);
                 let mut wmma_done = false;
@@ -3553,7 +3553,7 @@ fn prefill_chunk_batched(
             // processes per config: 1372 -> 1356 ms at 1080 (+1.2%) and 7366 ->
             // 7310 ms at 4241 (+0.8%), byte-identical both lengths. Env opt-out
             // HIPFIRE_GLIMMER_O_RESIDUAL=0 kept for A/B.
-            let o_use_residual = std::env::var("HIPFIRE_GLIMMER_O_RESIDUAL")
+            let o_use_residual = hipfire_config::developer_var("HIPFIRE_GLIMMER_O_RESIDUAL")
                 .map(|v| v != "0" && !v.is_empty())
                 .unwrap_or(true)
                 && b > 1

--- a/crates/hipfire-arch-muse-glimmer/src/glimmer.rs
+++ b/crates/hipfire-arch-muse-glimmer/src/glimmer.rs
@@ -167,7 +167,7 @@ pub fn hidden_can_rewind_to(
 /// unless set; may synchronize and download.
 #[inline]
 pub fn device_capture_audit_enabled() -> bool {
-    std::env::var("HIPFIRE_GLIMMER_DEVICE_CAPTURE_AUDIT")
+    hipfire_config::developer_var("HIPFIRE_GLIMMER_DEVICE_CAPTURE_AUDIT")
         .ok()
         .as_deref()
         == Some("1")
@@ -1043,7 +1043,7 @@ fn load_norm_with(
 ) -> Result<GpuTensor, String> {
     let mut f32_data = load_f32_vec(hfq, name, dim)?;
     if centered
-        && std::env::var("HIPFIRE_GLIMMER_NO_CENTERED_NORM")
+        && hipfire_config::developer_var("HIPFIRE_GLIMMER_NO_CENTERED_NORM")
             .ok()
             .as_deref()
             != Some("1")
@@ -1784,7 +1784,7 @@ impl GlimmerState {
     ) -> Result<Self, String> {
         // `HIPFIRE_GLIMMER_KV_VMM=0` falls back to the contiguous allocator.
         // Default remains VMM so examples/tools keep working without a LoadCtx.
-        let use_vmm = std::env::var("HIPFIRE_GLIMMER_KV_VMM")
+        let use_vmm = hipfire_config::developer_var("HIPFIRE_GLIMMER_KV_VMM")
             .map(|v| v != "0" && !v.is_empty())
             .unwrap_or(true);
         let backend = if use_vmm {

--- a/crates/hipfire-arch-qwen35-vl/Cargo.toml
+++ b/crates/hipfire-arch-qwen35-vl/Cargo.toml
@@ -15,6 +15,7 @@ default = ["deltanet"]
 deltanet = ["hipfire-runtime/deltanet", "rdna-compute/deltanet"]
 
 [dependencies]
+hipfire-config = { path = "../hipfire-config" }
 hipfire-runtime = { path = "../hipfire-runtime" }
 hip-bridge = { path = "../hip-bridge" }
 rdna-compute = { path = "../rdna-compute" }

--- a/crates/hipfire-arch-qwen35-vl/src/image.rs
+++ b/crates/hipfire-arch-qwen35-vl/src/image.rs
@@ -72,7 +72,7 @@ const VISION_LDS_MAX_PIXELS: usize = 4_128_768;
 /// Resolve the vision input pixel budget, honouring `HIPFIRE_VL_MAX_PIXELS`
 /// but never exceeding what the attention kernel's LDS can hold.
 fn vision_max_pixels() -> usize {
-    std::env::var("HIPFIRE_VL_MAX_PIXELS")
+    hipfire_config::developer_var("HIPFIRE_VL_MAX_PIXELS")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|v| *v > 0)

--- a/crates/hipfire-arch-qwen35-vl/src/qwen35_vl.rs
+++ b/crates/hipfire-arch-qwen35-vl/src/qwen35_vl.rs
@@ -994,12 +994,9 @@ pub fn vision_forward(
     let n = grid_h * grid_w;
     let patch_dim = 3 * config.temporal_patch_size * config.patch_size * config.patch_size;
     let t0 = std::time::Instant::now();
-    let dump_dir = std::env::var_os("HIPFIRE_VL_DUMP_DIR").map(std::path::PathBuf::from);
-    let dump_dir = dump_dir.as_deref();
-
     // Diagnostic stage dumps (env-gated; see `vl_dump_slice`).
     let dump_dir: Option<std::path::PathBuf> =
-        std::env::var("HIPFIRE_VL_DUMP_DIR").ok().map(Into::into);
+        hipfire_config::developer_var("HIPFIRE_VL_DUMP_DIR").ok().map(Into::into);
     let dd = dump_dir.as_deref();
     if dd.is_some() {
         eprintln!(

--- a/crates/hipfire-arch-qwen35/src/mtp_speculator.rs
+++ b/crates/hipfire-arch-qwen35/src/mtp_speculator.rs
@@ -29,15 +29,15 @@ use rdna_compute::Gpu;
 /// Env `HIPFIRE_NGRAM_MOD_{N_MATCH,N_MIN,N_MAX}` with production defaults.
 /// `None` when the triple is invalid (max>64, zero match/max, or min>max).
 fn ngram_mod_env_config() -> Option<NgramModConfig> {
-    let n_match: usize = std::env::var("HIPFIRE_NGRAM_MOD_N_MATCH")
+    let n_match: usize = hipfire_config::developer_var("HIPFIRE_NGRAM_MOD_N_MATCH")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(24);
-    let n_min: usize = std::env::var("HIPFIRE_NGRAM_MOD_N_MIN")
+    let n_min: usize = hipfire_config::developer_var("HIPFIRE_NGRAM_MOD_N_MIN")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(48);
-    let n_max: usize = std::env::var("HIPFIRE_NGRAM_MOD_N_MAX")
+    let n_max: usize = hipfire_config::developer_var("HIPFIRE_NGRAM_MOD_N_MAX")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(64);
@@ -165,7 +165,7 @@ impl Qwen35MtpDrafter {
     fn ensure_state(&mut self, gpu: &mut Gpu, slot: &ModelSlot) -> Result<(), String> {
         if self.state.is_none() {
             let verify_capacity =
-                if std::env::var("HIPFIRE_MTP_NGRAM").ok().as_deref() == Some("1") {
+                if hipfire_config::developer_var("HIPFIRE_MTP_NGRAM").ok().as_deref() == Some("1") {
                     ngram_mod_env_config()
                         .map(|cfg| self.max_n.max(cfg.n_max))
                         .unwrap_or(self.max_n)

--- a/crates/hipfire-arch-qwen35/src/qwen35/load.rs
+++ b/crates/hipfire-arch-qwen35/src/qwen35/load.rs
@@ -4266,7 +4266,7 @@ fn try_load_packed_mq4_experts(
             HostBlob::Owned(results.next().expect("two packed MQ4 jobs").data),
         )
     };
-    let trace = std::env::var_os("HIPFIRE_LOAD_TRACE").is_some();
+    let trace = hipfire_config::developer_var_os("HIPFIRE_LOAD_TRACE").is_some();
     let zero_copy =
         matches!(gate_up_host, HostBlob::Borrowed(_)) && matches!(down_host, HostBlob::Borrowed(_));
     let t_upload = Instant::now();

--- a/crates/hipfire-config/src/lib.rs
+++ b/crates/hipfire-config/src/lib.rs
@@ -3235,6 +3235,29 @@ pub fn developer_var(name: &str) -> std::result::Result<String, std::env::VarErr
 pub fn developer_var_os(name: &str) -> Option<std::ffi::OsString> {
     process_value(name).map(Into::into)
 }
+/// Strict process-snapshot boolean for the `HIPFIRE_*` long tail.
+/// Reads exactly one snapshot value: `"1"` is true, `"0"` is false, and
+/// anything else (absent, empty, or any other spelling) falls back to
+/// `default`. The strict table matters: it exactly preserves both ambient
+/// idioms it replaces — `var == "1"` (default off) and `var != "0"`
+/// (default on) — while routing the read through the versioned
+/// [`ProcessConfig`] snapshot so TOML `[developer]` overrides and the
+/// env-beats-config-beats-default precedence apply. Deliberately narrower
+/// than `FeatureFlags::from_lookup`'s `parse_bool`, which also accepts
+/// `true`/`on`/`yes`: call sites that accept those spellings keep their
+/// own predicate.
+pub fn developer_bool(name: &str, default: bool) -> bool {
+    parse_developer_bool(process_value(name).as_deref(), default)
+}
+/// Pure truth table behind [`developer_bool`], split out so unit tests can
+/// pin the contract without touching the process-global snapshot.
+fn parse_developer_bool(raw: Option<&str>, default: bool) -> bool {
+    match raw {
+        Some("1") => true,
+        Some("0") => false,
+        _ => default,
+    }
+}
 
 fn render_compat_value(value: &ConfigValue) -> Option<String> {
     Some(match value {
@@ -4443,6 +4466,32 @@ mod tests {
 
     fn temp_root(name: &str) -> PathBuf {
         env::temp_dir().join(format!("hipfire-config-{name}-{}", std::process::id()))
+    }
+
+    #[test]
+    fn developer_bool_truth_table_is_strict() {
+        // "1" is true and "0" is false regardless of the default; every
+        // other spelling (including "true"/"on"/empty) falls back to it,
+        // which is what makes the helper an exact replacement for both
+        // `var == "1"` (default off) and `var != "0"` (default on).
+        for default in [false, true] {
+            assert!(parse_developer_bool(Some("1"), default));
+            assert!(!parse_developer_bool(Some("0"), default));
+            assert_eq!(parse_developer_bool(None, default), default);
+            assert_eq!(parse_developer_bool(Some("true"), default), default);
+            assert_eq!(parse_developer_bool(Some("on"), default), default);
+            assert_eq!(parse_developer_bool(Some("yes"), default), default);
+            assert_eq!(parse_developer_bool(Some(""), default), default);
+            assert_eq!(parse_developer_bool(Some("2"), default), default);
+        }
+    }
+
+    #[test]
+    fn developer_bool_defaults_when_unset() {
+        // A probe name nothing sets must resolve to the caller's default
+        // through the live snapshot (no install, no TOML, no env).
+        assert!(!developer_bool("HIPFIRE_S4_FLAG_PROBE_UNSET_OFF", false));
+        assert!(developer_bool("HIPFIRE_S4_FLAG_PROBE_UNSET_ON", true));
     }
 
     #[test]

--- a/crates/hipfire-config/src/lib.rs
+++ b/crates/hipfire-config/src/lib.rs
@@ -1594,6 +1594,15 @@ pub static FIELDS: &[ConfigField] = &[
         Some("HIPFIRE_DEFAULT_CHATML"),
         "Allow the fallback ChatML frame when no template resolves."
     ),
+    process_bool_field!(
+        "prompt.jinja_chat",
+        "jinja_chat",
+        Prompt,
+        true,
+        false,
+        "HIPFIRE_JINJA_CHAT",
+        "Render chat prompts through the model Jinja template; set HIPFIRE_JINJA_CHAT=0 for the hand-rolled ChatScaffold path."
+    ),
     process_field!(
         "hardware.devices",
         "devices",
@@ -2209,6 +2218,15 @@ pub static FIELDS: &[ConfigField] = &[
         true,
         "HIPFIRE_GATE_UP_NOSYNC",
         "Enable the no-sync gate/up experiment."
+    ),
+    process_bool_field!(
+        "kernel.calib_force_bf16",
+        "calib_force_bf16",
+        Kernel,
+        false,
+        true,
+        "HIPFIRE_CALIB_BF16",
+        "Keep native-BF16 calibration teachers in BF16 instead of widening to F32 (calibration only; shipped inference is unaffected)."
     ),
     process_bool_field!(
         "kernel.qkvza_split_tail",

--- a/crates/hipfire-config/src/rocm.rs
+++ b/crates/hipfire-config/src/rocm.rs
@@ -190,7 +190,7 @@ pub fn has_configured_root() -> bool {
 /// override never silently falls through to autodetection — that silent
 /// mismatch is the bug class this module exists to prevent.
 pub fn configured_compiler() -> Option<(&'static str, PathBuf)> {
-    std::env::var_os("HIPFIRE_HIPCC")
+    crate::developer_var_os("HIPFIRE_HIPCC")
         .filter(|v| !v.is_empty())
         .map(|value| ("HIPFIRE_HIPCC", PathBuf::from(value)))
 }
@@ -211,7 +211,7 @@ pub fn configured_compiler_from(value: Option<&str>) -> Option<(&'static str, Pa
 /// When `HIPFIRE_ROCM_STRICT=1` the cross-root compiler fallback is disabled
 /// and a runtime-headers-only root that lacks a compiler hard-fails as before.
 pub fn is_strict_rocm() -> bool {
-    strict_from(std::env::var_os("HIPFIRE_ROCM_STRICT").as_ref())
+    crate::developer_bool("HIPFIRE_ROCM_STRICT", false)
 }
 
 /// Pure predicate for strict mode without reading process-global env.

--- a/crates/hipfire-generate/src/ar.rs
+++ b/crates/hipfire-generate/src/ar.rs
@@ -700,17 +700,17 @@ pub fn qwen_ar_eviction_prefill_chunk_limit(
 }
 
 pub fn ckpt_resume_enabled() -> bool {
-    std::env::var("HIPFIRE_CACHE_CKPT_RESUME").ok().as_deref() != Some("0")
+    hipfire_config::developer_var("HIPFIRE_CACHE_CKPT_RESUME").ok().as_deref() != Some("0")
 }
 pub fn ckpt_interval() -> usize {
-    std::env::var("HIPFIRE_CACHE_CKPT_INTERVAL")
+    hipfire_config::developer_var("HIPFIRE_CACHE_CKPT_INTERVAL")
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(2048)
         .max(256)
 }
 pub fn ckpt_max() -> usize {
-    std::env::var("HIPFIRE_CACHE_CKPT_MAX")
+    hipfire_config::developer_var("HIPFIRE_CACHE_CKPT_MAX")
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(8)
@@ -1118,8 +1118,8 @@ pub fn generate(
         nonneutral_penalties: repeat_penalty != 1.0
             || presence_penalty != 0.0
             || frequency_penalty != 0.0,
-        force_ar_chat: std::env::var("HIPFIRE_DFLASH_CHAT").ok().as_deref() == Some("0"),
-        temp_spec_env_off: std::env::var("HIPFIRE_DFLASH_TEMP_SPEC").ok().as_deref() == Some("0"),
+        force_ar_chat: hipfire_config::developer_var("HIPFIRE_DFLASH_CHAT").ok().as_deref() == Some("0"),
+        temp_spec_env_off: hipfire_config::developer_var("HIPFIRE_DFLASH_TEMP_SPEC").ok().as_deref() == Some("0"),
         fast_sample_on: hipfire_runtime::config::get().dflash_fast_sample,
         supports_temp_swor,
         supports_chain_nucleus_verify,
@@ -1909,7 +1909,7 @@ pub fn generate(
     // is OFF, physical grows unbounded up to max_seq; reset when we'd overrun.
     let tokenizer = m.tokenizer.as_ref().unwrap();
     let prompt_est = tokenizer.encode(prompt).len() + 20;
-    if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
+    if hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
         eprintln!(
             "[qwen-cache GEN-ENTRY] conv_tok={} seq_pos={}",
             m.conversation_tokens.len(),
@@ -2078,7 +2078,7 @@ pub fn generate(
             (None, None) => String::new(),
         }
     }
-    if std::env::var("HIPFIRE_PFLASH_DEBUG").is_ok() {
+    if hipfire_config::developer_var("HIPFIRE_PFLASH_DEBUG").is_ok() {
         eprintln!(
             "[pflash] gen: state={} cfg-present seq_pos={} q={} drafter_gpu={}",
             pflash_state.is_some(),
@@ -2203,7 +2203,7 @@ pub fn generate(
     // Jinja default-ON (flipped 2026-06-09): render through the model's chat
     // template for ALL arches; opt out with HIPFIRE_JINJA_CHAT=0 (hand-rolled
     // ChatML/Plain). Falls back to Plain automatically when no template resolves.
-    let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
+    let jinja_enabled = hipfire_config::developer_var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
     // Jinja renders the FULL conversation every turn (stateless full-render,
     // like crate::qwen::generate_dflash) — fire on every turn, not just `seq_pos == 0`.
     // `render_messages` below replays `messages_history` (all prior turns) and
@@ -2335,7 +2335,7 @@ pub fn generate(
     // (seq_pos=0, conversation_tokens.clear(), zero DeltaNet, KV
     // compact_offset=0) and prefill the FULL rendered prompt — DeltaNet
     // is not reversible to position M<N so partial rollback is unsafe.
-    let cache_kill_switch = std::env::var("HIPFIRE_QWEN_PROMPT_CACHE").ok().as_deref() == Some("0");
+    let cache_kill_switch = hipfire_config::developer_var("HIPFIRE_QWEN_PROMPT_CACHE").ok().as_deref() == Some("0");
     let pflash_active = pflash_cfg
         .map(|c| !matches!(c.mode, hipfire_pflash::pflash::PflashMode::Off))
         .unwrap_or(false);
@@ -2351,7 +2351,7 @@ pub fn generate(
     // so the operator gets consistent rendering across all turns.
     // Cache-with-Jinja is a future project (would require Jinja-side
     // assistant-turn replay).
-    let jinja_active = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0")
+    let jinja_active = hipfire_config::developer_var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0")
         && m.chat_template.is_some();
     // Cache-with-Jinja (item #37): `jinja_active` is NO LONGER a disqualifier.
     // When jinja is active the prompt-build below routes through
@@ -2363,7 +2363,7 @@ pub fn generate(
         && m.eviction.is_none()
         && !pflash_active
         && !m.conversation_tokens.is_empty();
-    if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
+    if hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
         eprintln!(
             "[qwen-cache eligible] eligible={} kill={} hist={} evict_none={} !pflash={} jinja={} conv_tok={}",
             cache_eligible, cache_kill_switch, messages_history.is_some(),
@@ -2373,7 +2373,7 @@ pub fn generate(
     let mut cached_tokens_count: usize = 0;
     let new_tokens: Vec<u32> = if cache_eligible {
         let history = messages_history.unwrap();
-        let trace_cache = std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1");
+        let trace_cache = hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1");
         // Build the canonical full-conversation token stream, replaying
         // any historical assistant turn whose fingerprint matches a
         // cached emission (BPE-bijective replacement).
@@ -3332,7 +3332,7 @@ pub fn generate(
         //
         // Disable with `HIPFIRE_QWEN35_GRAMMAR=0` for A/B comparison.
         let grammar_enabled = hipfire_runtime::prompt_frame::qwen35_grammar_on(
-            std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref(),
+            hipfire_config::developer_var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref(),
             &m.model_path,
         );
         let tool_schemas_qwen: Vec<saddle_core::grammar::json::ToolSchema> = if grammar_enabled {
@@ -3494,7 +3494,7 @@ pub fn generate(
         // +256 EOS below only counts in-think tokens, so a non-think ramble or a
         // re-open loop after the cap latches would run to max_tokens. Hard-EOS
         // once generation runs this many tokens past the latch.
-        let post_latch_answer_budget: usize = std::env::var("HIPFIRE_POST_LATCH_ANSWER_TOKENS")
+        let post_latch_answer_budget: usize = hipfire_config::developer_var("HIPFIRE_POST_LATCH_ANSWER_TOKENS")
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(768);
@@ -4277,7 +4277,7 @@ pub fn generate(
                     cached_seq.pop();
                 }
             }
-            if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
+            if hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
                 eprintln!(
                     "[qwen-cache store] cached_seq={} emit_text.len={} tool_calls={} preview={:?}",
                     cached_seq.len(),

--- a/crates/hipfire-generate/src/batch.rs
+++ b/crates/hipfire-generate/src/batch.rs
@@ -141,8 +141,8 @@ pub fn is_batch_request_eligible(
             || sampling.presence_penalty != 0.0
             || sampling.frequency_penalty != 0.0,
         force_ar_chat: false,
-        temp_spec_env_off: std::env::var("HIPFIRE_DFLASH_TEMP_SPEC").ok().as_deref() == Some("0"),
-        fast_sample_on: std::env::var("HIPFIRE_FAST_SAMPLE").ok().as_deref() != Some("0"),
+        temp_spec_env_off: hipfire_config::developer_var("HIPFIRE_DFLASH_TEMP_SPEC").ok().as_deref() == Some("0"),
+        fast_sample_on: hipfire_config::developer_var("HIPFIRE_FAST_SAMPLE").ok().as_deref() != Some("0"),
         supports_temp_swor,
         supports_chain_nucleus_verify,
         kv_adaptive: has_adaptive,
@@ -2501,8 +2501,8 @@ pub fn is_qwen_ep_batch_request_eligible(
             || sampling.presence_penalty != 0.0
             || sampling.frequency_penalty != 0.0,
         force_ar_chat: false,
-        temp_spec_env_off: std::env::var("HIPFIRE_DFLASH_TEMP_SPEC").ok().as_deref() == Some("0"),
-        fast_sample_on: std::env::var("HIPFIRE_FAST_SAMPLE").ok().as_deref() != Some("0"),
+        temp_spec_env_off: hipfire_config::developer_var("HIPFIRE_DFLASH_TEMP_SPEC").ok().as_deref() == Some("0"),
+        fast_sample_on: hipfire_config::developer_var("HIPFIRE_FAST_SAMPLE").ok().as_deref() != Some("0"),
         supports_temp_swor: m
             .speculator
             .as_ref()

--- a/crates/hipfire-generate/src/common.rs
+++ b/crates/hipfire-generate/src/common.rs
@@ -661,7 +661,7 @@ pub fn emit_committed_event(
 ) {
     use std::sync::LazyLock;
     static ENABLED: LazyLock<bool> =
-        LazyLock::new(|| std::env::var("HIPFIRE_EMIT_TOKEN_IDS").ok().as_deref() == Some("1"));
+        LazyLock::new(|| hipfire_config::developer_var("HIPFIRE_EMIT_TOKEN_IDS").ok().as_deref() == Some("1"));
     if !*ENABLED {
         return;
     }
@@ -963,7 +963,7 @@ pub fn build_deepseek4_dsml_prompt(
                     let normalized =
                         hipfire_runtime::tokenizer::maybe_normalize_prompt(&stripped).into_owned();
                     let fp = asst_turn_fingerprint(&normalized, &msg.tool_calls);
-                    if std::env::var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
+                    if hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
                         .ok()
                         .as_deref()
                         == Some("1")

--- a/crates/hipfire-generate/src/dense.rs
+++ b/crates/hipfire-generate/src/dense.rs
@@ -358,7 +358,7 @@ pub fn generate_deepseek4_spec(
     }
 
     // spec_k: env chain → 2 (the deepseek4-specific default; see generate_deepseek4).
-    let spec_k: usize = std::env::var("HIPFIRE_DEEPSEEK4_SPEC_K")
+    let spec_k: usize = hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_SPEC_K")
         .ok()
         .and_then(|s| s.parse().ok())
         .or_else(|| Some(hipfire_runtime::config::get().mtp_k))
@@ -630,7 +630,7 @@ pub fn generate_deepseek4_spec(
             };
             let action = ds4_cache_action(&terminal, &run.finish, run.finish.visible_text.as_str());
             if action.store {
-                if std::env::var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
+                if hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
                     .ok()
                     .as_deref()
                     == Some("1")
@@ -644,7 +644,7 @@ pub fn generate_deepseek4_spec(
                 }
                 let _ = ds4_apply_cache_action(
                     |fp, seq| {
-                        if std::env::var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
+                        if hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
                             .ok()
                             .as_deref()
                             == Some("1")
@@ -772,7 +772,7 @@ pub fn generate_deepseek4(
         return;
     }
 
-    if std::env::var("HIPFIRE_DEEPSEEK4_DUMP_PROMPT")
+    if hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_DUMP_PROMPT")
         .ok()
         .as_deref()
         == Some("1")
@@ -1045,11 +1045,11 @@ pub fn generate_deepseek4(
     // for local deployment; we honor that as the default. Pure greedy
     // (temp <= 1e-6) is supported but enters block-level attractors on
     // structured prompts.
-    let top_k: usize = std::env::var("HIPFIRE_DEEPSEEK4_TOP_K")
+    let top_k: usize = hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_TOP_K")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(0);
-    let seed: u64 = std::env::var("HIPFIRE_DEEPSEEK4_SEED")
+    let seed: u64 = hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_SEED")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or_else(|| {
@@ -1407,7 +1407,7 @@ pub fn generate_deepseek4(
             && m.conversation_tokens.len() > decode_start_tokens_idx
         {
             let cached_seq: Vec<u32> = m.conversation_tokens[decode_start_tokens_idx..].to_vec();
-            if std::env::var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
+            if hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
                 .ok()
                 .as_deref()
                 == Some("1")
@@ -1421,7 +1421,7 @@ pub fn generate_deepseek4(
             }
             let _ = ds4_apply_cache_action(
                 |fp, seq| {
-                    if std::env::var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
+                    if hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
                         .ok()
                         .as_deref()
                         == Some("1")
@@ -1610,7 +1610,7 @@ pub fn generate_deepseek4_heterogeneous(
         !matches!(think_mode, ThinkMode::NonThink),
         ds4_gen_start_contract_version(),
     );
-    let top_k = std::env::var("HIPFIRE_DEEPSEEK4_TOP_K")
+    let top_k = hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_TOP_K")
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(0);
@@ -1815,17 +1815,17 @@ fn gemma4_logit_trace_config() -> Option<&'static Gemma4LogitTraceConfig> {
     static CONFIG: OnceLock<Option<Gemma4LogitTraceConfig>> = OnceLock::new();
     CONFIG
         .get_or_init(|| {
-            let dir = std::env::var_os("HIPFIRE_GEMMA4_LOGIT_TRACE_DIR")?;
-            let top_k = std::env::var("HIPFIRE_GEMMA4_LOGIT_TRACE_TOPK")
+            let dir = hipfire_config::developer_var_os("HIPFIRE_GEMMA4_LOGIT_TRACE_DIR")?;
+            let top_k = hipfire_config::developer_var("HIPFIRE_GEMMA4_LOGIT_TRACE_TOPK")
                 .ok()
                 .and_then(|value| value.parse().ok())
                 .unwrap_or(16)
                 .clamp(1, 128);
-            let max_steps = std::env::var("HIPFIRE_GEMMA4_LOGIT_TRACE_MAX_STEPS")
+            let max_steps = hipfire_config::developer_var("HIPFIRE_GEMMA4_LOGIT_TRACE_MAX_STEPS")
                 .ok()
                 .and_then(|value| value.parse().ok())
                 .unwrap_or(8192);
-            let full_steps = std::env::var("HIPFIRE_GEMMA4_LOGIT_TRACE_FULL_STEPS")
+            let full_steps = hipfire_config::developer_var("HIPFIRE_GEMMA4_LOGIT_TRACE_FULL_STEPS")
                 .unwrap_or_default()
                 .split(',')
                 .filter_map(|value| value.trim().parse().ok())
@@ -2051,7 +2051,7 @@ pub fn generate_gemma4(
     // ── Prompt build (same two-path branch as the lfm2moe AR path) ──
     let prompt_ids: Vec<u32> = {
         let tokenizer = m.tokenizer.as_ref().unwrap();
-        let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
+        let jinja_enabled = hipfire_config::developer_var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
         let try_jinja = jinja_enabled && m.chat_template.is_some();
         let mut ids: Vec<u32> = if try_jinja {
             let template = m.chat_template.as_ref().unwrap();
@@ -2169,7 +2169,7 @@ pub fn generate_gemma4(
     // opt-in until long-context parity is certified on each supported board.
     let mut last_logits: Vec<f32> = Vec::new();
     {
-        let requested_prefill_batch = std::env::var("HIPFIRE_GEMMA4_PREFILL_BATCH")
+        let requested_prefill_batch = hipfire_config::developer_var("HIPFIRE_GEMMA4_PREFILL_BATCH")
             .ok()
             .and_then(|value| value.parse::<usize>().ok());
         let resolved_prefill_batch =
@@ -2262,7 +2262,7 @@ pub fn generate_gemma4(
     // avoids that, which is how the numbers above were taken.
     let eagle_active = bundle.eagle.is_some()
         && temp <= 1e-6
-        && std::env::var("HIPFIRE_GEMMA4_EAGLE").ok().as_deref() == Some("1");
+        && hipfire_config::developer_var("HIPFIRE_GEMMA4_EAGLE").ok().as_deref() == Some("1");
     if eagle_active {
         let draft_len = bundle.eagle.as_ref().unwrap().draft_len;
         // Seed hidden = post-`model.norm` hidden of the last prompt position
@@ -2591,7 +2591,7 @@ pub fn generate_gemma4(
 /// `HIPFIRE_GLIMMER_TAP_LAYERS=0,12,24,36,48` selects the other convention so
 /// the two can be compared on hardware instead of argued about.
 pub fn glimmer_tap_layers(n_layers: usize) -> Vec<usize> {
-    match std::env::var("HIPFIRE_GLIMMER_TAP_LAYERS") {
+    match hipfire_config::developer_var("HIPFIRE_GLIMMER_TAP_LAYERS") {
         Ok(v) if !v.trim().is_empty() => v
             .split(',')
             .filter_map(|t| t.trim().parse::<usize>().ok())
@@ -4234,7 +4234,7 @@ pub fn generate_muse_glimmer(
     // ── Prompt build (same two-path branch as the gemma4 AR path) ──
     let prompt_ids: Vec<u32> = {
         let tokenizer = m.tokenizer.as_ref().unwrap();
-        let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
+        let jinja_enabled = hipfire_config::developer_var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
         let try_jinja = jinja_enabled && m.chat_template.is_some();
         let mut ids: Vec<u32> = if try_jinja {
             let template = m.chat_template.as_ref().unwrap();
@@ -4467,11 +4467,11 @@ pub fn generate_muse_glimmer(
     // On hit: rewind_session_to(lcp) BEFORE mirror/seq truncation.
     // On miss / cache-disabled / rewind error: reset_session_state + full prefill at 0.
     let (prefill_ids, prefill_start_pos): (Vec<u32>, u32) = {
-        let cache_disabled = std::env::var("HIPFIRE_GLIMMER_PROMPT_CACHE")
+        let cache_disabled = hipfire_config::developer_var("HIPFIRE_GLIMMER_PROMPT_CACHE")
             .ok()
             .as_deref()
             == Some("0");
-        let trace = std::env::var("HIPFIRE_GLIMMER_CACHE_TRACE").ok().as_deref() == Some("1");
+        let trace = hipfire_config::developer_var("HIPFIRE_GLIMMER_CACHE_TRACE").ok().as_deref() == Some("1");
         if cache_disabled {
             // Opting out of the cache does NOT restore the CLI's per-request
             // reset — arch 14 is in the cache_capable allowlist either way, so
@@ -4638,7 +4638,7 @@ pub fn generate_muse_glimmer(
             &bundle.weights,
         );
     let fast_sample_on = hipfire_runtime::config::get().dflash_fast_sample;
-    let temp_spec_env_off = std::env::var("HIPFIRE_DFLASH_TEMP_SPEC").ok().as_deref() == Some("0");
+    let temp_spec_env_off = hipfire_config::developer_var("HIPFIRE_DFLASH_TEMP_SPEC").ok().as_deref() == Some("0");
     let spec_mode = glimmer_spec_admission(
         bundle.drafter.is_some(),
         max_tokens,
@@ -4657,7 +4657,7 @@ pub fn generate_muse_glimmer(
     // Shared by native AR, profit probes, and post-retirement AR tail.
     let top_k_opt = if top_k > 0 { Some(top_k as u32) } else { None };
     let gpu_sample = !matches!(
-        std::env::var("HIPFIRE_GLIMMER_GPU_SAMPLE").ok().as_deref(),
+        hipfire_config::developer_var("HIPFIRE_GLIMMER_GPU_SAMPLE").ok().as_deref(),
         Some("0")
     );
     let mut gpu_rng: u32 = (rng.next_u64() as u32) | 1;
@@ -4673,13 +4673,13 @@ pub fn generate_muse_glimmer(
     let mut spec_accepted: usize = 0;
     // Request-local profit guard: default on for greedy spec; kill-switch or
     // timing-distorting diag/audit modes disable it for this request only.
-    let profit_guard_env_off = std::env::var("HIPFIRE_GLIMMER_SPEC_PROFIT_GUARD")
+    let profit_guard_env_off = hipfire_config::developer_var("HIPFIRE_GLIMMER_SPEC_PROFIT_GUARD")
         .ok()
         .as_deref()
         == Some("0");
-    let profit_guard_diag_off = std::env::var("HIPFIRE_GLIMMER_SPEC_DIAG").ok().as_deref()
+    let profit_guard_diag_off = hipfire_config::developer_var("HIPFIRE_GLIMMER_SPEC_DIAG").ok().as_deref()
         == Some("1")
-        || std::env::var("HIPFIRE_GLIMMER_DEVICE_CAPTURE_AUDIT")
+        || hipfire_config::developer_var("HIPFIRE_GLIMMER_DEVICE_CAPTURE_AUDIT")
             .ok()
             .as_deref()
             == Some("1");
@@ -4780,7 +4780,7 @@ pub fn generate_muse_glimmer(
             loop {
                 let t_window = std::time::Instant::now();
                 let do_window_timing =
-                    std::env::var("HIPFIRE_GLIMMER_TIMING").ok().as_deref() == Some("1");
+                    hipfire_config::developer_var("HIPFIRE_GLIMMER_TIMING").ok().as_deref() == Some("1");
                 if generated_count >= max_tokens {
                     break;
                 }
@@ -4845,7 +4845,7 @@ pub fn generate_muse_glimmer(
                 let t_after_noise = t_window.elapsed();
                 let device_capture = bundle.device_hidden_capture_enabled();
                 // Freeze effective ctx_cap to min(configured, drafter scratch, device log).
-                let configured_ctx_cap = std::env::var("HIPFIRE_GLIMMER_CTX_CAP")
+                let configured_ctx_cap = hipfire_config::developer_var("HIPFIRE_GLIMMER_CTX_CAP")
                     .ok()
                     .and_then(|v| v.trim().parse::<usize>().ok())
                     .filter(|v| *v > 0)
@@ -4976,7 +4976,7 @@ pub fn generate_muse_glimmer(
                 };
                 if let Err(e) = drafter_ok {
                     // Bring-up: requested drafter must be loud and fatal, not silent fallback
-                    let fatal = std::env::var("HIPFIRE_GLIMMER_SPEC_FALLBACK")
+                    let fatal = hipfire_config::developer_var("HIPFIRE_GLIMMER_SPEC_FALLBACK")
                         .ok()
                         .as_deref()
                         != Some("1");
@@ -5075,7 +5075,7 @@ pub fn generate_muse_glimmer(
                 let t_after_drafter = t_window.elapsed();
                 // Bring-up diagnostic: HIPFIRE_GLIMMER_SPEC_DIAG=1 — device mode
                 // does not require/download host hidden; print backend + logical length.
-                if std::env::var("HIPFIRE_GLIMMER_SPEC_DIAG").ok().as_deref() == Some("1")
+                if hipfire_config::developer_var("HIPFIRE_GLIMMER_SPEC_DIAG").ok().as_deref() == Some("1")
                     && windows < 2
                 {
                     let l2 = |v: &[f32]| -> f32 { v.iter().map(|x| x * x).sum::<f32>().sqrt() };
@@ -5360,7 +5360,7 @@ pub fn generate_muse_glimmer(
                 // accept_greedy_prefix). Gate so sampled does not emit a spurious
                 // FAILED when the greedy comparison is not in use.
                 if spec_mode == GlimmerSpecMode::Greedy
-                    && std::env::var("HIPFIRE_GLIMMER_SPEC_PERTURB")
+                    && hipfire_config::developer_var("HIPFIRE_GLIMMER_SPEC_PERTURB")
                         .ok()
                         .as_deref()
                         == Some("1")
@@ -5958,7 +5958,7 @@ pub fn generate_lfm2moe(
         // Jinja default-ON (flipped 2026-06-09): render through the model's chat
         // template for ALL arches; opt out with HIPFIRE_JINJA_CHAT=0 (hand-rolled
         // ChatML/Plain). Falls back to Plain automatically when no template resolves.
-        let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
+        let jinja_enabled = hipfire_config::developer_var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
         let try_jinja = jinja_enabled && m.chat_template.is_some();
         if try_jinja {
             let template = m.chat_template.as_ref().unwrap();
@@ -6345,7 +6345,7 @@ pub fn generate_minimax(
         // jinja on for both (falls back to Plain only when the .hfq carries no
         // template).
         // Jinja default-ON (flipped 2026-06-09); opt out with HIPFIRE_JINJA_CHAT=0.
-        let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
+        let jinja_enabled = hipfire_config::developer_var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
         let try_jinja = jinja_enabled && m.chat_template.is_some();
         if try_jinja {
             let template = m.chat_template.as_ref().unwrap();
@@ -6509,7 +6509,7 @@ pub fn generate_minimax(
             // the degenerate pure-extension case (rewind is then a no-op).
             let cache_hit = lcp > 0 && lcp < prompt_ids.len();
             let partial = lcp < prior_len;
-            if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
+            if hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
                 eprintln!(
                 "[minimax-cache] prior_len={} rendered_len={} lcp={} hit={} partial={} n_tokens={}",
                 prior_len, prompt_ids.len(), lcp, cache_hit, cache_hit && partial,
@@ -6555,7 +6555,7 @@ pub fn generate_minimax(
         // dtypes have batched kernels; the pre-check routes unsupported tiers
         // (MQ3-Lloyd etc.) to the sequential path to avoid a mid-pass error.
         // Force off with HIPFIRE_MINIMAX_BATCH_PREFILL=0.
-        let batch_prefill = std::env::var_os("HIPFIRE_MINIMAX_BATCH_PREFILL")
+        let batch_prefill = hipfire_config::developer_var_os("HIPFIRE_MINIMAX_BATCH_PREFILL")
             .map_or(true, |v| v != "0")
             && minimax::forward::forward_batch_supported(weights);
         if batch_prefill && !prefill_ids.is_empty() {
@@ -6768,7 +6768,7 @@ pub fn generate_cohere2moe(
         // (b) never matches across turns so the LCP prompt-cache is dead. Force
         // jinja on (falls back to Plain only when the .hfq carries no template).
         // Jinja default-ON; opt out with HIPFIRE_JINJA_CHAT=0.
-        let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
+        let jinja_enabled = hipfire_config::developer_var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
         let try_jinja = jinja_enabled && m.chat_template.is_some();
         if try_jinja {
             let template = m.chat_template.as_ref().unwrap();
@@ -6822,7 +6822,7 @@ pub fn generate_cohere2moe(
             match render_result {
                 Ok(rendered) => {
                     primed_think = rendered.trim_end().ends_with("<think>");
-                    if std::env::var("HIPFIRE_C2M_DUMP_PROMPT").ok().as_deref() == Some("1") {
+                    if hipfire_config::developer_var("HIPFIRE_C2M_DUMP_PROMPT").ok().as_deref() == Some("1") {
                         let ids = tokenizer.encode(&rendered);
                         eprintln!(
                             "[c2m prompt dump] rendered chars={} tokens={}\n>>> HEAD(400):\n{}\n>>> TAIL(800):\n{}\n<<< end",
@@ -6933,7 +6933,7 @@ pub fn generate_cohere2moe(
         // the degenerate pure-extension case (rewind is then a no-op).
         let cache_hit = lcp > 0 && lcp < prompt_ids.len();
         let partial = lcp < prior_len;
-        if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
+        if hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
             eprintln!(
                 "[cohere2moe-cache] prior_len={} rendered_len={} lcp={} hit={} partial={} n_tokens={}",
                 prior_len, prompt_ids.len(), lcp, cache_hit, cache_hit && partial,
@@ -7089,7 +7089,7 @@ pub fn generate_cohere2moe(
     // or a tool_call) was produced; if EOS arrives before that, mask it and
     // re-sample so the model is forced into <|START_TEXT|>/<|START_ACTION|> and
     // actually returns content. Opt out with HIPFIRE_C2M_EMPTY_TURN_GUARD=0.
-    let empty_turn_guard = std::env::var("HIPFIRE_C2M_EMPTY_TURN_GUARD")
+    let empty_turn_guard = hipfire_config::developer_var("HIPFIRE_C2M_EMPTY_TURN_GUARD")
         .ok()
         .as_deref()
         != Some("0");

--- a/crates/hipfire-generate/src/qwen.rs
+++ b/crates/hipfire-generate/src/qwen.rs
@@ -191,7 +191,7 @@ pub fn generate_ep(
             }
         }
     };
-    if std::env::var("HIPFIRE_DEEPSEEK4_DUMP_PROMPT")
+    if hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_DUMP_PROMPT")
         .ok()
         .as_deref()
         == Some("1")
@@ -1291,7 +1291,7 @@ pub fn ep_serve_ds4(
     }
     // Mirror prior gate: require generated > 0 so empty turns never store.
     if action.store && generated > 0 {
-        if std::env::var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
+        if hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
             .ok()
             .as_deref()
             == Some("1")
@@ -1305,7 +1305,7 @@ pub fn ep_serve_ds4(
         }
         let _ = ds4_apply_cache_action(
             |fp, seq| {
-                if std::env::var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
+                if hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_CACHE_TRACE")
                     .ok()
                     .as_deref()
                     == Some("1")
@@ -1388,7 +1388,7 @@ pub fn ep_serve_minimax(
             lcp += 1;
         }
         let cache_hit = lcp > 0 && lcp < prompt_n;
-        if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
+        if hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
             eprintln!(
                 "[minimax-ep-cache] prior_len={} rendered_len={} lcp={} hit={} partial={}",
                 prior_len,
@@ -1637,7 +1637,7 @@ pub fn ep_serve_minimax(
 /// byte-consistent — a mismatch would break the LCP forward-extension.
 pub fn qwen_history_tool_render(model_path: &str) -> hipfire_runtime::prompt_frame::ToolCallRender {
     hipfire_runtime::prompt_frame::qwen35_history_render(
-        std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref(),
+        hipfire_config::developer_var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref(),
         model_path,
     )
 }
@@ -1723,7 +1723,7 @@ pub fn plan_from_rendered(
         while lcp < max_match && conversation_tokens[lcp] == rendered[lcp] {
             lcp += 1;
         }
-        if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
+        if hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
             eprintln!(
                 "[qwen-cache lcp {trace_tag}] prior_len={} rendered_len={} lcp={}",
                 prior_len,
@@ -1960,7 +1960,7 @@ pub fn generate_dflash(
     // template for ALL arches; opt out with HIPFIRE_JINJA_CHAT=0 (hand-rolled
     // ChatML/Plain). No template ⇒ Plain. Template present + render Err ⇒
     // fail closed (see match below).
-    let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
+    let jinja_enabled = hipfire_config::developer_var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
     let try_jinja = jinja_enabled && m.chat_template.is_some();
     let mut started_in_think = matches!(
         assistant_prefix,
@@ -2103,7 +2103,7 @@ pub fn generate_dflash(
     // spliced stream byte-matches the end-of-turn bake. Divergence (edited
     // history, roundtrip-unstable text) lands on the checkpoint-resume path —
     // worst case equals today's cold prefill, never wrong tokens.
-    let cache_disabled = std::env::var("HIPFIRE_QWEN_PROMPT_CACHE").ok().as_deref() == Some("0");
+    let cache_disabled = hipfire_config::developer_var("HIPFIRE_QWEN_PROMPT_CACHE").ok().as_deref() == Some("0");
     // DFlash divergent-render resume (default ON; opt out with
     // HIPFIRE_DFLASH_CKPT_RESUME=0). Requires no eviction (resume rewinds the
     // resident KV prefix). When on, the recurrent state is checkpointed during
@@ -2111,7 +2111,7 @@ pub fn generate_dflash(
     // ≤ lcp — byte-identical to a cold prefill of the same render (verified),
     // so worst case equals the legacy cold-reset path. Off ⇒ no checkpoints
     // (zero overhead) + legacy cold-reset-on-divergence.
-    let dflash_resume_enabled = std::env::var("HIPFIRE_DFLASH_CKPT_RESUME").ok().as_deref()
+    let dflash_resume_enabled = hipfire_config::developer_var("HIPFIRE_DFLASH_CKPT_RESUME").ok().as_deref()
         != Some("0")
         && m.eviction.is_none();
     let dflash_ckpt_positions: Vec<usize> = m
@@ -2153,7 +2153,7 @@ pub fn generate_dflash(
             };
             let cache_ref = &mut m.asst_turn_cache;
             let trace_cache =
-                std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1");
+                hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1");
             let rendered = match hipfire_runtime::prompt_frame::build_cached_history_jinja(
                 &frame,
                 hist,
@@ -2277,7 +2277,7 @@ pub fn generate_dflash(
     // honors the `HIPFIRE_QWEN35_GRAMMAR=0` kill-switch by withholding `tools`
     // (⇒ empty schema ⇒ grammar inactive).
     let grammar_enabled = hipfire_runtime::prompt_frame::qwen35_grammar_on(
-        std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref(),
+        hipfire_config::developer_var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref(),
         &m.model_path,
     );
     let emit_tools: Option<Vec<serde_json::Value>> = if grammar_enabled {
@@ -2305,7 +2305,7 @@ pub fn generate_dflash(
             cactus_delta,
             rng_seed: request_seed,
             allow_ngram_modifier: spec_name == "mtp"
-                && std::env::var("HIPFIRE_MTP_NGRAM").ok().as_deref() == Some("1")
+                && hipfire_config::developer_var("HIPFIRE_MTP_NGRAM").ok().as_deref() == Some("1")
                 && temp <= 1e-6
                 && max_think_tokens == 1,
         });
@@ -2565,7 +2565,7 @@ pub fn generate_dflash(
                 let mut action = qwen_dflash_cache_action(&terminal);
                 action.store = effects.store_cache && action.store;
                 if action.store {
-                    if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
+                    if hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
                         eprintln!(
                             "[qwen-cache store dflash] fp_text.len={} tool_calls={} preview={:?}",
                             action.fingerprint_text.len(),
@@ -2575,7 +2575,7 @@ pub fn generate_dflash(
                     }
                     let _ = qwen_dflash_apply_cache_action(
                         |fp, seq| {
-                            if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref()
+                            if hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref()
                                 == Some("1")
                             {
                                 eprintln!(
@@ -2732,7 +2732,7 @@ pub fn generate_dflash(
             let emit_text =
                 hipfire_runtime::tokenizer::maybe_normalize_prompt(&stripped).into_owned();
             let fp = asst_turn_fingerprint(&emit_text, &wire_calls);
-            if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
+            if hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
                 eprintln!(
                     "[qwen-cache store dflash] fp={:#018x} cached_seq={} emit_text.len={} tool_calls={} preview={:?}",
                     fp, cached_seq.len(), emit_text.len(), wire_calls.len(),
@@ -2937,7 +2937,7 @@ pub fn generate_spec(
         // bookkeeping remains.
         m.seq_pos = 0;
         m.conversation_tokens.clear();
-    } else if std::env::var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
+    } else if hipfire_config::developer_var("HIPFIRE_QWEN_CACHE_TRACE").ok().as_deref() == Some("1") {
         eprintln!(
             "[qwen-cache HIT dflash] reuse prefix={} suffix={} (no reset)",
             prefill_start,
@@ -4241,7 +4241,7 @@ pub fn generate_multi(
     // Jinja default-ON (flipped 2026-06-09): render through the model's chat
     // template for ALL arches; opt out with HIPFIRE_JINJA_CHAT=0 (hand-rolled
     // ChatML/Plain). Falls back to Plain automatically when no template resolves.
-    let jinja_enabled = std::env::var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
+    let jinja_enabled = hipfire_config::developer_var("HIPFIRE_JINJA_CHAT").ok().as_deref() != Some("0");
     // hunt3 H-A: drop the `seq_pos == 0` gate (PR #389 removed it from generate()).
     // With the gate, turn 2+ fell through to the Plain scaffold, dropping the
     // system prompt and the full history replay that render_messages provides.
@@ -4528,7 +4528,7 @@ pub fn generate_multi(
     // (m.decoded_vocab) because `m` is already mutably borrowed here (kv/dn/gpus)
     // — pp>1 + tools is uncommon, so the per-request decode is acceptable.
     let grammar_enabled = hipfire_runtime::prompt_frame::qwen35_grammar_on(
-        std::env::var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref(),
+        hipfire_config::developer_var("HIPFIRE_QWEN35_GRAMMAR").ok().as_deref(),
         &m.model_path,
     );
     let tool_schemas_qwen: Vec<hipfire_arch_qwen35::grammar::ToolSchema> = if grammar_enabled {
@@ -4683,7 +4683,7 @@ pub fn generate_multi(
     // and runs to max_tokens. Mark the latch position and hard-EOS once
     // generation runs this many tokens past it — generous for a real final
     // answer, bounded against runaway.
-    let post_latch_answer_budget: usize = std::env::var("HIPFIRE_POST_LATCH_ANSWER_TOKENS")
+    let post_latch_answer_budget: usize = hipfire_config::developer_var("HIPFIRE_POST_LATCH_ANSWER_TOKENS")
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(768);

--- a/crates/hipfire-generate/src/vision.rs
+++ b/crates/hipfire-generate/src/vision.rs
@@ -57,10 +57,7 @@ fn emit_committed_event(
     pos: usize,
     t_ms: u64,
 ) {
-    use std::sync::LazyLock;
-    static ENABLED: LazyLock<bool> =
-        LazyLock::new(|| std::env::var("HIPFIRE_EMIT_TOKEN_IDS").ok().as_deref() == Some("1"));
-    if !*ENABLED {
+    if !hipfire_config::developer_bool("HIPFIRE_EMIT_TOKEN_IDS", false) {
         return;
     }
     // Build through `serde_json::json!` for the same reason

--- a/crates/rdna-compute/src/attention.rs
+++ b/crates/rdna-compute/src/attention.rs
@@ -10,7 +10,6 @@ use crate::Gpu;
 use crate::GpuTensor;
 use hip_bridge::{DeviceBuffer, HipResult};
 use std::ffi::c_void;
-use std::sync::OnceLock;
 
 /// HIP `hipDeviceAttributeMaxSharedMemoryPerBlock` (CUDA-compatible block).
 /// Verified against ROCm 5.x/6.x/7.x headers: ordinal 74.
@@ -97,33 +96,23 @@ pub fn q8_flash_tile_size(
     head_dim: usize,
     max_seq: usize,
 ) -> usize {
-    static OVERRIDE: OnceLock<Option<usize>> = OnceLock::new();
-    OVERRIDE
-        .get_or_init(|| {
-            hipfire_config::developer_var("HIPFIRE_Q8_FLASH_TILE")
-                .ok()
-                .and_then(|value| value.parse::<usize>().ok())
-                .filter(|value| matches!(value, 16 | 32 | 64 | 128 | 256))
-        })
+    hipfire_config::developer_var("HIPFIRE_Q8_FLASH_TILE")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| matches!(value, 16 | 32 | 64 | 128 | 256))
         .unwrap_or_else(|| q8_flash_default_tile_size(arch, n_heads, n_kv_heads, head_dim, max_seq))
 }
 
 const V_MODE_Q8: i32 = 8;
 
 fn gfx1100_asym3_q8_pair_enabled(gpu: &Gpu, head_dim: usize) -> bool {
-    static ENABLED: OnceLock<bool> = OnceLock::new();
+    // Qwen3.6-27B graph-on decode: three fresh-process samples per
+    // arm measured +0.61% by median (+0.11/+0.45/+0.61% paired),
+    // while attribution removed exactly 16 dispatches/token.
     gpu.arch_caps.is_gfx1100()
         && head_dim == 256
         && !gpu.replay.is_recording()
-        && *ENABLED.get_or_init(|| {
-            // Qwen3.6-27B graph-on decode: three fresh-process samples per
-            // arm measured +0.61% by median (+0.11/+0.45/+0.61% paired),
-            // while attribution removed exactly 16 dispatches/token.
-            hipfire_config::developer_var("HIPFIRE_GFX1100_ASYM3_Q8_PAIR")
-                .ok()
-                .as_deref()
-                != Some("0")
-        })
+        && hipfire_config::developer_bool("HIPFIRE_GFX1100_ASYM3_Q8_PAIR", true)
 }
 
 #[inline]
@@ -142,23 +131,15 @@ fn replay_stable_tile_count(
 
 /// Opt-in gate for the WMMA flash-attention prefill path.
 fn is_wmma_fa_enabled() -> bool {
-    use std::sync::OnceLock;
-    static GATE: OnceLock<bool> = OnceLock::new();
-    *GATE.get_or_init(|| {
-        hipfire_config::developer_var("HIPFIRE_WMMA_FA").map_or(false, |v| v == "1")
-    })
+    hipfire_config::developer_bool("HIPFIRE_WMMA_FA", false)
 }
 
 /// Minimum chunk size to engage the WMMA-FA route.
 fn wmma_fa_min_batch() -> usize {
-    use std::sync::OnceLock;
-    static GATE: OnceLock<usize> = OnceLock::new();
-    *GATE.get_or_init(|| {
-        hipfire_config::developer_var("HIPFIRE_WMMA_FA_MIN_BATCH")
-            .ok()
-            .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(16)
-    })
+    hipfire_config::developer_var("HIPFIRE_WMMA_FA_MIN_BATCH")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(16)
 }
 
 impl Gpu {
@@ -11032,14 +11013,8 @@ impl Gpu {
         // `HIPFIRE_HC_CTRL_T1024=1` selects the 1024-thread variant. See
         // `kernels::HC_COMPUTE_CONTROL_T1024_SRC` — same algorithm, wider
         // block, NOT bit-exact (the LDS partial tree widens 8 -> 32).
-        static T1024: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
         let t1024 = prefer_t1024
-            || *T1024.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_HC_CTRL_T1024")
-                    .ok()
-                    .as_deref()
-                    == Some("1")
-            });
+            || hipfire_config::developer_bool("HIPFIRE_HC_CTRL_T1024", false);
         let (logical_name, src, threads) = if t1024 {
             (
                 "hc_compute_control_vec4_finalize_t1024",
@@ -12920,34 +12895,10 @@ impl Gpu {
         max_k: i32,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        static FORCE_SERIAL: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let force_serial = *FORCE_SERIAL.get_or_init(|| {
-            hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_INDEXER_TOPK_SERIAL")
-                .ok()
-                .as_deref()
-                == Some("1")
-        });
-        static FORCE_BOUNDED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let force_bounded = *FORCE_BOUNDED.get_or_init(|| {
-            hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_INDEXER_TOPK_BOUNDED")
-                .ok()
-                .as_deref()
-                == Some("1")
-        });
-        static FORCE_BLOCK1024: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let force_block1024 = *FORCE_BLOCK1024.get_or_init(|| {
-            hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_INDEXER_TOPK_BLOCK1024")
-                .ok()
-                .as_deref()
-                == Some("1")
-        });
-        static FORCE_UNROLLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let force_unrolled = *FORCE_UNROLLED.get_or_init(|| {
-            hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_INDEXER_TOPK_UNROLLED")
-                .ok()
-                .as_deref()
-                == Some("1")
-        });
+        let force_serial = hipfire_config::developer_bool("HIPFIRE_DEEPSEEK4_INDEXER_TOPK_SERIAL", false);
+        let force_bounded = hipfire_config::developer_bool("HIPFIRE_DEEPSEEK4_INDEXER_TOPK_BOUNDED", false);
+        let force_block1024 = hipfire_config::developer_bool("HIPFIRE_DEEPSEEK4_INDEXER_TOPK_BLOCK1024", false);
+        let force_unrolled = hipfire_config::developer_bool("HIPFIRE_DEEPSEEK4_INDEXER_TOPK_UNROLLED", false);
         // gfx1151 keeps its certified route selection. gfx1201 reuses the
         // wave-size-independent bounded source, compiled into its own exact
         // device code object after the raw-i32 parity channel passed.
@@ -14691,43 +14642,18 @@ impl Gpu {
         topk_window: i32,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        static WARP_GFX1151: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        static ILP4_GFX1151: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        static SCOREGRID_XLANE_GFX1151: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        static SCOREGRID_LARGE_SERIAL_GFX1151: std::sync::OnceLock<bool> =
-            std::sync::OnceLock::new();
         let scoregrid_arch = self.arch == "gfx1151" || self.arch == "gfx1201";
         let scoregrid = scoregrid_arch && head_dim == 512 && deepseek4_scoregrid_route;
         let ilp4 = self.arch == "gfx1151"
             && head_dim == 512
-            && *ILP4_GFX1151.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_ATTN_ILP4")
-                    .ok()
-                    .as_deref()
-                    == Some("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_DEEPSEEK4_ATTN_ILP4", false);
         let warp = self.arch == "gfx1151"
             && head_dim == 512
-            && *WARP_GFX1151.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_ATTN_WARP")
-                    .ok()
-                    .as_deref()
-                    == Some("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_DEEPSEEK4_ATTN_WARP", false);
         let scoregrid_xlane = scoregrid
-            && *SCOREGRID_XLANE_GFX1151.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_ATTN_SCOREGRID_XLANE")
-                    .ok()
-                    .as_deref()
-                    == Some("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_DEEPSEEK4_ATTN_SCOREGRID_XLANE", false);
         let scoregrid_large_serial = scoregrid
-            && *SCOREGRID_LARGE_SERIAL_GFX1151.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_ATTN_SCOREGRID_LARGE_SERIAL")
-                    .ok()
-                    .as_deref()
-                    == Some("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_DEEPSEEK4_ATTN_SCOREGRID_LARGE_SERIAL", false);
         let (logical_name, symbol, block, source) = if scoregrid_large_serial {
             (
                 "deepseek4_attn_swa_topk_scoregrid_large_serial_gfx1151",

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -15,7 +15,7 @@ use hip_bridge::{
 use std::collections::HashMap;
 use std::ffi::c_void;
 use std::sync::atomic::AtomicUsize;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 /// Per-group byte size of the MQ3-Lloyd quantization layout.
 ///
@@ -158,11 +158,10 @@ pub const GL_CB3: [f32; 8] = [
 pub static MMQ_CURRENT_LAYER: AtomicUsize = AtomicUsize::new(0);
 
 fn pm4_dynamic_grid_enabled() -> bool {
-    static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED.get_or_init(|| {
-        hipfire_config::process_value("HIPFIRE_REPLAY_PM4_DYNAMIC_GRID")
-            .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes" | "on"))
-    })
+    // Multi-spelling ("1"/"true"/"yes"/"on") predicate preserved verbatim;
+    // only the process-global cache is gone (the snapshot is the cache now).
+    hipfire_config::process_value("HIPFIRE_REPLAY_PM4_DYNAMIC_GRID")
+        .is_some_and(|value| matches!(value.as_str(), "1" | "true" | "yes" | "on"))
 }
 
 /// Minimum batch size at which the FP8 WMMA prefill path is enabled.
@@ -2079,13 +2078,7 @@ impl Gpu {
         size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let dump = *DUMP.get_or_init(|| {
-            hipfire_config::developer_var("HIPFIRE_DTOD_DUMP")
-                .ok()
-                .as_deref()
-                == Some("1")
-        });
+        let dump = hipfire_config::developer_bool("HIPFIRE_DTOD_DUMP", false);
         if dump {
             let loc = std::panic::Location::caller();
             eprintln!("dtod bytes={} at {}:{}", size, loc.file(), loc.line());
@@ -2811,8 +2804,7 @@ impl Gpu {
     /// runs fine there (uses WMMA backends on RDNA3, not MFMA) so this is
     /// a useful smoke-path in the absence of an MI300.
     pub(crate) fn rocblas_arch_eligible(&self) -> bool {
-        static CACHE: OnceLock<bool> = OnceLock::new();
-        let all_archs = *CACHE.get_or_init(|| self.flags.rocblas_all_archs);
+        let all_archs = self.flags.rocblas_all_archs;
         if all_archs {
             return self.rocblas.is_some();
         }
@@ -2827,13 +2819,10 @@ impl Gpu {
     /// which disables the rocBLAS path entirely for A/B benchmarking against
     /// the hand-rolled GEMV baseline.
     pub(crate) fn rocblas_min_batch(&self) -> usize {
-        static CACHE: OnceLock<usize> = OnceLock::new();
-        *CACHE.get_or_init(|| {
-            if self.flags.rocblas_off {
-                return usize::MAX;
-            }
-            self.flags.rocblas_min_batch.unwrap_or(4)
-        })
+        if self.flags.rocblas_off {
+            return usize::MAX;
+        }
+        self.flags.rocblas_min_batch.unwrap_or(4)
     }
 
     /// Batched-attention tile size, from `HIPFIRE_ATTN_TILE_SIZE`.
@@ -2848,13 +2837,10 @@ impl Gpu {
     /// needs, which can exceed buffers sized elsewhere against the 128 default.
     pub fn attn_tile_size(&self) -> usize {
         // bind_thread: skip — pure flag read, touches no device state.
-        static CACHE: OnceLock<usize> = OnceLock::new();
-        *CACHE.get_or_init(|| {
-            self.flags
-                .attn_tile_size
-                .filter(|&t| t > 0 && t % 32 == 0)
-                .unwrap_or(128)
-        })
+        self.flags
+            .attn_tile_size
+            .filter(|&t| t > 0 && t % 32 == 0)
+            .unwrap_or(128)
     }
 
     /// Multi-slot attention flash-vs-scalar crossover override, in tokens.

--- a/crates/rdna-compute/src/feature_flags.rs
+++ b/crates/rdna-compute/src/feature_flags.rs
@@ -101,6 +101,11 @@ pub struct FeatureFlags {
     pub wo_mmq: bool,
     pub lm_head_wmma_disabled: bool,
     pub lm_head_overwrite: bool,
+    /// Calibration-only override keeping native-BF16 teachers in BF16
+    /// (`HIPFIRE_CALIB_BF16=1`). Mirrors the `calib_force_bf16` snapshot
+    /// read so fresh `Gpu` code can take the flag from `self.flags`
+    /// instead of a process-global cache.
+    pub calib_force_bf16: bool,
 
     // ── MMQ screening ─────────────────────────────────────────────
     pub mmq_screen: bool,
@@ -436,6 +441,7 @@ impl FeatureFlags {
             wo_mmq: value("HIPFIRE_WO_MMQ").ok().as_deref() == Some("1"),
             lm_head_wmma_disabled: value("HIPFIRE_LM_HEAD_WMMA").map_or(false, |v| v == "0"),
             lm_head_overwrite: value("HIPFIRE_LM_HEAD_OVERWRITE").as_deref() == Ok("1"),
+            calib_force_bf16: value("HIPFIRE_CALIB_BF16").as_deref() == Ok("1"),
 
             // MMQ screening
             mmq_screen: value("HIPFIRE_MMQ_SCREEN")
@@ -702,6 +708,7 @@ impl FeatureFlags {
             wo_mmq: false,
             lm_head_wmma_disabled: false,
             lm_head_overwrite: false,
+            calib_force_bf16: false,
             mmq_screen: false,
             mmq_screen_threshold: if is_gfx906 { 0.50 } else { 0.10 },
             mmq_diag_quantize_only: false,

--- a/crates/rdna-compute/src/flash_attn_ck.rs
+++ b/crates/rdna-compute/src/flash_attn_ck.rs
@@ -1724,7 +1724,7 @@ mod tests {
 
     #[test]
     fn explicit_test_sidecar_loads_and_rejects_invalid_params() {
-        let Ok(path) = std::env::var("HIPFIRE_FLASH_ATTN_CK_TEST_LIB") else {
+        let Ok(path) = hipfire_config::developer_var("HIPFIRE_FLASH_ATTN_CK_TEST_LIB") else {
             return;
         };
         let sidecar = unsafe { FlashAttnCk::load(path) }.expect("load explicit test sidecar");

--- a/crates/rdna-compute/src/gemm.rs
+++ b/crates/rdna-compute/src/gemm.rs
@@ -211,12 +211,8 @@ impl Gpu {
         k: usize,
         batch_size: usize,
     ) -> HipResult<bool> {
-        static ENABLED: OnceLock<bool> = OnceLock::new();
         static ADMISSION_LOGGED: OnceLock<()> = OnceLock::new();
-        let enabled = *ENABLED.get_or_init(|| {
-            hipfire_config::developer_var("HIPFIRE_DEEPSEEK4_GFX942_E8_ROCBLAS").as_deref()
-                == Ok("1")
-        });
+        let enabled = hipfire_config::developer_bool("HIPFIRE_DEEPSEEK4_GFX942_E8_ROCBLAS", false);
         if self.arch != "gfx942"
             || !enabled
             || weight.dtype != DType::MFP4G32E8SOA
@@ -2659,29 +2655,20 @@ impl Gpu {
             return self.fused_qkv_hfq4g256_dp4a(a_q, a_k, a_v, x, y_q, y_k, y_v, q_m, k_m, v_m, k);
         }
 
-        static GFX1151_QKVZA_WAVE64: OnceLock<bool> = OnceLock::new();
         let gfx1151_wave64 = self.arch_caps.is_gfx1151()
-            && *GFX1151_QKVZA_WAVE64.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_QKVZA_WAVE64").as_deref() == Ok("1")
-            });
-        static GFX1151_QKV_ALL_BUFFER_CPOL: OnceLock<String> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_QKVZA_WAVE64", false);
+        let gfx1151_all_buffer_cpol_owned: String =
+            hipfire_config::developer_var("HIPFIRE_GFX1151_QKV_ALL_BUFFER_CPOL")
+                .unwrap_or_default()
+                .to_ascii_lowercase();
         let gfx1151_all_buffer_cpol = if self.arch_caps.is_gfx1151() && k == 2_048 {
-            GFX1151_QKV_ALL_BUFFER_CPOL
-                .get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_QKV_ALL_BUFFER_CPOL")
-                        .unwrap_or_default()
-                        .to_ascii_lowercase()
-                })
-                .as_str()
+            gfx1151_all_buffer_cpol_owned.as_str()
         } else {
             ""
         };
-        static GFX1151_QKV_X_BUFFER: OnceLock<bool> = OnceLock::new();
         let gfx1151_x_buffer = self.arch_caps.is_gfx1151()
             && k == 2_048
-            && *GFX1151_QKV_X_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_QKV_X_BUFFER").as_deref() == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_QKV_X_BUFFER", false);
         let cdna_wave64 = self.arch_caps.is_wave64_native()
             || (self.arch_caps.is_rdna3_dgpu() && self.flags.rdna3_hfq4_qkv_wave64)
             || gfx1151_wave64;
@@ -3066,74 +3053,41 @@ impl Gpu {
             self.arch_caps.is_gfx1100() && self.flags.rdna3_hfq4_qkvza_reduce_chain;
         let rdna3_k2048 =
             self.arch_caps.is_gfx1100() && self.flags.rdna3_hfq4_qkvza_k2048 && k == 2_048;
-        static GFX1151_WEIGHT_BUFFER_LOADS: OnceLock<bool> = OnceLock::new();
         let gfx1151_k2048_buffer = self.arch_caps.is_gfx1151()
             && k == 2_048
-            && *GFX1151_WEIGHT_BUFFER_LOADS.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_WEIGHT_BUFFER_LOADS").as_deref()
-                    == Ok("1")
-                    || hipfire_config::developer_var("HIPFIRE_GFX1151_WEIGHT_BUFFER_QKVZA")
-                        .as_deref()
-                        == Ok("1")
-            });
+            && (hipfire_config::developer_bool("HIPFIRE_GFX1151_WEIGHT_BUFFER_LOADS", false)
+                || hipfire_config::developer_bool("HIPFIRE_GFX1151_WEIGHT_BUFFER_QKVZA", false));
         let gfx1151_k2048_all_buffer = self.arch_caps.is_gfx1151() && k == 2_048;
         let gfx1151_k2048_hybrid_buffer =
             self.arch_caps.is_gfx1151() && k == 2_048 && total_m == 1_281;
-        static GFX1151_QKVZA_X_BUFFER_LARGE: OnceLock<bool> = OnceLock::new();
         let gfx1151_k2048_x_buffer_large = self.arch_caps.is_gfx1151()
             && k == 2_048
             && total_m > 2_048
-            && *GFX1151_QKVZA_X_BUFFER_LARGE.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_QKVZA_X_BUFFER_LARGE").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_QKVZA_ALL_BUFFER_CPOL: OnceLock<String> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_QKVZA_X_BUFFER_LARGE", false);
+        let gfx1151_k2048_all_buffer_cpol_owned: String =
+            hipfire_config::developer_var("HIPFIRE_GFX1151_QKVZA_ALL_BUFFER_CPOL")
+                .unwrap_or_default()
+                .to_ascii_lowercase();
         let gfx1151_k2048_all_buffer_cpol = if self.arch_caps.is_gfx1151() && k == 2_048 {
-            GFX1151_QKVZA_ALL_BUFFER_CPOL
-                .get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_QKVZA_ALL_BUFFER_CPOL")
-                        .unwrap_or_default()
-                        .to_ascii_lowercase()
-                })
-                .as_str()
+            gfx1151_k2048_all_buffer_cpol_owned.as_str()
         } else {
             ""
         };
-        static GFX1151_QKVZA_LDSX8_BUFFER: OnceLock<bool> = OnceLock::new();
         let gfx1151_k2048_ldsx8_buffer = self.arch_caps.is_gfx1151()
             && k == 2_048
-            && *GFX1151_QKVZA_LDSX8_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_QKVZA_LDSX8_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_QKVZA_PAIR_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_QKVZA_LDSX8_BUFFER", false);
         let gfx1151_k2048_pair_buffer = self.arch_caps.is_gfx1151()
             && k == 2_048
-            && *GFX1151_QKVZA_PAIR_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_QKVZA_PAIR_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_QKVZA_K2048_HOIST: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_QKVZA_PAIR_BUFFER", false);
         let gfx1151_k2048_hoist = self.arch_caps.is_gfx1151()
             && k == 2_048
-            && *GFX1151_QKVZA_K2048_HOIST.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_QKVZA_K2048_HOIST").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_QKVZA_R2: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_QKVZA_K2048_HOIST", false);
         let gfx1151_k2048_r2 = self.arch_caps.is_gfx1151()
             && k == 2_048
-            && *GFX1151_QKVZA_R2.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_QKVZA_R2").as_deref() == Ok("1")
-            });
-        static GFX1151_QKVZA_R2_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_QKVZA_R2", false);
         let gfx1151_k2048_r2_buffer = self.arch_caps.is_gfx1151()
             && k == 2_048
-            && *GFX1151_QKVZA_R2_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_QKVZA_R2_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_QKVZA_R4_STREAM: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_QKVZA_R2_BUFFER", false);
         let gfx1151_k2048_r4_stream = self.arch_caps.is_gfx1151()
             && k == 2_048
             && total_m > 2_048
@@ -3141,27 +3095,14 @@ impl Gpu {
             && z_m.is_multiple_of(4)
             && beta_m.is_multiple_of(4)
             && alpha_m.is_multiple_of(4)
-            && *GFX1151_QKVZA_R4_STREAM.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_QKVZA_R4_STREAM").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_QKVZA_WAVE64_SHARE_X: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_QKVZA_R4_STREAM", false);
         let gfx1151_wave64_share_x = self.arch_caps.is_gfx1151()
             && k == 2_048
-            && *GFX1151_QKVZA_WAVE64_SHARE_X.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_QKVZA_WAVE64_SHARE_X").as_deref()
-                    == Ok("1")
-            });
-        static QKVZA_R2: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_QKVZA_WAVE64_SHARE_X", false);
         let rdna3_k2048_r2 = rdna3_k2048
-            && *QKVZA_R2.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_RDNA3_QKVZA_R2").as_deref() == Ok("1")
-            });
-        static QKVZA_CPOL_SLC: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_RDNA3_QKVZA_R2", false);
         let rdna3_k2048_cpol_slc = rdna3_k2048
-            && *QKVZA_CPOL_SLC.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_QKVZA_CPOL").as_deref() == Ok("slc")
-            });
+            && hipfire_config::developer_var("HIPFIRE_QKVZA_CPOL").as_deref() == Ok("slc");
         let cdna_wave64 = self.arch_caps.is_wave64_native()
             || (self.arch_caps.is_rdna3_dgpu() && self.flags.rdna3_hfq4_qkv_wave64);
         let glimmer_qkvg_k6656_gfx1100 = self.arch_caps.is_gfx1100()
@@ -18093,11 +18034,10 @@ impl Gpu {
         // scratch + fixed-order finalize → deterministic at perf parity
         // (benched 16..1024 batch on gfx1100), so it is now the default.
         // HIPFIRE_DETERMINISTIC=1 still forces k2 (single-block K reduction)
-        // for the strictest single-kernel byte-parity escape hatch.
-        // Cached — getenv on every decode token would re-parse 6× per layer
-        // × N layers per step. Read once at first dispatch.
-        static FORCE_DET: OnceLock<bool> = OnceLock::new();
-        let force_det = *FORCE_DET.get_or_init(|| self.flags.deterministic);
+        // for the strictest single-kernel byte-parity escape hatch. Read from
+        // `FeatureFlags` (resolved once at GPU startup from the process
+        // snapshot), so this is a single bool load per call.
+        let force_det = self.flags.deterministic;
         let auto_variant = if force_det {
             "k2"
         } else if is_gfx115x && batch_size <= 16 {
@@ -18190,8 +18130,8 @@ impl Gpu {
         // Synchronously times only the ksplit kernel launch (not memset / convert).
         // Measures actual GPU execution time via device_synchronize pre+post —
         // costs latency vs async pipelining but gives shape-accurate µs.
-        static DUMP: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let dump = *DUMP.get_or_init(|| self.flags.gemm_dump);
+        // (`gemm_dump` is a resolved `FeatureFlags` bool; no per-call cache.)
+        let dump = self.flags.gemm_dump;
         if dump {
             self.hip.device_synchronize()?;
         }
@@ -22108,8 +22048,7 @@ impl Gpu {
         n: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        static USE_LEGACY: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-        let use_legacy = *USE_LEGACY.get_or_init(|| self.flags.q8_batched_legacy);
+        let use_legacy = self.flags.q8_batched_legacy;
         // Route to WMMA on ALL wave32-WMMA arches (gfx11 RDNA3, gfx1151
         // RDNA3.5, gfx12 RDNA4), not just RDNA4. `gemm_q8_0_wmma` selects the
         // RDNA3 vs RDNA4 kernel internally and asserts `has_wmma()`, so this is
@@ -23129,34 +23068,21 @@ impl Gpu {
         // Host-gated identity; reuses fused_gate_up_hfq4g256 arithmetic template.
         let glimmer_gate_up_k6656_gfx1100 =
             self.arch_caps.is_gfx1100() && gate_m == 19_968 && up_m == 19_968 && k == 6_656;
-        static GFX1100_DENSE_GATE_UP_STAGE_X32: OnceLock<bool> = OnceLock::new();
         let dense_gate_up_stage_x32_gfx1100 = self.arch_caps.is_gfx1100()
             && gate_m == 17_408
             && up_m == 17_408
             && k == 5_120
-            && *GFX1100_DENSE_GATE_UP_STAGE_X32.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1100_DENSE_GATE_UP_STAGE_X32")
-                    .map_or(true, |value| value != "0")
-            });
-        static GFX1100_DENSE_GATE_UP_PAIR: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1100_DENSE_GATE_UP_STAGE_X32", true);
         let dense_gate_up_pair_gfx1100 = self.arch_caps.is_gfx1100()
             && gate_m == 17_408
             && up_m == 17_408
             && k == 5_120
-            && *GFX1100_DENSE_GATE_UP_PAIR.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1100_DENSE_GATE_UP_PAIR").as_deref()
-                    == Ok("1")
-            });
-        static GFX1100_DENSE_GATE_UP_PAIR2: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1100_DENSE_GATE_UP_PAIR", false);
         let dense_gate_up_pair2_gfx1100 = self.arch_caps.is_gfx1100()
             && gate_m == 17_408
             && up_m == 17_408
             && k == 5_120
-            && *GFX1100_DENSE_GATE_UP_PAIR2.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1100_DENSE_GATE_UP_PAIR2").as_deref()
-                    == Ok("1")
-            });
-        static GFX1100_DENSE_GATE_UP_DOT_REFORM: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1100_DENSE_GATE_UP_PAIR2", false);
         // Qwen3.6-27B MQ4, W7900/gfx1100: two fresh-process alternating
         // campaigns measured +0.42% and +0.49% decode throughput. Keep this
         // explicit because the algebraic rewrite changes FP association even
@@ -23165,11 +23091,7 @@ impl Gpu {
             && gate_m == 17_408
             && up_m == 17_408
             && k == 5_120
-            && *GFX1100_DENSE_GATE_UP_DOT_REFORM.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1100_DENSE_GATE_UP_DOT_REFORM").as_deref()
-                    == Ok("1")
-            });
-        static GFX1100_DENSE_GATE_UP_QUAD_PREFETCH: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1100_DENSE_GATE_UP_DOT_REFORM", false);
         // Qwen3.6-27B MQ4, W7900/gfx1100: a fresh-process 128-token
         // A/B/B/A measured +0.42% throughput and -0.42% p50 latency. Keep
         // opt-in: 92 VGPR remains spill-free, but the gain is too small to
@@ -23178,30 +23100,17 @@ impl Gpu {
             && gate_m == 17_408
             && up_m == 17_408
             && k == 5_120
-            && *GFX1100_DENSE_GATE_UP_QUAD_PREFETCH.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1100_DENSE_GATE_UP_QUAD_PREFETCH")
-                    .as_deref()
-                    == Ok("1")
-            });
-        static GFX1100_DENSE_GATE_UP_SETPRIO: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1100_DENSE_GATE_UP_QUAD_PREFETCH", false);
         let dense_gate_up_setprio_gfx1100 = self.arch_caps.is_gfx1100()
             && gate_m == 17_408
             && up_m == 17_408
             && k == 5_120
-            && *GFX1100_DENSE_GATE_UP_SETPRIO.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1100_DENSE_GATE_UP_SETPRIO").as_deref()
-                    == Ok("1")
-            });
-        static GFX1100_DENSE_GATE_UP_LANE0_HEADERS: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1100_DENSE_GATE_UP_SETPRIO", false);
         let dense_gate_up_lane0_headers_gfx1100 = self.arch_caps.is_gfx1100()
             && gate_m == 17_408
             && up_m == 17_408
             && k == 5_120
-            && *GFX1100_DENSE_GATE_UP_LANE0_HEADERS.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1100_DENSE_GATE_UP_LANE0_HEADERS")
-                    .as_deref()
-                    == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1100_DENSE_GATE_UP_LANE0_HEADERS", false);
         let dense_gate_up_dot_prefetch_gfx1100 =
             dense_gate_up_dot_reform_gfx1100 && dense_gate_up_quad_prefetch_gfx1100;
         let (func_name, block, grid_x) = if dense_gate_up_pair2_gfx1100 {

--- a/crates/rdna-compute/src/gemv.rs
+++ b/crates/rdna-compute/src/gemv.rs
@@ -60,32 +60,19 @@ fn validate_mq_rotate_live(input: &[f32], output: &[f32], k: usize, batch: usize
 
 /// DIAGNOSTIC: when HIPFIRE_E8_STRIP=1, gemv_mfp4g32_e8 (gfx1151) launches the
 /// compute-stripped kernel instead of the real decode kernel — for measuring
-/// the memory-vs-compute bound (output is garbage). Cached once.
+/// the memory-vs-compute bound (output is garbage). Read from the process
+/// snapshot on each call.
 fn e8_strip_enabled() -> bool {
-    use std::sync::OnceLock;
-    static FLAG: OnceLock<bool> = OnceLock::new();
-    *FLAG.get_or_init(|| {
-        hipfire_config::developer_var("HIPFIRE_E8_STRIP")
-            .map(|v| v == "1")
-            .unwrap_or(false)
-    })
+    hipfire_config::developer_bool("HIPFIRE_E8_STRIP", false)
 }
 
 /// EXPERIMENT: HIPFIRE_E8_LDSX=1 routes gemv_mfp4g32_e8 (gfx1151) to the
 /// LDS-staged-x + 4-rows/block variant (memory-level-parallelism lever).
 fn e8_ldsx_enabled() -> bool {
-    use std::sync::OnceLock;
-    static FLAG: OnceLock<bool> = OnceLock::new();
-    *FLAG.get_or_init(|| {
-        hipfire_config::developer_var("HIPFIRE_E8_LDSX")
-            .map(|v| v == "1")
-            .unwrap_or(false)
-    })
+    hipfire_config::developer_bool("HIPFIRE_E8_LDSX", false)
 }
 
 fn gfx1100_awq_norm_direct_enabled(gpu: &Gpu, k: usize) -> bool {
-    use std::sync::OnceLock;
-    static FLAG: OnceLock<bool> = OnceLock::new();
     if !gpu.arch_caps.is_gfx1100() {
         return false;
     }
@@ -93,13 +80,12 @@ fn gfx1100_awq_norm_direct_enabled(gpu: &Gpu, k: usize) -> bool {
     // caches functions by symbol, while prefill and decode share this route.
     // Qwen3.6-27B K=5120 measured +2.44% over a 512-token A/B/B/A; rocprof
     // measured 14.859 -> 9.116 us/launch, and a 1025-token replay was exact.
-    *FLAG.get_or_init(|| {
-        k == 5_120
-            && hipfire_config::developer_var("HIPFIRE_GFX1100_AWQ_NORM_DIRECT")
-                .ok()
-                .as_deref()
-                != Some("0")
-    })
+    // NOTE (S4 flags): the env half used to be OnceLock-cached together with
+    // the first call's `k`, so a process that ever passed K=5120 kept the
+    // direct kernel for all later shapes. The snapshot read below evaluates
+    // `k` per call instead; single-model processes (constant K) are
+    // unaffected, and mixed-K processes now pick the kernel their K selects.
+    k == 5_120 && hipfire_config::developer_bool("HIPFIRE_GFX1100_AWQ_NORM_DIRECT", true)
 }
 
 fn awq_norm_kernel(gpu: &Gpu, k: usize) -> (&'static str, &'static str, u32) {
@@ -137,19 +123,13 @@ fn awq_norm_kernel(gpu: &Gpu, k: usize) -> (&'static str, &'static str, u32) {
 /// batching) where the cache spills to GDDR6 and latency-hiding may pay off.
 /// Set =1 to route through the 4-way-unroll twin for A/B.
 fn e8_dgpu_twin_enabled() -> bool {
-    use std::sync::OnceLock;
-    static FLAG: OnceLock<bool> = OnceLock::new();
-    *FLAG.get_or_init(|| {
-        hipfire_config::developer_var("HIPFIRE_E8_DGPU_TWIN")
-            .map(|v| v == "1")
-            .unwrap_or(false) // default OFF — delta <5% on gfx1100 (see comment)
-    })
+    hipfire_config::developer_bool("HIPFIRE_E8_DGPU_TWIN", false)
 }
 
 /// HIPFIRE_E8_SOA_EXPERTS: route E8 MoE gate_up decode to the SoA-coalesced kernel
 /// (reads SoA-laid-out expert weights). MUST be consistent with the load path: when
 /// set, routed E8 gate_up experts are transposed AoS->SoA at load, and the dispatch
-/// uses the SoA kernel. Read once (cached) — never per launch.
+/// uses the SoA kernel. Read from the process snapshot on each call.
 ///
 /// Default OFF. Validated COHERENT on gfx1100 (q36a3b.mfp4e8-gptq-v2) — kernel +
 /// transpose-on-load correct. But A3B decode = WASH: 102.0 (SoA) vs 102.0 (AoS) tok/s.
@@ -159,13 +139,7 @@ fn e8_dgpu_twin_enabled() -> bool {
 /// small per-expert MoE GEMVs. Far below the +8% ship bar — kept opt-in + documented.
 /// (Increment-1 yes/no per docs/plans/e8-soa-indexed-moe-decode.md: answer = no win.)
 pub(crate) fn e8_soa_experts_enabled() -> bool {
-    use std::sync::OnceLock;
-    static FLAG: OnceLock<bool> = OnceLock::new();
-    *FLAG.get_or_init(|| {
-        hipfire_config::developer_var("HIPFIRE_E8_SOA_EXPERTS")
-            .map(|v| v == "1")
-            .unwrap_or(false)
-    })
+    hipfire_config::developer_bool("HIPFIRE_E8_SOA_EXPERTS", false)
 }
 
 impl Gpu {
@@ -6811,14 +6785,10 @@ impl Gpu {
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        use std::sync::OnceLock;
-        static GFX1151_LM_HEAD_DOT2: OnceLock<bool> = OnceLock::new();
         let gfx1151_lm_head_dot2 = self.arch_caps.is_gfx1151()
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_DOT2.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_DOT2").as_deref() == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_DOT2", false);
         let gfx1151_lm_head_r1_hybrid_buffer =
             self.arch_caps.is_gfx1151() && m == 248_320 && k == 2_048;
         let use_lm_head_k2048 = self.arch_caps.is_gfx1100()
@@ -6890,52 +6860,33 @@ impl Gpu {
         let rdna3 = self.arch_caps.is_rdna3_dgpu();
         let rows = self.arch_caps.gemv_rows_default();
         let use_multirow = rows > 1 && !gfx1151_lm_head_dot2 && !gfx1151_lm_head_r1_hybrid_buffer;
-        static GFX1151_LM_HEAD_BUFFER: OnceLock<bool> = OnceLock::new();
         let gfx1151_lm_head_buffer = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_LM_HEAD_HYBRID_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_BUFFER", false);
         let gfx1151_lm_head_hybrid_buffer = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_HYBRID_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_LM_HEAD_ALL_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER", false);
         let gfx1151_lm_head_all_buffer = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_ALL_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_LM_HEAD_CPOL: OnceLock<Option<String>> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER", false);
+        let gfx1151_lm_head_cpol_owned = hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok();
         let gfx1151_lm_head_cpol =
             if self.arch_caps.is_gfx1151() && rows == 2 && m == 248_320 && k == 2_048 {
-                GFX1151_LM_HEAD_CPOL
-                    .get_or_init(|| {
-                        hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok()
-                    })
-                    .as_deref()
+                gfx1151_lm_head_cpol_owned.as_deref()
             } else {
                 None
             };
-        static GFX1151_LM_HEAD_K2048: OnceLock<bool> = OnceLock::new();
         let gfx1151_lm_head_k2048 = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_K2048.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_K2048").as_deref() == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_K2048", false);
 
         // RDNA2 (gfx1030/1031): always use the arch-optimized narrow kernel.
         // Other non-RDNA3 archs: use wide kernel (2 rows/block) for large M.
@@ -7155,40 +7106,22 @@ impl Gpu {
             && self.flags.rdna3_hfq4_residual_stage_x32
             && self.flags.rdna3_hfq4_residual_k2048
             && k == 2_048;
-        use std::sync::OnceLock;
-        static GFX1151_WEIGHT_BUFFER_LOADS: OnceLock<bool> = OnceLock::new();
+        // Keep residual separate from the combined gfx1151 probe:
+        // LLVM spills this dual-row raw-buffer schedule (private=16),
+        // which is not admissible for the scratch-free PM4 replay.
         let gfx1151_buffer = self.arch_caps.is_gfx1151()
-            && *GFX1151_WEIGHT_BUFFER_LOADS.get_or_init(|| {
-                // Keep residual separate from the combined gfx1151 probe:
-                // LLVM spills this dual-row raw-buffer schedule (private=16),
-                // which is not admissible for the scratch-free PM4 replay.
-                hipfire_config::developer_var("HIPFIRE_GFX1151_WEIGHT_BUFFER_RESIDUAL").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_RESIDUAL_HYBRID_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_WEIGHT_BUFFER_RESIDUAL", false);
         let gfx1151_hybrid_buffer = self.arch_caps.is_gfx1151()
-            && *GFX1151_RESIDUAL_HYBRID_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_RESIDUAL_HYBRID_BUFFER").as_deref()
-                    == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_RESIDUAL_HYBRID_BUFFER", false);
         let gfx1151_rt_low = self.arch_caps.is_gfx1151();
-        static GFX1151_RESIDUAL_ROW1: OnceLock<bool> = OnceLock::new();
         let gfx1151_row1 = self.arch_caps.is_gfx1151()
-            && *GFX1151_RESIDUAL_ROW1.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_RESIDUAL_ROW1").as_deref() == Ok("1")
-            });
-        static GFX1151_RESIDUAL_K4096: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_RESIDUAL_ROW1", false);
         let gfx1151_k4096 = self.arch_caps.is_gfx1151()
             && m == 2_048
             && k == 4_096
-            && *GFX1151_RESIDUAL_K4096.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_RESIDUAL_K4096").as_deref()
-                    == Ok("1")
-            });
-        static RESIDUAL_CPOL: OnceLock<Option<String>> = OnceLock::new();
-        let cpol = RESIDUAL_CPOL
-            .get_or_init(|| hipfire_config::developer_var("HIPFIRE_RESIDUAL_CPOL").ok())
-            .as_deref();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_RESIDUAL_K4096", false);
+        let cpol_owned = hipfire_config::developer_var("HIPFIRE_RESIDUAL_CPOL").ok();
+        let cpol = cpol_owned.as_deref();
         let cpol = if self.arch_caps.is_gfx1100() && self.flags.rdna3_hfq4_residual_stage_x32 {
             cpol
         } else {
@@ -7277,26 +7210,14 @@ impl Gpu {
         // CDNA3 wave64 fast path: 2 rows per block, halves grid.x. The base
         // kernel runs at half throughput on a wave64-native arch because
         // half the wave masks out per `__shfl_down`. Byte-exact with base.
-        static GFX1151_RESIDUAL_WAVE64: OnceLock<bool> = OnceLock::new();
         let gfx1151_wave64 = self.arch_caps.is_gfx1151()
-            && *GFX1151_RESIDUAL_WAVE64.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_RESIDUAL_WAVE64").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_RESIDUAL_TIGHT_GRID: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_RESIDUAL_WAVE64", false);
         let gfx1151_tight_grid = self.arch_caps.is_gfx1151()
-            && *GFX1151_RESIDUAL_TIGHT_GRID.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_RESIDUAL_TIGHT_GRID").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_RESIDUAL_MULTIROW_R2: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_RESIDUAL_TIGHT_GRID", false);
         let gfx1151_multirow_r2 = self.arch_caps.is_gfx1151()
             && m == 2_048
             && k == 2_048
-            && *GFX1151_RESIDUAL_MULTIROW_R2.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_RESIDUAL_MULTIROW_R2").as_deref()
-                    == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_RESIDUAL_MULTIROW_R2", false);
         let cdna3 = self.arch_caps.is_wave64_native() || gfx1151_wave64;
 
         // RDNA3 multi-row override path. Same selector as the non-residual
@@ -7716,14 +7637,10 @@ impl Gpu {
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        use std::sync::OnceLock;
-        static GFX1151_LM_HEAD_DOT2: OnceLock<bool> = OnceLock::new();
         let gfx1151_lm_head_dot2 = self.arch_caps.is_gfx1151()
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_DOT2.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_DOT2").as_deref() == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_DOT2", false);
         let gfx1151_lm_head_r1_hybrid_buffer =
             self.arch_caps.is_gfx1151() && m == 248_320 && k == 2_048;
         let use_lm_head_k2048 = self.arch_caps.is_gfx1100()
@@ -7786,52 +7703,33 @@ impl Gpu {
         let rdna3 = self.arch_caps.is_rdna3_dgpu();
         let rows = self.arch_caps.gemv_rows_default();
         let use_multirow = rows > 1 && !gfx1151_lm_head_dot2 && !gfx1151_lm_head_r1_hybrid_buffer;
-        static GFX1151_LM_HEAD_BUFFER: OnceLock<bool> = OnceLock::new();
         let gfx1151_lm_head_buffer = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_LM_HEAD_HYBRID_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_BUFFER", false);
         let gfx1151_lm_head_hybrid_buffer = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_HYBRID_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_LM_HEAD_ALL_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER", false);
         let gfx1151_lm_head_all_buffer = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_ALL_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_LM_HEAD_CPOL: OnceLock<Option<String>> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER", false);
+        let gfx1151_lm_head_cpol_owned = hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok();
         let gfx1151_lm_head_cpol =
             if self.arch_caps.is_gfx1151() && rows == 2 && m == 248_320 && k == 2_048 {
-                GFX1151_LM_HEAD_CPOL
-                    .get_or_init(|| {
-                        hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok()
-                    })
-                    .as_deref()
+                gfx1151_lm_head_cpol_owned.as_deref()
             } else {
                 None
             };
-        static GFX1151_LM_HEAD_K2048: OnceLock<bool> = OnceLock::new();
         let gfx1151_lm_head_k2048 = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_K2048.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_K2048").as_deref() == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_K2048", false);
         let use_wide = !gfx1151_lm_head_dot2
             && !gfx1151_lm_head_r1_hybrid_buffer
             && !use_multirow
@@ -7946,14 +7844,10 @@ impl Gpu {
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        use std::sync::OnceLock;
-        static GFX1151_LM_HEAD_DOT2: OnceLock<bool> = OnceLock::new();
         let gfx1151_lm_head_dot2 = self.arch_caps.is_gfx1151()
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_DOT2.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_DOT2").as_deref() == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_DOT2", false);
         let gfx1151_lm_head_r1_hybrid_buffer =
             self.arch_caps.is_gfx1151() && m == 248_320 && k == 2_048;
         let use_lm_head_k2048 = self.arch_caps.is_gfx1100()
@@ -8016,52 +7910,33 @@ impl Gpu {
         let rdna3 = self.arch_caps.is_rdna3_dgpu();
         let rows = self.arch_caps.gemv_rows_default();
         let use_multirow = rows > 1 && !gfx1151_lm_head_dot2 && !gfx1151_lm_head_r1_hybrid_buffer;
-        static GFX1151_LM_HEAD_BUFFER: OnceLock<bool> = OnceLock::new();
         let gfx1151_lm_head_buffer = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_LM_HEAD_HYBRID_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_BUFFER", false);
         let gfx1151_lm_head_hybrid_buffer = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_HYBRID_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_LM_HEAD_ALL_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER", false);
         let gfx1151_lm_head_all_buffer = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_ALL_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_LM_HEAD_CPOL: OnceLock<Option<String>> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER", false);
+        let gfx1151_lm_head_cpol_owned = hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok();
         let gfx1151_lm_head_cpol =
             if self.arch_caps.is_gfx1151() && rows == 2 && m == 248_320 && k == 2_048 {
-                GFX1151_LM_HEAD_CPOL
-                    .get_or_init(|| {
-                        hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok()
-                    })
-                    .as_deref()
+                gfx1151_lm_head_cpol_owned.as_deref()
             } else {
                 None
             };
-        static GFX1151_LM_HEAD_K2048: OnceLock<bool> = OnceLock::new();
         let gfx1151_lm_head_k2048 = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_K2048.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_K2048").as_deref() == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_K2048", false);
         let use_wide = !gfx1151_lm_head_dot2
             && !gfx1151_lm_head_r1_hybrid_buffer
             && !use_multirow
@@ -8177,65 +8052,43 @@ impl Gpu {
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        use std::sync::OnceLock;
         let rdna3 = self.arch_caps.is_rdna3_dgpu();
         let rows = self.arch_caps.gemv_rows_default();
         let gfx1151_lm_head_buffer = {
-            static GFX1151_LM_HEAD_BUFFER: OnceLock<bool> = OnceLock::new();
             self.arch_caps.is_gfx1151()
                 && rows == 2
                 && m == 248_320
                 && k == 2_048
-                && *GFX1151_LM_HEAD_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_BUFFER").as_deref()
-                        == Ok("1")
-                })
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_BUFFER", false)
         };
         let gfx1151_lm_head_hybrid_buffer = {
-            static GFX1151_LM_HEAD_HYBRID_BUFFER: OnceLock<bool> = OnceLock::new();
             self.arch_caps.is_gfx1151()
                 && rows == 2
                 && m == 248_320
                 && k == 2_048
-                && *GFX1151_LM_HEAD_HYBRID_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER")
-                        .as_deref()
-                        == Ok("1")
-                })
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER", false)
         };
         let gfx1151_lm_head_all_buffer = {
-            static GFX1151_LM_HEAD_ALL_BUFFER: OnceLock<bool> = OnceLock::new();
             self.arch_caps.is_gfx1151()
                 && rows == 2
                 && m == 248_320
                 && k == 2_048
-                && *GFX1151_LM_HEAD_ALL_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER").as_deref()
-                        == Ok("1")
-                })
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER", false)
         };
+        let gfx1151_lm_head_cpol_owned = hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok();
         let gfx1151_lm_head_cpol = {
-            static GFX1151_LM_HEAD_CPOL: OnceLock<Option<String>> = OnceLock::new();
             if self.arch_caps.is_gfx1151() && rows == 2 && m == 248_320 && k == 2_048 {
-                GFX1151_LM_HEAD_CPOL
-                    .get_or_init(|| {
-                        hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok()
-                    })
-                    .as_deref()
+                gfx1151_lm_head_cpol_owned.as_deref()
             } else {
                 None
             }
         };
         let gfx1151_lm_head_k2048 = {
-            static GFX1151_LM_HEAD_K2048: OnceLock<bool> = OnceLock::new();
             self.arch_caps.is_gfx1151()
                 && rows == 2
                 && m == 248_320
                 && k == 2_048
-                && *GFX1151_LM_HEAD_K2048.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_K2048").as_deref()
-                        == Ok("1")
-                })
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_K2048", false)
         };
         let a_ptr = a_raw.buf.as_ptr();
         let x_ptr = x.buf.as_ptr();
@@ -8362,65 +8215,43 @@ impl Gpu {
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        use std::sync::OnceLock;
         let rdna3 = self.arch_caps.is_rdna3_dgpu();
         let rows = self.arch_caps.gemv_rows_default();
         let gfx1151_lm_head_buffer = {
-            static GFX1151_LM_HEAD_BUFFER: OnceLock<bool> = OnceLock::new();
             self.arch_caps.is_gfx1151()
                 && rows == 2
                 && m == 248_320
                 && k == 2_048
-                && *GFX1151_LM_HEAD_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_BUFFER").as_deref()
-                        == Ok("1")
-                })
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_BUFFER", false)
         };
         let gfx1151_lm_head_hybrid_buffer = {
-            static GFX1151_LM_HEAD_HYBRID_BUFFER: OnceLock<bool> = OnceLock::new();
             self.arch_caps.is_gfx1151()
                 && rows == 2
                 && m == 248_320
                 && k == 2_048
-                && *GFX1151_LM_HEAD_HYBRID_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER")
-                        .as_deref()
-                        == Ok("1")
-                })
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER", false)
         };
         let gfx1151_lm_head_all_buffer = {
-            static GFX1151_LM_HEAD_ALL_BUFFER: OnceLock<bool> = OnceLock::new();
             self.arch_caps.is_gfx1151()
                 && rows == 2
                 && m == 248_320
                 && k == 2_048
-                && *GFX1151_LM_HEAD_ALL_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER").as_deref()
-                        == Ok("1")
-                })
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER", false)
         };
+        let gfx1151_lm_head_cpol_owned = hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok();
         let gfx1151_lm_head_cpol = {
-            static GFX1151_LM_HEAD_CPOL: OnceLock<Option<String>> = OnceLock::new();
             if self.arch_caps.is_gfx1151() && rows == 2 && m == 248_320 && k == 2_048 {
-                GFX1151_LM_HEAD_CPOL
-                    .get_or_init(|| {
-                        hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok()
-                    })
-                    .as_deref()
+                gfx1151_lm_head_cpol_owned.as_deref()
             } else {
                 None
             }
         };
         let gfx1151_lm_head_k2048 = {
-            static GFX1151_LM_HEAD_K2048: OnceLock<bool> = OnceLock::new();
             self.arch_caps.is_gfx1151()
                 && rows == 2
                 && m == 248_320
                 && k == 2_048
-                && *GFX1151_LM_HEAD_K2048.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_K2048").as_deref()
-                        == Ok("1")
-                })
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_K2048", false)
         };
         let a_ptr = a_raw.buf.as_ptr();
         let x_ptr = x.buf.as_ptr();
@@ -8597,27 +8428,14 @@ impl Gpu {
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        use std::sync::OnceLock;
-        static GFX1151_RESIDUAL_WAVE64: OnceLock<bool> = OnceLock::new();
         let gfx1151_wave64 = self.arch_caps.is_gfx1151()
-            && *GFX1151_RESIDUAL_WAVE64.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_RESIDUAL_WAVE64").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_RESIDUAL_TIGHT_GRID: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_RESIDUAL_WAVE64", false);
         let gfx1151_tight_grid = self.arch_caps.is_gfx1151()
-            && *GFX1151_RESIDUAL_TIGHT_GRID.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_RESIDUAL_TIGHT_GRID").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_RESIDUAL_MULTIROW_R2: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_RESIDUAL_TIGHT_GRID", false);
         let gfx1151_multirow_r2 = self.arch_caps.is_gfx1151()
             && m == 2_048
             && k == 2_048
-            && *GFX1151_RESIDUAL_MULTIROW_R2.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_RESIDUAL_MULTIROW_R2").as_deref()
-                    == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_RESIDUAL_MULTIROW_R2", false);
         let cdna3 = self.arch_caps.is_wave64_native() || gfx1151_wave64;
 
         let rdna3 = self.arch_caps.is_rdna3_dgpu();
@@ -8714,14 +8532,10 @@ impl Gpu {
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        use std::sync::OnceLock;
-        static GFX1151_LM_HEAD_DOT2: OnceLock<bool> = OnceLock::new();
         let gfx1151_lm_head_dot2 = self.arch_caps.is_gfx1151()
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_DOT2.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_DOT2").as_deref() == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_DOT2", false);
         let gfx1151_lm_head_r1_hybrid_buffer =
             self.arch_caps.is_gfx1151() && m == 248_320 && k == 2_048;
         let use_lm_head_k2048 = self.arch_caps.is_gfx1100()
@@ -8803,52 +8617,33 @@ impl Gpu {
         let rdna3 = self.arch_caps.is_rdna3_dgpu();
         let rows = self.arch_caps.gemv_rows_default();
         let use_multirow = rows > 1 && !gfx1151_lm_head_dot2 && !gfx1151_lm_head_r1_hybrid_buffer;
-        static GFX1151_LM_HEAD_BUFFER: OnceLock<bool> = OnceLock::new();
         let gfx1151_lm_head_buffer = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_LM_HEAD_HYBRID_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_BUFFER", false);
         let gfx1151_lm_head_hybrid_buffer = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_HYBRID_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_LM_HEAD_ALL_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER", false);
         let gfx1151_lm_head_all_buffer = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_ALL_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_LM_HEAD_CPOL: OnceLock<Option<String>> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER", false);
+        let gfx1151_lm_head_cpol_owned = hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok();
         let gfx1151_lm_head_cpol =
             if self.arch_caps.is_gfx1151() && rows == 2 && m == 248_320 && k == 2_048 {
-                GFX1151_LM_HEAD_CPOL
-                    .get_or_init(|| {
-                        hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok()
-                    })
-                    .as_deref()
+                gfx1151_lm_head_cpol_owned.as_deref()
             } else {
                 None
             };
-        static GFX1151_LM_HEAD_K2048: OnceLock<bool> = OnceLock::new();
         let gfx1151_lm_head_k2048 = self.arch_caps.is_gfx1151()
             && rows == 2
             && m == 248_320
             && k == 2_048
-            && *GFX1151_LM_HEAD_K2048.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_K2048").as_deref() == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_K2048", false);
 
         let use_wide = !gfx1151_lm_head_dot2
             && !gfx1151_lm_head_r1_hybrid_buffer
@@ -8957,65 +8752,43 @@ impl Gpu {
         k: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        use std::sync::OnceLock;
         let rdna3 = self.arch_caps.is_rdna3_dgpu();
         let rows = self.arch_caps.gemv_rows_default();
         let gfx1151_lm_head_buffer = {
-            static GFX1151_LM_HEAD_BUFFER: OnceLock<bool> = OnceLock::new();
             self.arch_caps.is_gfx1151()
                 && rows == 2
                 && m == 248_320
                 && k == 2_048
-                && *GFX1151_LM_HEAD_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_BUFFER").as_deref()
-                        == Ok("1")
-                })
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_BUFFER", false)
         };
         let gfx1151_lm_head_hybrid_buffer = {
-            static GFX1151_LM_HEAD_HYBRID_BUFFER: OnceLock<bool> = OnceLock::new();
             self.arch_caps.is_gfx1151()
                 && rows == 2
                 && m == 248_320
                 && k == 2_048
-                && *GFX1151_LM_HEAD_HYBRID_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER")
-                        .as_deref()
-                        == Ok("1")
-                })
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_HYBRID_BUFFER", false)
         };
         let gfx1151_lm_head_all_buffer = {
-            static GFX1151_LM_HEAD_ALL_BUFFER: OnceLock<bool> = OnceLock::new();
             self.arch_caps.is_gfx1151()
                 && rows == 2
                 && m == 248_320
                 && k == 2_048
-                && *GFX1151_LM_HEAD_ALL_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER").as_deref()
-                        == Ok("1")
-                })
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_ALL_BUFFER", false)
         };
+        let gfx1151_lm_head_cpol_owned = hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok();
         let gfx1151_lm_head_cpol = {
-            static GFX1151_LM_HEAD_CPOL: OnceLock<Option<String>> = OnceLock::new();
             if self.arch_caps.is_gfx1151() && rows == 2 && m == 248_320 && k == 2_048 {
-                GFX1151_LM_HEAD_CPOL
-                    .get_or_init(|| {
-                        hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_CPOL").ok()
-                    })
-                    .as_deref()
+                gfx1151_lm_head_cpol_owned.as_deref()
             } else {
                 None
             }
         };
         let gfx1151_lm_head_k2048 = {
-            static GFX1151_LM_HEAD_K2048: OnceLock<bool> = OnceLock::new();
             self.arch_caps.is_gfx1151()
                 && rows == 2
                 && m == 248_320
                 && k == 2_048
-                && *GFX1151_LM_HEAD_K2048.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_LM_HEAD_K2048").as_deref()
-                        == Ok("1")
-                })
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_LM_HEAD_K2048", false)
         };
         let a_ptr = a_raw.buf.as_ptr();
         let x_ptr = x.buf.as_ptr();
@@ -9279,38 +9052,23 @@ impl Gpu {
         self.bind_thread()?;
         let rdna3_rows4 = self.arch_caps.is_rdna3_dgpu() && self.flags.rdna3_hfq4_sigmoid_rows4;
         let rdna3_buffer = self.arch_caps.is_rdna3_dgpu() && self.flags.rdna3_hfq4_sigmoid_buffer;
-        use std::sync::OnceLock;
-        static GFX1151_WEIGHT_BUFFER_LOADS: OnceLock<bool> = OnceLock::new();
         let gfx1151_k512_buffer = self.arch_caps.is_gfx1151()
             && m == 2_048
             && k == 512
-            && *GFX1151_WEIGHT_BUFFER_LOADS.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_WEIGHT_BUFFER_LOADS").as_deref()
-                    == Ok("1")
-                    || hipfire_config::developer_var("HIPFIRE_GFX1151_WEIGHT_BUFFER_SIGMOID")
-                        .as_deref()
-                        == Ok("1")
-            });
-        static SIGMOID_K512: OnceLock<bool> = OnceLock::new();
-        static SIGMOID_HOIST_X16: OnceLock<bool> = OnceLock::new();
+            && (hipfire_config::developer_bool("HIPFIRE_GFX1151_WEIGHT_BUFFER_LOADS", false)
+                || hipfire_config::developer_bool("HIPFIRE_GFX1151_WEIGHT_BUFFER_SIGMOID", false));
         let rdna3_hoist_x16 = self.arch_caps.is_gfx1100()
             && rdna3_buffer
             && !rdna3_rows4
             && m == 2_048
             && k == 512
-            && *SIGMOID_HOIST_X16.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_RDNA3_HFQ4_SIGMOID_HOIST_X16").as_deref()
-                    == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_RDNA3_HFQ4_SIGMOID_HOIST_X16", false);
         let rdna3_k512 = self.arch_caps.is_gfx1100()
             && rdna3_buffer
             && !rdna3_rows4
             && m == 2_048
             && k == 512
-            && *SIGMOID_K512.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_RDNA3_HFQ4_SIGMOID_K512").as_deref()
-                    == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_RDNA3_HFQ4_SIGMOID_K512", false);
         let (module, source) = if rdna3_hoist_x16 {
             (
                 "gemv_hfq4g256_residual_sigmoid_k512_hoist_x16_buffer_gfx1100",
@@ -10423,29 +10181,17 @@ impl Gpu {
         n_ranks: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        use std::sync::OnceLock;
-        static GFX1151_GATE_UP_PERSISTENT_RANK8: OnceLock<bool> = OnceLock::new();
         let gfx1151_persistent_rank8 = self.arch_caps.is_gfx1151()
             && k == 2_048
             && n_ranks == 8
-            && *GFX1151_GATE_UP_PERSISTENT_RANK8.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_GATE_UP_PERSISTENT_RANK8").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_GATE_UP_PAIRED_WAVES: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_GATE_UP_PERSISTENT_RANK8", false);
         let gfx1151_paired_waves = !gfx1151_persistent_rank8
             && self.arch_caps.is_gfx1151()
             && k == 2_048
-            && *GFX1151_GATE_UP_PAIRED_WAVES.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_GATE_UP_PAIRED_WAVES").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_GATE_UP_SPLIT: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_GATE_UP_PAIRED_WAVES", false);
         let gfx1151_split = self.arch_caps.is_gfx1151()
             && k == 2_048
-            && *GFX1151_GATE_UP_SPLIT.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_GATE_UP_SPLIT").as_deref() == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_GATE_UP_SPLIT", false);
         if !gfx1151_persistent_rank8 && !gfx1151_paired_waves && gfx1151_split {
             return self.gemv_hfq4g256_moe_gate_up_k8_indexed_split_gfx1151(
                 expert_ptrs,
@@ -10458,14 +10204,10 @@ impl Gpu {
                 n_ranks,
             );
         }
-        static GFX1151_GATE_UP_WAVE64: OnceLock<bool> = OnceLock::new();
         let gfx1151_wave64 = !gfx1151_persistent_rank8
             && !gfx1151_paired_waves
             && self.arch_caps.is_gfx1151()
-            && *GFX1151_GATE_UP_WAVE64.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_GATE_UP_WAVE64").as_deref()
-                    == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_GATE_UP_WAVE64", false);
         let cdna_wave64 = self.arch_caps.is_wave64_native() || gfx1151_wave64;
         let (func_name, block, grid_x) = if cdna_wave64 {
             let (module, source) = if gfx1151_wave64 {
@@ -10490,23 +10232,15 @@ impl Gpu {
                 ((m as u32) + 1) / 2,
             )
         } else {
-            use std::sync::OnceLock;
-            static GATE_UP_WG2: OnceLock<bool> = OnceLock::new();
             let wg2 = self.arch_caps.is_gfx1100()
-                && *GATE_UP_WG2.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_MOE_GATE_UP_WG2").as_deref() == Ok("1")
-                });
+                && hipfire_config::developer_bool("HIPFIRE_MOE_GATE_UP_WG2", false);
             // The unchanged base kernel maps blockIdx.x to one logical row in
             // each M/2 gate and up output. The legacy M-sized grid therefore
             // leaves its upper half to exit at the row >= M/2 guard. Default
             // on for gfx1100 after exact shadow and stationary tg128 checks;
             // HIPFIRE_MOE_GATE_UP_TIGHT_GRID=0 restores the legacy geometry.
-            static GATE_UP_TIGHT_GRID: OnceLock<bool> = OnceLock::new();
             let tight_grid = if self.arch_caps.is_gfx1100() {
-                *GATE_UP_TIGHT_GRID.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_MOE_GATE_UP_TIGHT_GRID").as_deref()
-                        != Ok("0")
-                })
+                hipfire_config::developer_bool("HIPFIRE_MOE_GATE_UP_TIGHT_GRID", true)
             } else if self.arch_caps.is_gfx1151() {
                 // gfx1151 keeps its own performance-admission gate. The
                 // kernel maps blockIdx.x to one row in each M/2 output, so
@@ -10529,117 +10263,56 @@ impl Gpu {
             // ceil(M/2) blocks, each owning 2 output rows sharing this expert's x.
             // Token-id exact vs base (per-row math unchanged). Grid divisor here
             // MUST match the kernel's MOE_GATE_UP_NUM_ROWS.
-            static GATE_UP_FUSED: OnceLock<bool> = OnceLock::new();
-            let fused = *GATE_UP_FUSED.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_MOE_GATE_UP_FUSED").as_deref() == Ok("1")
-            });
-            static GATE_UP_RANK_INTERLEAVE: OnceLock<bool> = OnceLock::new();
+            let fused = hipfire_config::developer_bool("HIPFIRE_MOE_GATE_UP_FUSED", false);
             let rank_interleave = self.arch_caps.is_gfx1100()
                 && n_ranks == 8
-                && *GATE_UP_RANK_INTERLEAVE.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_MOE_GATE_UP_RANK_INTERLEAVE").as_deref()
-                        == Ok("1")
-                });
-            static GATE_UP_LOW_VGPR: OnceLock<bool> = OnceLock::new();
+                && hipfire_config::developer_bool("HIPFIRE_MOE_GATE_UP_RANK_INTERLEAVE", false);
             let low_vgpr = self.arch_caps.is_gfx1100()
-                && *GATE_UP_LOW_VGPR.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_MOE_GATE_UP_LOW_VGPR").as_deref()
-                        == Ok("1")
-                });
-            static GATE_UP_PAIR_VGPR: OnceLock<bool> = OnceLock::new();
+                && hipfire_config::developer_bool("HIPFIRE_MOE_GATE_UP_LOW_VGPR", false);
             let pair_vgpr = self.arch_caps.is_gfx1100()
-                && *GATE_UP_PAIR_VGPR.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_MOE_GATE_UP_PAIR_VGPR").as_deref()
-                        == Ok("1")
-                });
-            static GATE_UP_CPOL: OnceLock<String> = OnceLock::new();
+                && hipfire_config::developer_bool("HIPFIRE_MOE_GATE_UP_PAIR_VGPR", false);
+            // SLC is the gfx1100 product-certified policy: exact-shadow A-B-A
+            // and stationary tg128 A-B-A both beat the temporal-buffer
+            // control. Use `default` to restore cache-policy zero.
+            let cpol_owned: String = hipfire_config::developer_var("HIPFIRE_MOE_GATE_UP_CPOL")
+                .unwrap_or_else(|_| "slc".to_owned())
+                .to_ascii_lowercase();
             let cpol = if self.arch_caps.is_gfx1100() {
-                GATE_UP_CPOL
-                    .get_or_init(|| {
-                        hipfire_config::developer_var("HIPFIRE_MOE_GATE_UP_CPOL")
-                            // SLC is the gfx1100 product-certified policy:
-                            // exact-shadow A-B-A and stationary tg128 A-B-A
-                            // both beat the temporal-buffer control. Use
-                            // `default` to restore cache-policy zero.
-                            .unwrap_or_else(|_| "slc".to_owned())
-                            .to_ascii_lowercase()
-                    })
-                    .as_str()
+                cpol_owned.as_str()
             } else {
                 ""
             };
             let fixed_k2048 = self.arch_caps.is_gfx1100()
                 && self.flags.rdna3_hfq4_moe_gate_up_k2048
                 && k == 2_048;
-            static GFX1151_GATE_UP_K2048: OnceLock<bool> = OnceLock::new();
             let gfx1151_k2048 = self.arch_caps.is_gfx1151()
                 && k == 2_048
-                && *GFX1151_GATE_UP_K2048.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_GATE_UP_K2048").as_deref()
-                        == Ok("1")
-                });
-            static GFX1151_GATE_UP_LOW_VGPR: OnceLock<bool> = OnceLock::new();
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_GATE_UP_K2048", false);
             let gfx1151_low_vgpr = self.arch_caps.is_gfx1151()
                 && k == 2_048
-                && *GFX1151_GATE_UP_LOW_VGPR.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_GATE_UP_LOW_VGPR").as_deref()
-                        == Ok("1")
-                });
-            static GFX1151_GATE_UP_PAIR_VGPR: OnceLock<bool> = OnceLock::new();
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_GATE_UP_LOW_VGPR", false);
             let gfx1151_pair_vgpr = self.arch_caps.is_gfx1151()
                 && k == 2_048
-                && *GFX1151_GATE_UP_PAIR_VGPR.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_GATE_UP_PAIR_VGPR").as_deref()
-                        == Ok("1")
-                });
-            static GFX1151_GATE_UP_PAIR_BUFFER: OnceLock<bool> = OnceLock::new();
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_GATE_UP_PAIR_VGPR", false);
             let gfx1151_pair_buffer = self.arch_caps.is_gfx1151()
                 && k == 2_048
-                && *GFX1151_GATE_UP_PAIR_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_GATE_UP_PAIR_BUFFER").as_deref()
-                        == Ok("1")
-                });
-            static GFX1151_GATE_UP_HYBRID_BUFFER: OnceLock<bool> = OnceLock::new();
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_GATE_UP_PAIR_BUFFER", false);
             let gfx1151_hybrid_buffer = self.arch_caps.is_gfx1151()
                 && k == 2_048
-                && *GFX1151_GATE_UP_HYBRID_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_GATE_UP_HYBRID_BUFFER")
-                        .as_deref()
-                        == Ok("1")
-                });
-            static GFX1151_WEIGHT_BUFFER_LOADS: OnceLock<bool> = OnceLock::new();
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_GATE_UP_HYBRID_BUFFER", false);
             let gfx1151_k2048_buffer = self.arch_caps.is_gfx1151()
                 && k == 2_048
-                && *GFX1151_WEIGHT_BUFFER_LOADS.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_WEIGHT_BUFFER_LOADS").as_deref()
-                        == Ok("1")
-                        || hipfire_config::developer_var("HIPFIRE_GFX1151_WEIGHT_BUFFER_GATE_UP")
-                            .as_deref()
-                            == Ok("1")
-                });
-            static GFX1151_GATE_UP_ALL_BUFFER: OnceLock<bool> = OnceLock::new();
+                && (hipfire_config::developer_bool("HIPFIRE_GFX1151_WEIGHT_BUFFER_LOADS", false)
+                    || hipfire_config::developer_bool("HIPFIRE_GFX1151_WEIGHT_BUFFER_GATE_UP", false));
             let gfx1151_all_buffer = self.arch_caps.is_gfx1151()
                 && k == 2_048
-                && *GFX1151_GATE_UP_ALL_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_GATE_UP_ALL_BUFFER").as_deref()
-                        == Ok("1")
-                });
-            static GFX1151_GATE_UP_ROUTE_ALL_BUFFER: OnceLock<bool> = OnceLock::new();
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_GATE_UP_ALL_BUFFER", false);
             let gfx1151_route_all_buffer = self.arch_caps.is_gfx1151()
                 && k == 2_048
-                && *GFX1151_GATE_UP_ROUTE_ALL_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_GATE_UP_ROUTE_ALL_BUFFER")
-                        .as_deref()
-                        == Ok("1")
-                });
-            static GFX1151_GATE_UP_PAIR_ALL_BUFFER: OnceLock<bool> = OnceLock::new();
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_GATE_UP_ROUTE_ALL_BUFFER", false);
             let gfx1151_pair_all_buffer = self.arch_caps.is_gfx1151()
                 && k == 2_048
-                && *GFX1151_GATE_UP_PAIR_ALL_BUFFER.get_or_init(|| {
-                    hipfire_config::developer_var("HIPFIRE_GFX1151_GATE_UP_PAIR_ALL_BUFFER")
-                        .as_deref()
-                        == Ok("1")
-                });
+                && hipfire_config::developer_bool("HIPFIRE_GFX1151_GATE_UP_PAIR_ALL_BUFFER", false);
             if gfx1151_persistent_rank8 {
                 const PERSISTENT: &str =
                     "gemv_hfq4g256_moe_gate_up_k8_indexed_persistent_rank8_gfx1151";
@@ -11546,56 +11219,27 @@ impl Gpu {
         batch_size: usize,
     ) -> HipResult<()> {
         self.bind_thread()?;
-        use std::sync::OnceLock;
-        static DOWN_CPOL_SLC: OnceLock<bool> = OnceLock::new();
         let cpol_slc = self.arch_caps.is_gfx1100()
-            && *DOWN_CPOL_SLC.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_MOE_DOWN_CPOL").as_deref() == Ok("slc")
-            });
-        static GFX1151_WEIGHT_BUFFER_LOADS: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_var("HIPFIRE_MOE_DOWN_CPOL").as_deref() == Ok("slc");
         let gfx1151_buffer = self.arch_caps.is_gfx1151()
-            && *GFX1151_WEIGHT_BUFFER_LOADS.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_WEIGHT_BUFFER_LOADS").as_deref()
-                    == Ok("1")
-                    || hipfire_config::developer_var("HIPFIRE_GFX1151_WEIGHT_BUFFER_DOWN")
-                        .as_deref()
-                        == Ok("1")
-            });
-        static GFX1151_DOWN_HYBRID_BUFFER: OnceLock<bool> = OnceLock::new();
+            && (hipfire_config::developer_bool("HIPFIRE_GFX1151_WEIGHT_BUFFER_LOADS", false)
+                || hipfire_config::developer_bool("HIPFIRE_GFX1151_WEIGHT_BUFFER_DOWN", false));
         let gfx1151_hybrid_buffer = self.arch_caps.is_gfx1151()
             && k == 512
-            && *GFX1151_DOWN_HYBRID_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_DOWN_HYBRID_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_DOWN_ROW1_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_DOWN_HYBRID_BUFFER", false);
         let gfx1151_row1_buffer = self.arch_caps.is_gfx1151()
             && k == 512
-            && *GFX1151_DOWN_ROW1_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_DOWN_ROW1_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_DOWN_ROW2_BUFFER: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_DOWN_ROW1_BUFFER", false);
         let gfx1151_row2_buffer = self.arch_caps.is_gfx1151()
             && k == 512
-            && *GFX1151_DOWN_ROW2_BUFFER.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_DOWN_ROW2_BUFFER").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_DOWN_ROW2_CLUSTERED: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_DOWN_ROW2_BUFFER", false);
         let gfx1151_row2_clustered = self.arch_caps.is_gfx1151()
             && k == 512
-            && *GFX1151_DOWN_ROW2_CLUSTERED.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_DOWN_ROW2_CLUSTERED").as_deref()
-                    == Ok("1")
-            });
-        static GFX1151_DOWN_ROW8: OnceLock<bool> = OnceLock::new();
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_DOWN_ROW2_CLUSTERED", false);
         let gfx1151_row8 = self.arch_caps.is_gfx1151()
             && k == 512
             && m % 8 == 0
-            && *GFX1151_DOWN_ROW8.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_GFX1151_DOWN_ROW8").as_deref() == Ok("1")
-            });
+            && hipfire_config::developer_bool("HIPFIRE_GFX1151_DOWN_ROW8", false);
         let (module_name, source, func_name) = if cpol_slc {
             (
                 "gemv_hfq4g256_moe_down_k8_indexed_batched_expanded_cpol_slc_gfx1100",
@@ -11667,11 +11311,8 @@ impl Gpu {
         // The expanded kernel owns four consecutive output rows per workgroup.
         // Keep this opt-in while it is qualified on gfx1100: the legacy launch
         // used `m` workgroups, leaving three quarters to exit at the row0 guard.
-        static DOWN_TIGHT_GRID: OnceLock<bool> = OnceLock::new();
         let tight_grid = if self.arch_caps.is_gfx1100() {
-            *DOWN_TIGHT_GRID.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_MOE_DOWN_TIGHT_GRID").as_deref() == Ok("1")
-            })
+            hipfire_config::developer_bool("HIPFIRE_MOE_DOWN_TIGHT_GRID", false)
         } else if self.arch_caps.is_gfx1151() {
             // This kernel owns four rows per workgroup. Keep gfx1151's
             // measurement independent from gfx1100 even though the launch
@@ -12707,12 +12348,8 @@ impl Gpu {
             "gemv_hfq4g256_moe_down_k8_indexed_last_combine",
             bytes,
         );
-        use std::sync::OnceLock;
-        static DOWN_TIGHT_GRID: OnceLock<bool> = OnceLock::new();
         let grid_x = if self.arch_caps.is_gfx1100()
-            && *DOWN_TIGHT_GRID.get_or_init(|| {
-                hipfire_config::developer_var("HIPFIRE_MOE_DOWN_TIGHT_GRID").as_deref() == Ok("1")
-            }) {
+            && hipfire_config::developer_bool("HIPFIRE_MOE_DOWN_TIGHT_GRID", false) {
             (m as u32).div_ceil(4)
         } else {
             m as u32
@@ -14000,15 +13637,11 @@ impl Gpu {
                 m as u32,
             )
         } else {
-            use std::sync::OnceLock;
-            static MQ2_DOWN_ROWS: OnceLock<u32> = OnceLock::new();
-            let rows = *MQ2_DOWN_ROWS.get_or_init(|| {
-                match hipfire_config::developer_var("HIPFIRE_MQ2_DOWN_ROWS").as_deref() {
-                    Ok("2") => 2,
-                    Ok("4") => 4,
-                    _ => 1,
-                }
-            });
+            let rows = match hipfire_config::developer_var("HIPFIRE_MQ2_DOWN_ROWS").as_deref() {
+                Ok("2") => 2,
+                Ok("4") => 4,
+                _ => 1,
+            };
             let (module, func) = match rows {
                 2 => (
                     "gemv_mq2g256_lloyd_moe_down_indexed_r4",
@@ -14461,15 +14094,11 @@ impl Gpu {
         // five radiowave scheduler profiles) plus a host-side bit-parity
         // simulation; no GPU measurement backs it yet. See
         // docs/investigations/2026-08-05-mq3-down-rowtile/.
-        use std::sync::OnceLock;
-        static MQ3_DOWN_ROWS: OnceLock<u32> = OnceLock::new();
-        let rows = *MQ3_DOWN_ROWS.get_or_init(|| {
-            match hipfire_config::developer_var("HIPFIRE_MQ3_DOWN_ROWS").as_deref() {
-                Ok("2") => 2,
-                Ok("4") => 4,
-                _ => 1,
-            }
-        });
+        let rows = match hipfire_config::developer_var("HIPFIRE_MQ3_DOWN_ROWS").as_deref() {
+            Ok("2") => 2,
+            Ok("4") => 4,
+            _ => 1,
+        };
         let (module, func) = match rows {
             2 => (
                 "gemv_mq3g256_lloyd_moe_down_indexed_r4",

--- a/crates/rdna-compute/src/lib.rs
+++ b/crates/rdna-compute/src/lib.rs
@@ -41,7 +41,7 @@ pub use dispatch::{
 };
 pub use feature_flags::FeatureFlags;
 pub use hip_bridge::{HipError, HipResult};
-use std::sync::OnceLock;
+use hipfire_config::developer_bool;
 
 /// Calibration-only override that forces native-BF16 teachers to stay BF16.
 ///
@@ -54,8 +54,10 @@ use std::sync::OnceLock;
 /// reuse, no LDS, no MFMA). OFF by default so shipped inference is
 /// unaffected.
 pub fn calib_force_bf16() -> bool {
-    static CELL: OnceLock<bool> = OnceLock::new();
-    *CELL.get_or_init(|| std::env::var("HIPFIRE_CALIB_BF16").as_deref() == Ok("1"))
+    // Snapshot-backed (mirrors `FeatureFlags::calib_force_bf16`): no
+    // process-global cache here, the versioned `ProcessConfig` snapshot is
+    // itself resolved once. Arch callers keep calling this free function.
+    developer_bool("HIPFIRE_CALIB_BF16", false)
 }
 pub use kernels::GEMV_SRC;
 /// whose gfx11 and gfx12 kernels are separate translation units. Exported so
@@ -72,14 +74,12 @@ mod tests {
         // Spec requires false when HIPFIRE_CALIB_BF16 is not "1".
         // In CI the var is unset; if a prior test or env sets it to "1"
         // we skip rather than flake — the contract is OFF by default.
-        if std::env::var("HIPFIRE_CALIB_BF16").as_deref() == Ok("1") {
+        if hipfire_config::developer_var("HIPFIRE_CALIB_BF16").as_deref() == Ok("1") {
             return;
         }
-        // Ensure the var is not "1" for this assertion path.
-        // When OnceLock is already cached as true (because some earlier
-        // call saw "1"), the cached true would violate the unset
-        // expectation — but that path is unreachable when the env is
-        // unset at process start, which is the acceptance condition.
+        // Ensure the var is not "1" for this assertion path. The snapshot
+        // is resolved once per process; in CI the var is unset at process
+        // start, which is the acceptance condition.
         assert!(
             !calib_force_bf16(),
             "calib_force_bf16() must be false when HIPFIRE_CALIB_BF16 != \"1\" (OFF by default)"

--- a/crates/rdna-compute/src/norm.rs
+++ b/crates/rdna-compute/src/norm.rs
@@ -46,15 +46,15 @@ pub fn restore_gdn_requant_frame_checkpoint(frame: u32) {
 /// for MQ4/HFQ; opt in via `HIPFIRE_DN_REQUANT_PER_TOKEN=1` for PARO checkpoints
 /// (shisa-ai A3B). For n_tokens==1 (AR decode / DFlash draft) both are identical.
 fn dn_requant_per_token() -> bool {
-    static V: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *V.get_or_init(|| {
-        hipfire_config::developer_var("HIPFIRE_DN_REQUANT_PER_TOKEN")
-            .map(|v| {
-                let v = v.trim();
-                !v.is_empty() && v != "0"
-            })
-            .unwrap_or(false)
-    })
+    // Truthy (non-empty, non-"0") predicate preserved verbatim from the
+    // cached form; only the process-global cache is gone (the snapshot is
+    // the cache now).
+    hipfire_config::developer_var("HIPFIRE_DN_REQUANT_PER_TOKEN")
+        .map(|v| {
+            let v = v.trim();
+            !v.is_empty() && v != "0"
+        })
+        .unwrap_or(false)
 }
 
 /// Use the chunked (parallel) FP32 GDN kernel on the multi-token (n>1) linear
@@ -62,29 +62,24 @@ fn dn_requant_per_token() -> bool {
 /// PoC: each chunk is a separate host-side launch (cross-chunk is serial).
 /// Numerically EQUAL to batch_seq (oracle gdn_chunked_f32, 1.3e-15).
 pub fn gdn_chunked() -> bool {
-    static V: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *V.get_or_init(|| {
-        hipfire_config::developer_var("HIPFIRE_GDN_CHUNKED")
-            .map(|v| {
-                let v = v.trim();
-                !v.is_empty() && v != "0"
-            })
-            .unwrap_or(false)
-    })
+    // Same truthy-predicate note as `dn_requant_per_token`.
+    hipfire_config::developer_var("HIPFIRE_GDN_CHUNKED")
+        .map(|v| {
+            let v = v.trim();
+            !v.is_empty() && v != "0"
+        })
+        .unwrap_or(false)
 }
 
 /// Chunk size CS for the chunked FP32 GDN kernel. Default 16 (fits 64 KB LDS
 /// with occupancy headroom). Clamped to [1, 32] (CS_MAX). CS=32 is opt-in and
 /// occupancy-1; CS>32 is refused (LDS overflow).
 pub fn gdn_chunk_size() -> usize {
-    static V: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *V.get_or_init(|| {
-        let cs = hipfire_config::developer_var("HIPFIRE_GDN_CHUNK_SIZE")
-            .ok()
-            .and_then(|v| v.trim().parse::<usize>().ok())
-            .unwrap_or(16);
-        cs.clamp(1, 32)
-    })
+    let cs = hipfire_config::developer_var("HIPFIRE_GDN_CHUNK_SIZE")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .unwrap_or(16);
+    cs.clamp(1, 32)
 }
 
 impl Gpu {

--- a/crates/rdna-compute/src/sampling.rs
+++ b/crates/rdna-compute/src/sampling.rs
@@ -13,15 +13,9 @@ use hip_bridge::{HipError, HipResult};
 
 /// Whether the multi-workgroup parallel sampler is enabled (default ON).
 /// `HIPFIRE_SAMPLE_PARALLEL=0` forces the legacy single-block kernel (for
-/// byte-exact A/B and as a fallback). Read once, cached.
+/// byte-exact A/B and as a fallback). Snapshot-backed, no per-flag cache.
 fn sample_parallel_enabled() -> bool {
-    use std::sync::OnceLock;
-    static EN: OnceLock<bool> = OnceLock::new();
-    *EN.get_or_init(|| {
-        hipfire_config::developer_var("HIPFIRE_SAMPLE_PARALLEL")
-            .map(|v| v != "0")
-            .unwrap_or(true)
-    })
+    hipfire_config::developer_bool("HIPFIRE_SAMPLE_PARALLEL", true)
 }
 
 /// Whether the tie-safe fast reducer is enabled (default ON). This keeps the
@@ -29,13 +23,7 @@ fn sample_parallel_enabled() -> bool {
 /// performance control without falling all the way back to the single-block
 /// sampler.
 fn sample_fast_stable_enabled() -> bool {
-    use std::sync::OnceLock;
-    static EN: OnceLock<bool> = OnceLock::new();
-    *EN.get_or_init(|| {
-        hipfire_config::developer_var("HIPFIRE_SAMPLE_FAST")
-            .map(|v| v != "0")
-            .unwrap_or(true)
-    })
+    hipfire_config::developer_bool("HIPFIRE_SAMPLE_FAST", true)
 }
 
 /// HIP source for the default parallel sampler module (`sample_top_p_parallel`,

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -140,6 +140,7 @@ Values and defaults below match `hipfire-config`, the native CLI, and/or `Runtim
 | `HIPFIRE_FLASH_PREFILL` | Developer override for Q8 WMMA flash prefill: `0` forces off, `1` forces on; unset uses the architecture/workload envelope. |
 | `HIPFIRE_FLASH_PREFILL_FIXED_HD` | Developer ablation: fixed-head-dimension specialization is on unless `0`. |
 | `HIPFIRE_FLASH_PREFILL_PREFETCH_V` | Developer ablation: gfx12 V prefetch is on unless `0`. |
+| `HIPFIRE_CALIB_BF16` | Calibration-only: keep native-BF16 teachers in BF16 (`kernel.calib_force_bf16`, default off; shipped inference unaffected) |
 
 ### LFM (arch 11) — branch-scoped optimized prefill
 


### PR DESCRIPTION
Slice 4 of the overhaul: consolidates the ~100 ad-hoc OnceLock/LazyLock + ambient env readers onto the versioned ProcessConfig snapshot.

Three commits: P0 strict developer_bool helper (+tests; home-root/open_first surveyed, deliberately no new helpers per the single-caller rule), P1 prompt.jinja_chat + kernel.calib_force_bf16 schema fields and FeatureFlags::calib_force_bf16, P2 reader migration with OnceLock deletion.

Gates run: cargo check -p rdna-compute -p hipfire-config -p hipfire-generate clean; cargo test -p hipfire-config -p hipfire-generate all green. check-env-docs.py fails only on out-of-scope crates + 4 intentional grammar_config test-harness lines (details in commit 3 message). Token-identity fixture NOT run (GPUs busy; parent runs it on hardware).