### PR TITLE
overhaul/s7: GPU QOL — bounded sync, launch-attributed HipError, shared content-keyed kernel cache

### DIFF
--- a/crates/hip-bridge/examples/peer_chain.rs
+++ b/crates/hip-bridge/examples/peer_chain.rs
@@ -731,6 +731,7 @@ fn check_rocr_completion(signal: &CompletionSignal) -> HipResult<()> {
         Err(HipError {
             code: 1,
             message: format!("ROCr async-copy completion signal ended at {value}, expected 0"),
+            context: None,
         })
     }
 }
@@ -739,6 +740,7 @@ fn rocr_as_hip(error: redline_rocr::RuntimeError) -> HipError {
     HipError {
         code: 1,
         message: error.to_string(),
+        context: None,
     }
 }
 
@@ -927,6 +929,7 @@ fn rccl_as_hip(error: hip_bridge::RcclError) -> HipError {
     HipError {
         code: error.status,
         message: error.to_string(),
+        context: None,
     }
 }
 

--- a/crates/hip-bridge/src/error.rs
+++ b/crates/hip-bridge/src/error.rs
@@ -21,10 +21,28 @@ pub const HIP_ERROR_PEER_ACCESS_UNSUPPORTED: HipErrorCode = 217;
 pub const HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED: HipErrorCode = 704;
 pub const HIP_ERROR_PEER_ACCESS_NOT_ENABLED: HipErrorCode = 705;
 
-#[derive(Debug)]
+/// Callsite context for a failed kernel launch: which kernel was being
+/// launched and where the launch was issued from.
+///
+/// Boxed behind [`HipError::context`] so the common `HipResult<()>` path
+/// carries no heap payload — only launch failures that opt in via
+/// [`HipError::with_kernel`] allocate.
+#[derive(Debug, Clone)]
+pub struct LaunchContext {
+    /// Kernel/function name passed to the launch helper.
+    pub kernel: String,
+    /// Source file that issued the launch (`Location::caller` of `with_kernel`).
+    pub file: &'static str,
+    /// Source line that issued the launch.
+    pub line: u32,
+}
+
+#[derive(Debug, Clone)]
 pub struct HipError {
     pub code: HipErrorCode,
     pub message: String,
+    /// Launch attribution. `None` for non-launch errors (alloc, memcpy, sync).
+    pub context: Option<Box<LaunchContext>>,
 }
 
 impl HipError {
@@ -32,7 +50,23 @@ impl HipError {
         Self {
             code,
             message: format!("{context} (hipError={code})"),
+            context: None,
         }
+    }
+
+    /// Attach launch attribution: the kernel being launched and the callsite
+    /// that issued it. `#[track_caller]` makes `file:line` the *caller's*
+    /// location, so each launch funnel calls this once and the recorded
+    /// callsite is the dispatch line, not this helper.
+    #[track_caller]
+    pub fn with_kernel(mut self, kernel: &str) -> Self {
+        let loc = std::panic::Location::caller();
+        self.context = Some(Box::new(LaunchContext {
+            kernel: kernel.to_string(),
+            file: loc.file(),
+            line: loc.line(),
+        }));
+        self
     }
 
     pub(crate) fn from_code(
@@ -57,14 +91,42 @@ impl HipError {
         Self {
             code,
             message: format!("{context}: {detail}"),
+            context: None,
         }
     }
 }
 
 impl fmt::Display for HipError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "HipError({}): {}", self.code, self.message)
+        write!(f, "HipError({}): {}", self.code, self.message)?;
+        if let Some(ctx) = self.context.as_deref() {
+            write!(f, " [kernel={} at {}:{}]", ctx.kernel, ctx.file, ctx.line)?;
+        }
+        Ok(())
     }
 }
 
 impl std::error::Error for HipError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_without_context_is_unchanged() {
+        let e = HipError::new(719, "hipModuleLaunchKernel");
+        assert_eq!(
+            e.to_string(),
+            "HipError(719): hipModuleLaunchKernel (hipError=719)"
+        );
+    }
+
+    #[test]
+    fn display_with_kernel_names_kernel_and_callsite() {
+        let e = HipError::new(719, "hipModuleLaunchKernel").with_kernel("gemv_hfq4g256");
+        let s = e.to_string();
+        assert!(s.contains("HipError(719)"), "keeps the status: {s}");
+        assert!(s.contains("gemv_hfq4g256"), "names the kernel: {s}");
+        assert!(s.contains("error.rs"), "names the callsite file: {s}");
+    }
+}

--- a/crates/hip-bridge/src/ffi.rs
+++ b/crates/hip-bridge/src/ffi.rs
@@ -1302,8 +1302,19 @@ impl HipRuntime {
     }
 
     pub fn stream_synchronize(&self, stream: &Stream) -> HipResult<()> {
+        self.stream_synchronize_raw(stream.as_raw())
+    }
+
+    /// Synchronize a stream given as a raw handle.
+    ///
+    /// Same call as [`Self::stream_synchronize`]; the raw form exists for
+    /// bounded-sync helpers that must move the handle across threads (`Stream`
+    /// is `Send` but not `Sync`, so `&Stream` cannot be shared into a scoped
+    /// thread — callers pass the handle as a `usize` and cast back here).
+    /// The handle must be a live `hipStream_t`.
+    pub fn stream_synchronize_raw(&self, stream: *mut c_void) -> HipResult<()> {
         let t = std::time::Instant::now();
-        let code = unsafe { (self.fn_stream_synchronize)(stream.0) };
+        let code = unsafe { (self.fn_stream_synchronize)(stream) };
         crate::ffi::launch_counters::stream_sync::record(t.elapsed().as_nanos() as u64);
         self.check(code, "hipStreamSynchronize")
     }

--- a/crates/hip-bridge/src/ffi.rs
+++ b/crates/hip-bridge/src/ffi.rs
@@ -113,6 +113,11 @@ type HipGraphExec = *mut c_void;
 pub type HipMemGenericAllocationHandle = *mut c_void;
 
 const HIP_SUCCESS: u32 = 0;
+
+/// `hipEventQuery` return when previously-recorded work is still outstanding.
+/// Per `hip_runtime_api.h` (`hipErrorNotReady = 600`); a non-blocking poll
+/// treats exactly this code as "not yet", every other nonzero code as failure.
+pub const HIP_ERROR_NOT_READY: u32 = 600;
 pub const HIP_MEM_LOCATION_TYPE_DEVICE: u32 = 1;
 pub const HIP_MEM_ALLOCATION_TYPE_PINNED: u32 = 1;
 pub const HIP_MEM_ACCESS_FLAGS_PROT_READ_WRITE: u32 = 3;
@@ -297,6 +302,7 @@ pub struct HipRuntime {
     fn_event_create: unsafe extern "C" fn(*mut HipEvent) -> u32,
     fn_event_create_with_flags: unsafe extern "C" fn(*mut HipEvent, c_uint) -> u32,
     fn_event_record: unsafe extern "C" fn(HipEvent, HipStream) -> u32,
+    fn_event_query: unsafe extern "C" fn(HipEvent) -> u32,
     fn_event_synchronize: unsafe extern "C" fn(HipEvent) -> u32,
     fn_event_elapsed_time: unsafe extern "C" fn(*mut f32, HipEvent, HipEvent) -> u32,
     fn_event_destroy: unsafe extern "C" fn(HipEvent) -> u32,
@@ -605,6 +611,11 @@ impl HipRuntime {
                     lib,
                     "hipEventRecord",
                     unsafe extern "C" fn(HipEvent, HipStream) -> u32
+                ),
+                fn_event_query: load_fn!(
+                    lib,
+                    "hipEventQuery",
+                    unsafe extern "C" fn(HipEvent) -> u32
                 ),
                 fn_event_synchronize: load_fn!(
                     lib,
@@ -1302,19 +1313,8 @@ impl HipRuntime {
     }
 
     pub fn stream_synchronize(&self, stream: &Stream) -> HipResult<()> {
-        self.stream_synchronize_raw(stream.as_raw())
-    }
-
-    /// Synchronize a stream given as a raw handle.
-    ///
-    /// Same call as [`Self::stream_synchronize`]; the raw form exists for
-    /// bounded-sync helpers that must move the handle across threads (`Stream`
-    /// is `Send` but not `Sync`, so `&Stream` cannot be shared into a scoped
-    /// thread — callers pass the handle as a `usize` and cast back here).
-    /// The handle must be a live `hipStream_t`.
-    pub fn stream_synchronize_raw(&self, stream: *mut c_void) -> HipResult<()> {
         let t = std::time::Instant::now();
-        let code = unsafe { (self.fn_stream_synchronize)(stream) };
+        let code = unsafe { (self.fn_stream_synchronize)(stream.0) };
         crate::ffi::launch_counters::stream_sync::record(t.elapsed().as_nanos() as u64);
         self.check(code, "hipStreamSynchronize")
     }
@@ -1484,6 +1484,22 @@ impl HipRuntime {
         let code = unsafe { (self.fn_event_synchronize)(event.0) };
         crate::ffi::launch_counters::event_sync::record(t.elapsed().as_nanos() as u64);
         self.check(code, "hipEventSynchronize")
+    }
+
+    pub fn event_query(&self, event: &Event) -> HipResult<bool> {
+        // Non-blocking by construction: hipSuccess = recorded and complete,
+        // hipErrorNotReady (600) = work still outstanding, anything else is
+        // a real failure (invalid handle, device lost) and propagates.
+        let code = unsafe { (self.fn_event_query)(event.0) };
+        if code == HIP_SUCCESS {
+            Ok(true)
+        } else if code == HIP_ERROR_NOT_READY {
+            Ok(false)
+        } else {
+            self.check(code, "hipEventQuery")?;
+            // Unreachable: check errs on every nonzero code.
+            Ok(false)
+        }
     }
 
     pub fn event_elapsed_ms(&self, start: &Event, stop: &Event) -> HipResult<f32> {

--- a/crates/hip-bridge/src/lib.rs
+++ b/crates/hip-bridge/src/lib.rs
@@ -15,8 +15,9 @@ mod rocsolver;
 mod vmm;
 
 pub use error::{
-    HipError, HipResult, HIP_ERROR_INVALID_IMAGE, HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED,
-    HIP_ERROR_PEER_ACCESS_NOT_ENABLED, HIP_ERROR_PEER_ACCESS_UNSUPPORTED,
+    HipError, HipErrorCode, HipResult, LaunchContext, HIP_ERROR_INVALID_IMAGE,
+    HIP_ERROR_PEER_ACCESS_ALREADY_ENABLED, HIP_ERROR_PEER_ACCESS_NOT_ENABLED,
+    HIP_ERROR_PEER_ACCESS_UNSUPPORTED,
 };
 pub use ffi::launch_counters;
 pub use ffi::{

--- a/crates/hip-bridge/src/lib.rs
+++ b/crates/hip-bridge/src/lib.rs
@@ -23,8 +23,8 @@ pub use ffi::launch_counters;
 pub use ffi::{
     Event, Function, Graph, GraphExec, HipMemAccessDesc, HipMemAllocationProp,
     HipMemGenericAllocationHandle, HipMemLocation, HipPointerAttribute, HipRuntime, Module, Stream,
-    HIP_EVENT_DISABLE_TIMING, HIP_EVENT_RELEASE_TO_SYSTEM, HIP_MEM_ALLOCATION_GRANULARITY_MINIMUM,
-    HIP_MEM_ALLOCATION_GRANULARITY_RECOMMENDED,
+    HIP_ERROR_NOT_READY, HIP_EVENT_DISABLE_TIMING, HIP_EVENT_RELEASE_TO_SYSTEM,
+    HIP_MEM_ALLOCATION_GRANULARITY_MINIMUM, HIP_MEM_ALLOCATION_GRANULARITY_RECOMMENDED,
 };
 pub use kernarg::KernargBlob;
 pub use rccl::{RcclComms, RcclDataType, RcclError, RcclRedOp, RcclResult, NCCL_SUCCESS};

--- a/crates/hip-bridge/src/vmm.rs
+++ b/crates/hip-bridge/src/vmm.rs
@@ -269,6 +269,7 @@ impl VmmArena {
                     size,
                     self.granularity,
                 ),
+                context: err.context,
             };
             let mut segment = VmmSegment {
                 offset: self.mapped_bytes,

--- a/crates/hipfire-runtime/src/multi_gpu.rs
+++ b/crates/hipfire-runtime/src/multi_gpu.rs
@@ -1033,19 +1033,23 @@ impl Gpus {
         }
         // D2H: synchronize producer stream, then download into row's prefix.
         // Preserve first error immediately — no partial-success claim.
+        // Bounded sync: a hung producer stream becomes a reportable error
+        // naming the last kernel launched on that device instead of hanging
+        // the collective forever. Every other sync in this file keeps its
+        // existing unbounded semantics.
         for r in 0..n {
             let dev = &self.devices[r];
             dev.bind_thread()?;
-            let stream = dev.active_stream.as_ref().ok_or_else(|| {
-                HipError::new(
+            if dev.active_stream.is_none() {
+                return Err(HipError::new(
                     0,
                     &format!(
                         "all_reduce_sum_f32_host: device {r} has no active_stream — \
                          set `gpus.devices[r].active_stream = Some(stream)` before calling.",
                     ),
-                )
-            })?;
-            dev.hip.stream_synchronize(stream)?;
+                ));
+            }
+            dev.sync_with_deadline(Gpu::GPU_SYNC_DEADLINE)?;
             // SAFETY: row.len() >= count ensured above, so first `count` f32
             // (bytes) lie within the Vec's initialized length. The derived
             // `[u8]` slice is exactly `bytes` and is bounded to that prefix.

--- a/crates/hipfire-runtime/src/multi_gpu.rs
+++ b/crates/hipfire-runtime/src/multi_gpu.rs
@@ -1037,6 +1037,11 @@ impl Gpus {
         // naming the last kernel launched on that device instead of hanging
         // the collective forever. Every other sync in this file keeps its
         // existing unbounded semantics.
+        // On `Err` the producer work is STILL OUTSTANDING (the deadline only
+        // stops waiting, it never cancels the GPU): `?` aborts the collective
+        // here, skipping the download below, so we never read a buffer its
+        // kernel may still be writing. The device must be treated as suspect
+        // by the caller — no retry on this stream without a reset path.
         for r in 0..n {
             let dev = &self.devices[r];
             dev.bind_thread()?;

--- a/crates/rdna-compute/src/compiler.rs
+++ b/crates/rdna-compute/src/compiler.rs
@@ -50,6 +50,35 @@ fn unique_token() -> String {
     format!("{}_{n}_{nanos}", std::process::id())
 }
 
+/// Shared on-disk kernel cache root: `$HIPFIRE_KERNEL_CACHE` when set,
+/// otherwise `$HOME/.hipfire_kernels` so every worktree and daemon on the
+/// machine shares one content-keyed store instead of recompiling per CWD.
+/// Falls back to the legacy CWD-relative dir only when `HOME` is unset.
+/// Pre-existing CWD `.hipfire_kernels` dirs are left alone — they simply go
+/// unused, never deleted or migrated by this code.
+fn default_cache_root() -> PathBuf {
+    if let Some(dir) = std::env::var_os("HIPFIRE_KERNEL_CACHE") {
+        return PathBuf::from(dir);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        return PathBuf::from(home).join(".hipfire_kernels");
+    }
+    PathBuf::from(".hipfire_kernels")
+}
+
+/// Content-keyed stem for hot entries: module name plus the full cache hash
+/// (source + flags + arch + toolchain + ABI). Distinct triples map to
+/// distinct paths, so a nonempty hit needs no sidecar validation and two
+/// daemons from different builds sharing one root never collide on a path.
+fn hot_stem(name: &str, src_hash: &str) -> String {
+    format!("{name}.{src_hash}")
+}
+
+/// Final hot object filename for a (`name`, `src_hash`) pair.
+fn hot_object_name(name: &str, src_hash: &str) -> String {
+    format!("{}.hsaco", hot_stem(name, src_hash))
+}
+
 /// Validated pair: nonempty regular HSACO **and** matching hash sidecar.
 /// A hash alone never certifies a missing/empty/directory blob. A blob alone
 /// is never treated as hash-validated.
@@ -263,8 +292,10 @@ const KERNEL_CACHE_ABI: u32 = 3;
 /// Compiles HIP kernel sources to code objects, with caching.
 ///
 /// Two-directory contract:
-/// - **hot** (`cache_dir`): per-process JIT workspace (`.hipfire_kernels/{arch}`
-///   by default). Preferred for lookup after seeding.
+/// - **hot** (`cache_dir`): shared JIT workspace
+///   (`$HOME/.hipfire_kernels/{arch}` by default). Hot filenames are
+///   content-keyed (`{name}.{hash}.hsaco`), so a nonempty hit is by
+///   construction the right blob. Preferred for lookup after seeding.
 /// - **cold** (`cold_dir`): persistent install location
 ///   (`kernels/compiled/{arch}` under the installed binary). Writeback target
 ///   so install-time / post-update recompiles refresh the blobs that seed the
@@ -305,23 +336,17 @@ pub struct KernelCompiler {
 
 impl KernelCompiler {
     pub fn new(arch: &str, extra_flags: String) -> HipResult<Self> {
-        // Cache (hot path) defaults to $CWD/.hipfire_kernels so parallel
-        // worktrees/agents on the same machine don't clobber each other's
-        // JIT'd .hsaco blobs. /tmp was shared state: two daemons from
-        // different git states wrote the same {name}.hsaco path and
-        // thrashed each other's hash sidecars. $CWD isolation fixes that.
-        // End-user / CI can pin the old location back via
-        // HIPFIRE_KERNEL_CACHE=/tmp/hipfire_kernels if tmpfs speed matters.
-        // Per-arch keying matters for hetero (gfx906 + gfx1031 in one process):
-        // without it, both arches would race for the same `{name}.hsaco` path,
-        // surviving correctness via the source+arch hash check but thrashing
-        // recompiles every cross-arch interleaving. Path layout matches the
-        // pre-compiled `kernels/compiled/{arch}/` install dir + the already-
-        // documented `.hipfire_kernels/{arch}/{name}.hsaco` shape in
-        // docs/perf-checkpoints/2026-05-04-gfx906-mmq-junroll.md.
-        let cache_root = std::env::var_os("HIPFIRE_KERNEL_CACHE")
-            .map(PathBuf::from)
-            .unwrap_or_else(|| PathBuf::from(".hipfire_kernels"));
+        // Hot JIT cache defaults to the shared `$HOME/.hipfire_kernels` root
+        // (overridable via `HIPFIRE_KERNEL_CACHE`), so parallel worktrees and
+        // daemons on one machine share compiled kernels instead of each
+        // recompiling into its own CWD dir. Sharing is safe because hot
+        // filenames are content-keyed (`{name}.{hash}.hsaco`, hash covering
+        // source + flags + arch + toolchain + ABI): distinct builds map to
+        // distinct paths and never clobber each other's blobs, and all entry
+        // writes are atomic (same-dir temp + rename) so a concurrent reader
+        // only ever sees a complete entry. Per-arch subdirs still isolate
+        // hetero processes (gfx906 + gfx1031) as before.
+        let cache_root = default_cache_root();
         let cache_dir = cache_root.join(arch);
         std::fs::create_dir_all(&cache_dir).map_err(|e| {
             hip_bridge::HipError::new(0, &format!("failed to create cache dir: {e}"))
@@ -758,11 +783,13 @@ impl KernelCompiler {
             }
         }
 
-        // Fall back to runtime compilation via hipcc into the hot cache.
-        let obj_path = self.cache_dir.join(format!("{name}.hsaco"));
-        let hash_path = self.cache_dir.join(format!("{name}.hash"));
+        // Hot entries are content-keyed (`{name}.{hash}.hsaco`): the filename
+        // IS the key, so a nonempty hit is by construction correct — no
+        // sidecar check, and no collision between builds sharing this root.
+        let stem = hot_stem(name, &src_hash);
+        let obj_path = self.cache_dir.join(hot_object_name(name, &src_hash));
 
-        if pair_valid(&obj_path, &hash_path, &src_hash) {
+        if nonempty_blob(&obj_path) {
             if let Some(dir) = self.writeback_dir() {
                 writeback_cold(name, &obj_path, &src_hash, dir, false);
             }
@@ -771,16 +798,40 @@ impl KernelCompiler {
             return Ok(&self.compiled[name]);
         }
 
+        // Legacy `{name}.hsaco` + hash fallback: entries written before
+        // content-keying, plus cold-seeded pairs. On a validated hit, promote
+        // once into the content-keyed name so later lookups take the direct
+        // path; if promotion fails the legacy path itself is still a valid hit.
+        let legacy_obj = self.cache_dir.join(format!("{name}.hsaco"));
+        let legacy_hash = self.cache_dir.join(format!("{name}.hash"));
+        if pair_valid(&legacy_obj, &legacy_hash, &src_hash) {
+            let hit_path = if publish_pair(&self.cache_dir, &stem, &legacy_obj, &src_hash, true)
+                .is_ok()
+            {
+                obj_path
+            } else {
+                legacy_obj
+            };
+            if let Some(dir) = self.writeback_dir() {
+                writeback_cold(name, &hit_path, &src_hash, dir, false);
+            }
+            self.ensure_radiowave_certification(name, &hit_path);
+            self.compiled.insert(name.to_string(), hit_path);
+            return Ok(&self.compiled[name]);
+        }
+
         if !self.has_hipcc {
-            // Nonempty unvalidated hot blob may still be usable on packaged installs.
-            if nonempty_blob(&obj_path) {
+            // Content-keyed hits returned above, so only a legacy unvalidated
+            // blob can still be usable on packaged installs (same warning as
+            // the precompiled path).
+            if nonempty_blob(&legacy_obj) {
                 eprintln!(
                     "  WARNING: {name}: using UNVALIDATED pre-compiled blob (hipcc unavailable)"
                 );
                 eprintln!(
                     "           Output may be incorrect. Install ROCm SDK or rebuild blobs with matching hashes."
                 );
-                self.compiled.insert(name.to_string(), obj_path);
+                self.compiled.insert(name.to_string(), legacy_obj);
                 return Ok(&self.compiled[name]);
             }
             return Err(
@@ -831,7 +882,7 @@ impl KernelCompiler {
 
         let module_flags = self.module_flags(name);
         let src_hash = self.cache_hash(name, source);
-        let obj_path = self.cache_dir.join(format!("{name}.hsaco"));
+        let obj_path = self.cache_dir.join(hot_object_name(name, &src_hash));
 
         Self::hipcc_compile_publish(
             &self.hipcc_bin,
@@ -1113,10 +1164,16 @@ impl KernelCompiler {
         extra_flags: &str,
         module_flags: &[String],
     ) -> HipResult<()> {
-        let src_path = cache_dir.join(format!("{name}.hip"));
-        let final_hsaco = cache_dir.join(format!("{name}.hsaco"));
+        // Content-keyed outputs: the source file, final blob, and temps all
+        // carry the hash, so concurrent builds compiling different sources
+        // under one module name never share a path. `name` stays the human
+        // label in messages. The hash sidecar is still published (same stem)
+        // for tooling that validates pairs; lookup needs only the blob.
+        let stem = hot_stem(name, src_hash);
+        let src_path = cache_dir.join(format!("{stem}.hip"));
+        let final_hsaco = cache_dir.join(format!("{stem}.hsaco"));
         let token = unique_token();
-        let tmp_obj = cache_dir.join(format!(".{name}.{token}.hsaco.tmp"));
+        let tmp_obj = cache_dir.join(format!(".{stem}.{token}.hsaco.tmp"));
 
         let cleanup_tmp = || {
             let _ = std::fs::remove_file(&tmp_obj);
@@ -1149,7 +1206,7 @@ impl KernelCompiler {
 
         // Publish blob then hash via the shared transactional helper.
         // On failure, leave prior durable pair intact (temps cleaned inside).
-        if let Err(e) = publish_pair(cache_dir, name, &tmp_obj, src_hash, true) {
+        if let Err(e) = publish_pair(cache_dir, &stem, &tmp_obj, src_hash, true) {
             cleanup_tmp();
             // If publish moved the temp already, final may exist without hash —
             // that is the safe invalid state (blob without certifying hash).
@@ -1164,7 +1221,7 @@ impl KernelCompiler {
         cleanup_tmp();
 
         // Defensive: final pair must be valid after publication.
-        let final_hash = cache_dir.join(format!("{name}.hash"));
+        let final_hash = cache_dir.join(format!("{stem}.hash"));
         if !pair_valid(&final_hsaco, &final_hash, src_hash) {
             return Err(hip_bridge::HipError::new(
                 0,
@@ -1216,11 +1273,12 @@ impl KernelCompiler {
                 }
             }
 
-            // Check temp cache with the same pair-valid helper.
-            let obj_path = self.cache_dir.join(format!("{name}.hsaco"));
-            let hash_path = self.cache_dir.join(format!("{name}.hash"));
+            // Hot lookup mirrors compile(): content-keyed hit first (correct
+            // by construction), then legacy pair with one-time promotion.
+            let stem = hot_stem(name, &src_hash);
+            let obj_path = self.cache_dir.join(hot_object_name(name, &src_hash));
 
-            if pair_valid(&obj_path, &hash_path, &src_hash) {
+            if nonempty_blob(&obj_path) {
                 if let Some(dir) = self.writeback_dir() {
                     writeback_cold(name, &obj_path, &src_hash, dir, false);
                 }
@@ -1228,15 +1286,31 @@ impl KernelCompiler {
                 continue;
             }
 
+            let legacy_obj = self.cache_dir.join(format!("{name}.hsaco"));
+            let legacy_hash = self.cache_dir.join(format!("{name}.hash"));
+            if pair_valid(&legacy_obj, &legacy_hash, &src_hash) {
+                let hit_path =
+                    if publish_pair(&self.cache_dir, &stem, &legacy_obj, &src_hash, true).is_ok() {
+                        obj_path
+                    } else {
+                        legacy_obj
+                    };
+                if let Some(dir) = self.writeback_dir() {
+                    writeback_cold(name, &hit_path, &src_hash, dir, false);
+                }
+                self.compiled.insert(name.to_string(), hit_path);
+                continue;
+            }
+
             if !self.has_hipcc {
-                if nonempty_blob(&obj_path) {
+                if nonempty_blob(&legacy_obj) {
                     eprintln!(
                         "  WARNING: {name}: using UNVALIDATED pre-compiled blob (hipcc unavailable)"
                     );
                     eprintln!(
                         "           Output may be incorrect. Install ROCm SDK or rebuild blobs with matching hashes."
                     );
-                    self.compiled.insert(name.to_string(), obj_path);
+                    self.compiled.insert(name.to_string(), legacy_obj);
                     continue;
                 }
                 return Err(
@@ -1288,7 +1362,7 @@ impl KernelCompiler {
                         &module_flags,
                     );
                     if result.is_ok() {
-                        let obj_path = cache_dir.join(format!("{name}.hsaco"));
+                        let obj_path = cache_dir.join(hot_object_name(&name, &src_hash));
                         // Write back to cold install dir (blob before hash).
                         if let Some(dir) = &writeback_dir {
                             writeback_cold(&name, &obj_path, &src_hash, dir, false);
@@ -1297,7 +1371,7 @@ impl KernelCompiler {
                     let i = done.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1;
                     let marker = if result.is_ok() { "✓" } else { "✗" };
                     eprintln!("  [{i:>3}/{n}] {marker} {name}");
-                    let obj_path = cache_dir.join(format!("{name}.hsaco"));
+                    let obj_path = cache_dir.join(hot_object_name(&name, &src_hash));
                     (name, obj_path, result)
                 });
                 handle
@@ -1698,6 +1772,170 @@ mod tests {
             base, toolchain_changed,
             "cache key must change when hipcc toolchain changes"
         );
+    }
+
+    #[test]
+    fn cache_key_covers_source_flags_and_arch() {
+        // The content key must be a pure function of (source, flags, arch):
+        // same triple → same key; changing any one of the three → new key.
+        // A hit is then by construction the right blob for this build.
+        let source = "__global__ void kernel() {}";
+        let base = test_compiler("", "hipcc 7.2").cache_hash("kernel", source);
+        assert_eq!(
+            base,
+            test_compiler("", "hipcc 7.2").cache_hash("kernel", source),
+            "same source + flags + arch must produce the same key"
+        );
+        assert_ne!(
+            base,
+            test_compiler("", "hipcc 7.2").cache_hash("kernel", "__global__ void kernel2() {}"),
+            "cache key must change when the source changes"
+        );
+        assert_ne!(
+            base,
+            test_compiler("-O0", "hipcc 7.2").cache_hash("kernel", source),
+            "cache key must change when compile flags change"
+        );
+        let mut other_arch = test_compiler("", "hipcc 7.2");
+        other_arch.arch = "gfx1100".to_string();
+        assert_ne!(
+            base,
+            other_arch.cache_hash("kernel", source),
+            "cache key must change when the target arch changes"
+        );
+    }
+
+    #[test]
+    fn hot_names_isolate_distinct_builds() {
+        // Content-keyed filenames: same (name, hash) → same path; any change
+        // → a different path, so daemons from different builds sharing one
+        // root never collide on an entry (the `named symbol not found` race).
+        assert_eq!(
+            hot_object_name("gemv_hfq4g256", "abc123"),
+            hot_object_name("gemv_hfq4g256", "abc123")
+        );
+        assert_ne!(
+            hot_object_name("gemv_hfq4g256", "abc123"),
+            hot_object_name("gemv_hfq4g256", "def456"),
+            "different source/flags/arch must map to a different entry path"
+        );
+        assert_ne!(
+            hot_object_name("gemv_hfq4g256", "abc123"),
+            hot_object_name("gemm_hfq4g128", "abc123"),
+            "different kernels must map to different entry paths"
+        );
+        let name = hot_object_name("gemv_hfq4g256", "abc123");
+        assert!(
+            name.contains("gemv_hfq4g256") && name.contains("abc123"),
+            "entry layout must stay self-describing: {name}"
+        );
+    }
+
+    #[test]
+    fn atomic_publish_never_shows_partial() {
+        // A concurrent reader must only ever observe a complete entry.
+        // Publish cycles several generations (distinct sizes + contents)
+        // while a reader thread samples the destination path; any truncation
+        // or interleave — the half-written object behind
+        // `named symbol not found` — fails the exact-equality check.
+        // No GPU needed: this exercises the same stage-temp + rename path
+        // every hot entry write uses.
+        let root = temp_root("atomic_publish");
+        let _ = std::fs::remove_dir_all(&root);
+        let dest = root.join("dest");
+        let src_dir = root.join("src");
+        std::fs::create_dir_all(&dest).unwrap();
+        std::fs::create_dir_all(&src_dir).unwrap();
+
+        let name = "k";
+        let gens: Vec<Vec<u8>> = (0..8u8).map(|g| vec![g; 1024 * (g as usize + 1)]).collect();
+        let seed = src_dir.join("seed.hsaco");
+        std::fs::write(&seed, &gens[0]).unwrap();
+        publish_pair(&dest, name, &seed, "gen0", true).unwrap();
+
+        let done = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let reader_done = std::sync::Arc::clone(&done);
+        let dest_path = dest.join(format!("{name}.hsaco"));
+
+        // The reader owns its observations locally and returns them through
+        // the scoped join — no shared lock between the threads.
+        let (seen, missings) = std::thread::scope(|scope| {
+            let reader = scope.spawn(move || {
+                let mut seen: Vec<Vec<u8>> = Vec::new();
+                let mut missings = 0;
+                let mut samples = 0;
+                while samples < 500 {
+                    match std::fs::read(&dest_path) {
+                        Ok(bytes) => {
+                            if !seen.contains(&bytes) {
+                                seen.push(bytes);
+                            }
+                        }
+                        Err(_) => missings += 1,
+                    }
+                    samples += 1;
+                    if reader_done.load(std::sync::atomic::Ordering::SeqCst) && samples >= 100 {
+                        break;
+                    }
+                }
+                (seen, missings)
+            });
+            for (g, content) in gens.iter().enumerate().skip(1) {
+                let src = src_dir.join(format!("gen{g}.hsaco"));
+                std::fs::write(&src, content).unwrap();
+                publish_pair(&dest, name, &src, &format!("gen{g}"), true).unwrap();
+            }
+            done.store(true, std::sync::atomic::Ordering::SeqCst);
+            reader.join().unwrap()
+        });
+
+        assert_eq!(
+            missings, 0,
+            "atomic rename must never expose a missing entry once seeded"
+        );
+        assert!(
+            seen.iter().all(|b| gens.contains(b)),
+            "reader saw a partial/mixed entry: sizes {:?}",
+            seen.iter().map(|b| b.len()).collect::<Vec<_>>()
+        );
+        assert!(
+            seen.iter().any(|b| *b != gens[0]),
+            "reader never observed a new generation — test sampled nothing"
+        );
+        assert!(
+            leftover_temps(&dest).is_empty(),
+            "publish series must leave no temps: {:?}",
+            leftover_temps(&dest)
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn default_cache_root_honors_env_and_shared_default() {
+        // Race-free (no env mutation): assert the ambient resolution.
+        match std::env::var_os("HIPFIRE_KERNEL_CACHE") {
+            Some(v) => assert_eq!(
+                default_cache_root(),
+                PathBuf::from(v),
+                "explicit HIPFIRE_KERNEL_CACHE must win"
+            ),
+            None => {
+                let root = default_cache_root();
+                assert_eq!(
+                    root.file_name().and_then(|n| n.to_str()),
+                    Some(".hipfire_kernels"),
+                    "default must be a single shared .hipfire_kernels root, not the CWD"
+                );
+                if let Some(home) = std::env::var_os("HOME") {
+                    assert_eq!(
+                        root,
+                        PathBuf::from(home).join(".hipfire_kernels"),
+                        "default must live under HOME so all worktrees share it"
+                    );
+                }
+            }
+        }
     }
 
     #[test]
@@ -2169,17 +2407,19 @@ mod tests {
         std::fs::write(hot.join(format!("{name}.hash")), "stale").unwrap();
 
         let path = c.compile(name, source).expect("fake hipcc must succeed");
-        assert_eq!(path, &hot.join(format!("{name}.hsaco")));
+        // Hot outputs are content-keyed: the blob carries the full cache hash.
+        let keyed = hot.join(hot_object_name(name, &src_hash));
+        assert_eq!(path, &keyed);
         assert_eq!(std::fs::read(path).unwrap(), b"COMPILED_OK");
         assert_eq!(
-            std::fs::read_to_string(hot.join(format!("{name}.hash")))
+            std::fs::read_to_string(hot.join(format!("{name}.{src_hash}.hash")))
                 .unwrap()
                 .trim(),
             src_hash
         );
         assert!(pair_valid(
-            &hot.join(format!("{name}.hsaco")),
-            &hot.join(format!("{name}.hash")),
+            &hot.join(hot_object_name(name, &src_hash)),
+            &hot.join(format!("{name}.{src_hash}.hash")),
             &src_hash
         ));
         assert!(

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -1058,52 +1058,66 @@ impl Gpu {
         }
     }
 
-    /// Bounded stream sync: like `hipStreamSynchronize` (or
-    /// `hipDeviceSynchronize` on the null stream) but returns a reportable
-    /// error naming the last-launched kernel instead of blocking forever when
-    /// the GPU hangs.
+    /// Poll interval for [`Self::sync_with_deadline`]: 2 ms. Coarse enough
+    /// never to spin a core, fine-grained enough for a deadline measured in
+    /// seconds.
+    pub(crate) const SYNC_POLL_INTERVAL: std::time::Duration =
+        std::time::Duration::from_millis(2);
+
+    /// Bounded stream sync: record a completion event on this `Gpu`'s stream
+    /// (or the null stream) and poll `hipEventQuery` until it completes or
+    /// `deadline` elapses.
     ///
-    /// The blocking HIP call runs on a scoped thread and the caller waits at
-    /// most `deadline`; on timeout the error names `last_launched_kernel`.
-    /// The timed-out sync thread is left parked inside HIP — the stream is
-    /// still busy and nothing here resets device state, so the caller must
-    /// treat the device as suspect after this error.
+    /// No helper thread: the query is non-blocking, so the deadline is real —
+    /// on timeout this returns `Err` naming `last_launched_kernel` while the
+    /// GPU work is still outstanding.
+    ///
+    /// Returning `Err` does NOT cancel the outstanding work. The contract is
+    /// "I stopped waiting", not "the GPU stopped": the stream is still busy
+    /// and nothing here resets device state, so the caller must treat the
+    /// device as suspect and must not touch buffers the outstanding work may
+    /// still write.
     ///
     /// Existing `sync()` callers keep their unbounded semantics; use this
     /// where a deadline is already meaningful (collective rendezvous,
     /// watchdog paths) rather than migrating every sync.
     pub fn sync_with_deadline(&self, deadline: std::time::Duration) -> HipResult<()> {
         self.bind_thread()?;
-        // `Stream` is Send but not Sync, so `&Stream` cannot be shared into
-        // the scoped waiter — the raw handle crosses as a `usize` instead.
-        let stream_raw: Option<usize> =
-            self.active_stream.as_ref().map(|s| s.as_raw() as usize);
+        // Timing-disabled event: a pure completion probe, no profiling state.
+        let event = self
+            .hip
+            .event_create_with_flags(hip_bridge::HIP_EVENT_DISABLE_TIMING)?;
+        self.hip.event_record(&event, self.active_stream.as_ref())?;
         let last_kernel = self.last_kernel.clone();
-        // Share `&HipRuntime` (Sync), never `&Gpu`/`&Stream` (both !Sync),
-        // into the scoped waiter. The handle crosses as a `usize` (Send);
-        // it is the live `hipStream_t` of `self.active_stream`, borrowed by
-        // the enclosing `&self` for the whole scope.
-        let hip = &self.hip;
-        let device_id = self.device_id;
-        let (tx, rx) = std::sync::mpsc::channel();
-        std::thread::scope(|scope| {
-            scope.spawn(move || {
-                // HIP device affinity is per-thread: bind the waiter to the
-                // same device before syncing its stream.
-                let result = hip.set_device(device_id).and_then(|()| match stream_raw {
-                    // SAFETY: `stream_raw` is the live handle of
-                    // `self.active_stream` for the whole scope; only
-                    // synchronize is issued on it.
-                    Some(raw) => hip.stream_synchronize_raw(raw as *mut std::ffi::c_void),
-                    None => hip.device_synchronize(),
-                });
-                let _ = tx.send(result);
-            });
-            match rx.recv_timeout(deadline) {
-                Ok(result) => result,
-                Err(_) => Err(Self::deadline_exceeded(last_kernel.as_deref(), deadline)),
+        let result = Self::poll_until_ready(deadline, last_kernel.as_deref(), || {
+            self.hip.event_query(&event)
+        });
+        // Best-effort teardown. On timeout the outstanding GPU work is NOT
+        // cancelled — this call only stopped waiting. Never shadow the poll
+        // result with a destroy error.
+        let _ = self.hip.event_destroy(event);
+        result
+    }
+
+    /// Poll `query` until it reports ready or `deadline` elapses. Query
+    /// errors propagate immediately; only `hipErrorNotReady` keeps polling.
+    /// Split from [`Self::sync_with_deadline`] so the timeout path is
+    /// unit-testable on CPU with a stubbed query.
+    pub(crate) fn poll_until_ready(
+        deadline: std::time::Duration,
+        last_kernel: Option<&str>,
+        mut query: impl FnMut() -> HipResult<bool>,
+    ) -> HipResult<()> {
+        let start = std::time::Instant::now();
+        loop {
+            if query()? {
+                return Ok(());
             }
-        })
+            if start.elapsed() >= deadline {
+                return Err(Self::deadline_exceeded(last_kernel, deadline));
+            }
+            std::thread::sleep(Self::SYNC_POLL_INTERVAL);
+        }
     }
 
     /// Bind this `Gpu`'s device on the calling thread. Delegates to
@@ -5310,10 +5324,8 @@ mod tests {
 
     #[test]
     fn deadline_error_names_last_kernel() {
-        // The blocking-sync timeout path cannot be driven without a GPU
-        // (and must not be: no GPU work in unit tests), so the error is
-        // constructed directly — the same constructor `sync_with_deadline`
-        // uses on timeout.
+        // Constructor-level pin; the timeout path itself is driven below
+        // through `poll_until_ready` with a stubbed query.
         let e = Gpu::deadline_exceeded(
             Some("gemv_hfq4g256"),
             std::time::Duration::from_secs(5),
@@ -5331,5 +5343,46 @@ mod tests {
         let s = e.to_string();
         assert!(s.contains("no kernel"), "states nothing was recorded: {s}");
         assert!(e.context.is_none());
+    }
+
+    #[test]
+    fn sync_timeout_returns_in_bounded_wall_time() {
+        // The test review asked for: a query that never reports ready (a
+        // hung GPU) must produce `Err` within bounded wall-clock time. The
+        // old scoped-thread design would block forever here on the join;
+        // the event poll returns. No GPU needed — the query is stubbed.
+        let deadline = std::time::Duration::from_millis(50);
+        let start = std::time::Instant::now();
+        let err = Gpu::poll_until_ready(deadline, Some("hung_kernel"), || Ok(false))
+            .expect_err("a never-ready query must time out");
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "deadline escaped its bound: {elapsed:?}"
+        );
+        assert!(
+            elapsed >= deadline,
+            "returned before the deadline elapsed: {elapsed:?}"
+        );
+        let s = err.to_string();
+        assert!(s.contains("hung_kernel"), "timeout names the kernel: {s}");
+    }
+
+    #[test]
+    fn poll_ready_immediately_returns_ok() {
+        let result = Gpu::poll_until_ready(std::time::Duration::from_secs(5), None, || Ok(true));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn poll_propagates_query_errors() {
+        // A real query failure (bad handle, lost device) is not "not ready".
+        let err = Gpu::poll_until_ready(
+            std::time::Duration::from_secs(5),
+            Some("k"),
+            || Err(hip_bridge::HipError::new(999, "boom")),
+        )
+        .expect_err("query errors must propagate");
+        assert!(err.to_string().contains("boom"), "{err}");
     }
 }

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -643,6 +643,12 @@ pub struct Gpu {
     orphan_vmm_arenas: Vec<VmmArena>,
     /// When set, all kernel launches go to this stream instead of null stream.
     pub active_stream: Option<hip_bridge::Stream>,
+    /// Name of the most recently launched kernel on this `Gpu`'s stream.
+    /// Recorded in `launch_maybe_blob_bound` (the shared dispatch funnel) on
+    /// every successful launch so `sync_with_deadline` can name the suspect
+    /// when a sync times out. Scratch-helper converts and the optional CK
+    /// path bypass this funnel and are deliberately not tracked here.
+    last_kernel: Option<String>,
     /// Scratch buffers for FWHT rotation, FP16/FP8 activation conversion, etc.
     pub scratch: crate::scratch::ScratchState,
     /// Model-scoped Redline warmup recorder and fail-closed backend gate.
@@ -1013,6 +1019,93 @@ impl Gpu {
         self.active_stream.as_ref()
     }
 
+    /// Default bound for [`Self::sync_with_deadline`]: five minutes. Long
+    /// enough that a healthy prefill/decode sync never trips it, short enough
+    /// that a hung GPU becomes a reportable error in one operator shift.
+    pub const GPU_SYNC_DEADLINE: std::time::Duration = std::time::Duration::from_secs(300);
+
+    /// Name of the kernel most recently launched through the dispatch funnel,
+    /// if any. Used to attribute a timed-out sync to the suspect kernel.
+    pub fn last_launched_kernel(&self) -> Option<&str> {
+        self.last_kernel.as_deref()
+    }
+
+    /// Build the timeout error directly (no device call). Split out so the
+    /// message is unit-testable on CPU-only hosts where the blocking-sync
+    /// path cannot be driven.
+    pub fn deadline_exceeded(
+        last_kernel: Option<&str>,
+        deadline: std::time::Duration,
+    ) -> hip_bridge::HipError {
+        match last_kernel {
+            Some(kernel) => hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "GPU sync exceeded deadline of {deadline:?}: \
+                     last kernel launched on this stream was '{kernel}' — \
+                     suspect a hang in '{kernel}' (stream still busy; \
+                     state was NOT reset)"
+                ),
+            )
+            .with_kernel(kernel),
+            None => hip_bridge::HipError::new(
+                0,
+                &format!(
+                    "GPU sync exceeded deadline of {deadline:?} with no kernel \
+                     recorded on this stream (stream still busy; state was NOT reset)"
+                ),
+            ),
+        }
+    }
+
+    /// Bounded stream sync: like `hipStreamSynchronize` (or
+    /// `hipDeviceSynchronize` on the null stream) but returns a reportable
+    /// error naming the last-launched kernel instead of blocking forever when
+    /// the GPU hangs.
+    ///
+    /// The blocking HIP call runs on a scoped thread and the caller waits at
+    /// most `deadline`; on timeout the error names `last_launched_kernel`.
+    /// The timed-out sync thread is left parked inside HIP — the stream is
+    /// still busy and nothing here resets device state, so the caller must
+    /// treat the device as suspect after this error.
+    ///
+    /// Existing `sync()` callers keep their unbounded semantics; use this
+    /// where a deadline is already meaningful (collective rendezvous,
+    /// watchdog paths) rather than migrating every sync.
+    pub fn sync_with_deadline(&self, deadline: std::time::Duration) -> HipResult<()> {
+        self.bind_thread()?;
+        // `Stream` is Send but not Sync, so `&Stream` cannot be shared into
+        // the scoped waiter — the raw handle crosses as a `usize` instead.
+        let stream_raw: Option<usize> =
+            self.active_stream.as_ref().map(|s| s.as_raw() as usize);
+        let last_kernel = self.last_kernel.clone();
+        // Share `&HipRuntime` (Sync), never `&Gpu`/`&Stream` (both !Sync),
+        // into the scoped waiter. The handle crosses as a `usize` (Send);
+        // it is the live `hipStream_t` of `self.active_stream`, borrowed by
+        // the enclosing `&self` for the whole scope.
+        let hip = &self.hip;
+        let device_id = self.device_id;
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::scope(|scope| {
+            scope.spawn(move || {
+                // HIP device affinity is per-thread: bind the waiter to the
+                // same device before syncing its stream.
+                let result = hip.set_device(device_id).and_then(|()| match stream_raw {
+                    // SAFETY: `stream_raw` is the live handle of
+                    // `self.active_stream` for the whole scope; only
+                    // synchronize is issued on it.
+                    Some(raw) => hip.stream_synchronize_raw(raw as *mut std::ffi::c_void),
+                    None => hip.device_synchronize(),
+                });
+                let _ = tx.send(result);
+            });
+            match rx.recv_timeout(deadline) {
+                Ok(result) => result,
+                Err(_) => Err(Self::deadline_exceeded(last_kernel.as_deref(), deadline)),
+            }
+        })
+    }
+
     /// Bind this `Gpu`'s device on the calling thread. Delegates to
     /// `crate::graph::bind_thread`.
     #[inline]
@@ -1210,6 +1303,7 @@ impl Gpu {
             vmm_arenas: HashMap::new(),
             orphan_vmm_arenas: Vec::new(),
             active_stream: None,
+            last_kernel: None,
             scratch: crate::scratch::ScratchState {
                 mq_signs1: None,
                 mq_signs2: None,
@@ -2232,7 +2326,7 @@ impl Gpu {
         blob_builder: impl FnOnce() -> hip_bridge::KernargBlob,
     ) -> HipResult<()> {
         let record = self.replay.is_recording();
-        if record || self.graphs.capture_mode || self.flags.force_blob_path {
+        let result: HipResult<()> = if record || self.graphs.capture_mode || self.flags.force_blob_path {
             let mut blob = blob_builder();
             blob.pad_to(16);
             if record {
@@ -2337,7 +2431,11 @@ impl Gpu {
                     params,
                 )
             }
+        };
+        if result.is_ok() {
+            self.last_kernel = Some(func_name.to_string());
         }
+        result.map_err(|e| e.with_kernel(func_name))
     }
 
     /// Diagnostic oracle for Redline prefix localization: relaunch the exact
@@ -2484,6 +2582,7 @@ impl Gpu {
             self.hip
                 .launch_kernel_blob(func, grid, block, shared_mem, self.stream_ref(), kernargs)
         }
+        .map_err(|e| e.with_kernel(func_name))
     }
 
     /// Compile and load a kernel, caching the result.
@@ -4727,6 +4826,7 @@ mod tests {
     use super::MQ3G256V2_GROUP_BYTES;
     use super::MQ5G256V2_GROUP_BYTES;
     use super::MQ6G256V2_GROUP_BYTES;
+    use super::Gpu;
 
     #[test]
     fn q8hfq_row_stride_matches_legacy_formula() {
@@ -5206,5 +5306,30 @@ mod tests {
         use crate::replay::{ReplayBackendRequest, ReplayController};
         let ctrl = ReplayController::new(ReplayBackendRequest::Hip);
         assert_eq!(ctrl.recorded_launches().len(), 0);
+    }
+
+    #[test]
+    fn deadline_error_names_last_kernel() {
+        // The blocking-sync timeout path cannot be driven without a GPU
+        // (and must not be: no GPU work in unit tests), so the error is
+        // constructed directly — the same constructor `sync_with_deadline`
+        // uses on timeout.
+        let e = Gpu::deadline_exceeded(
+            Some("gemv_hfq4g256"),
+            std::time::Duration::from_secs(5),
+        );
+        let s = e.to_string();
+        assert!(s.contains("gemv_hfq4g256"), "names the kernel: {s}");
+        assert!(s.contains("5s"), "names the deadline: {s}");
+        let ctx = e.context.expect("timeout carries launch context");
+        assert_eq!(ctx.kernel, "gemv_hfq4g256");
+    }
+
+    #[test]
+    fn deadline_error_without_kernel_says_so() {
+        let e = Gpu::deadline_exceeded(None, std::time::Duration::from_secs(5));
+        let s = e.to_string();
+        assert!(s.contains("no kernel"), "states nothing was recorded: {s}");
+        assert!(e.context.is_none());
     }
 }

--- a/crates/rdna-compute/src/scratch.rs
+++ b/crates/rdna-compute/src/scratch.rs
@@ -152,7 +152,7 @@ pub(crate) fn launch_maybe_blob(
     blob_builder: impl FnOnce() -> KernargBlob,
 ) -> HipResult<()> {
     let record = replay.as_ref().map_or(false, |r| r.is_recording());
-    if record || capture_mode || force_blob_path {
+    let result: HipResult<()> = if record || capture_mode || force_blob_path {
         let mut blob = blob_builder();
         blob.pad_to(16);
         if record {
@@ -226,7 +226,11 @@ pub(crate) fn launch_maybe_blob(
     } else {
         let func = &functions[func_name];
         unsafe { hip.launch_kernel(func, grid, block, shared_mem, stream, params) }
-    }
+    };
+    // Scratch converts share the dispatch stream: a failure here names the
+    // kernel the same way the dispatch funnel does. Deliberately no
+    // last-kernel recording — this helper has no `Gpu` to record into.
+    result.map_err(|e| e.with_kernel(func_name))
 }
 
 /// Predicate for the FP16/FP8 scratch fast path. The convert kernel must run

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -249,7 +249,7 @@ kernels/src/<name>.gfx12.hip            # family override (e.g. gfx1200+gfx1201)
         │  scripts/compile-kernels.sh  (chip → family → base)
         ▼
 kernels/compiled/<arch>/…               # packaged / tree prebuild output
-./.hipfire_kernels/<arch>/…             # default JIT cache (or HIPFIRE_KERNEL_CACHE)
+~/.hipfire_kernels/<arch>/<name>.<hash>.hsaco  # default JIT cache (or HIPFIRE_KERNEL_CACHE)
 ```
 
 On startup the runtime prefers a hash-matching precompiled blob. Missing or


### PR DESCRIPTION
Slice 7 (GPU QOL), last before the MSRV pin. No GPU work per slice constraints — hardware acceptance (induced hang, cold-start cache across two worktrees, xt fixture) is for the parent.

1. sync_with_deadline (rdna-compute): Gpu records the last kernel name in launch_maybe_blob_bound and gains a bounded stream/device sync (scoped waiter thread, raw handle crosses as usize, waiter binds the same device). Timeout names the suspect kernel; no existing sync() caller changes semantics. Used where a deadline is meaningful: host-allreduce producer sync (hipfire-runtime).
2. HipError context (hip-bridge): optional boxed LaunchContext (kernel + callsite via #[track_caller] with_kernel), wired at the dispatch / blob / scratch funnels. Display appends [kernel=... at file:line]; context-free rendering is byte-identical.
3. Kernel cache (rdna-compute): default root is now shared ~/.hipfire_kernels (env override honored; CWD fallback only without HOME), hot filenames content-keyed {name}.{hash}.hsaco so a hit is by construction correct and cross-build daemons never share a path. Writes stay atomic (temp + rename). Legacy/cold pairs still validate with one-time promotion; packaged kernels/compiled layout untouched.

Acceptance: cargo check -p rdna-compute -p hip-bridge -p hipfire-runtime clean; cargo test -p hip-bridge 17 passed; cargo test -p rdna-compute 216 passed (incl. new cache-key, atomic-publish, deadline-message, Display tests).