### PR TITLE
fix(hw-gate): pin the DFlash route to the qcal draft present on both hosts

### DIFF
--- a/scripts/hw-gate/fixtures.json
+++ b/scripts/hw-gate/fixtures.json
@@ -14,11 +14,7 @@
       "sha256": "86a5f80fd29d545abb1093dead242725ced6d68b8607c6d566d897b1a82442dc",
       "size_bytes": 14984158208,
       "arch_id": 5,
-      "why": "Canonical dense trunk (AGENTS.md pinned fixture); Qwen3.5-family text artifact whose embedded config carries vision_config with no vision tower.",
-      "dflash_draft": [
-        "qwen36-27b-dflash-mq4.hfq",
-        "qwen38-27b-dflash-mq4.hfq"
-      ]
+      "why": "Canonical dense trunk (AGENTS.md pinned fixture); Qwen3.5-family text artifact whose embedded config carries vision_config with no vision tower."
     },
     {
       "tag": "ornith-1.5:35b-a3b-mq4r",
@@ -44,9 +40,10 @@
       "arch_id": 5,
       "why": "MQ4V2 xt tier \u2014 the neutral-header v2 quant family (537a292df) that the device-mesh series refused.",
       "dflash_draft": [
-        "qwen38-27b-dflash-mq4.hfq",
-        "qwen36-27b-dflash-mq4.hfq"
-      ]
+        "~/qcal/ladder-v2/drafts/qwen3.8-27b-dflash.mq4v2.hfq"
+      ],
+      "dflash_draft_sha256": "d0a74a232a0e2166d889f823e91e0fbf778d21dd9668d7de055cdecb065401bc",
+      "dflash_draft_why": "The draft the canonical fixture identity was measured with (md5 013395583cd0 alongside target e45d15bfe0c9): 157 tokens / 11 cycles / tau 13.1818 / accept 0.8788. Present and byte-identical on both gate hosts under ~/qcal/ladder-v2/drafts."
     }
   ],
   "buckets": {

--- a/scripts/hw-gate/run.py
+++ b/scripts/hw-gate/run.py
@@ -541,14 +541,39 @@ def _run_harness_mode(repo, fixture, env_base, logs_dir, device, mode, harness_c
         declared = fixture.get("dflash_draft")
         candidates = [declared] if isinstance(declared, str) else list(declared or [])
         models_root = Path(models_dir).expanduser()
-        present = [models_root / c for c in candidates if (models_root / c).is_file()]
+
+        def resolve_candidate(c: str) -> Path:
+            """A bare filename lives in the models dir; anything path-shaped is
+            taken as given. The 3.8 V2 ladder's drafts live under
+            ~/qcal/ladder-v2/drafts on BOTH hosts, outside the models dir, and
+            they are the drafts the canonical fixture identity was measured
+            with -- so the manifest has to be able to name them."""
+            p = Path(c).expanduser()
+            return p if ("/" in c or c.startswith("~")) else models_root / c
+
+        resolved = [resolve_candidate(c) for c in candidates]
+        present = [p for p in resolved if p.is_file()]
         if not candidates:
             return {"exit": 0, "seconds": 0.0, "rows": [], "status": "skip",
                     "reason": f"fixture {tag} declares no dflash_draft"}
         if not present:
             return {"exit": 0, "seconds": 0.0, "rows": [], "status": "skip",
-                    "reason": f"none of {candidates} present under {models_root} for fixture {tag}"}
+                    "reason": f"none of {[str(p) for p in resolved]} present for fixture {tag}"}
         draft_path = present[0]
+        # A wrong draft does not fail loudly, it silently changes tau -- which
+        # is exactly the kind of number that then gets quoted. So the draft is
+        # pinned like the target: mismatch is a hard fail, not a skip.
+        expected_draft_sha = fixture.get("dflash_draft_sha256", "")
+        if expected_draft_sha:
+            h = hashlib.sha256()
+            with open(draft_path, "rb") as fh:
+                for chunk in iter(lambda: fh.read(8 * 1024 * 1024), b""):
+                    h.update(chunk)
+            actual_draft_sha = h.hexdigest()
+            if actual_draft_sha != expected_draft_sha:
+                return {"exit": 2, "seconds": 0.0, "rows": [], "status": "fail",
+                        "reason": (f"dflash_draft {draft_path} sha256 mismatch: expected "
+                                   f"{expected_draft_sha[:16]}…, got {actual_draft_sha[:16]}…")}
     # per-fixture home: subdirectory of gate home
     gate_home = env_base.get("HIPFIRE_HOME") or str(Path.home() / ".hipfire")
     per_home = Path(gate_home) / f"{safe_tag}-{mode}"

--- a/scripts/hw-gate/tests/test_run.py
+++ b/scripts/hw-gate/tests/test_run.py
@@ -978,3 +978,40 @@ def test_fixtures_manifest_declares_dflash_routes(tmp_path):
     for tag, drafts in declared.items():
         if drafts is not None:
             assert isinstance(drafts, list) and drafts, f"{tag} dflash_draft must be a non-empty list"
+
+
+def test_dflash_draft_can_live_outside_the_models_dir(tmp_path, monkeypatch):
+    """The 3.8 V2 ladder's drafts live under ~/qcal/ladder-v2/drafts on both
+    hosts, not in the models dir, and they are the drafts the canonical
+    identity was measured with (draft md5 013395583cd0 / target e45d15bfe0c9).
+    A manifest that can only name files inside the models dir cannot pin them.
+    """
+    outside = tmp_path / "qcal" / "drafts"
+    outside.mkdir(parents=True)
+    draft = outside / "qwen3.8-27b-dflash.mq4v2.hfq"
+    draft.write_text("draft")
+    fix = {"tag": "qwen3.8:27b-mq4-xt", "file": "x.mq4", "dflash_draft": [str(draft)]}
+    argv, res = _dflash_env(tmp_path, monkeypatch, fix, "battery-dflash", [])
+    assert res["status"] == "pass", res
+    assert argv[argv.index("--draft") + 1] == str(draft)
+
+
+def test_a_mismatched_draft_fails_rather_than_skewing_tau(tmp_path, monkeypatch):
+    """A wrong draft does not fail loudly, it silently changes tau. Pin it."""
+    outside = tmp_path / "qcal"
+    outside.mkdir(parents=True)
+    draft = outside / "d.hfq"
+    draft.write_text("not the pinned draft")
+    fix = {"tag": "qwen3.8:27b-mq4-xt", "file": "x.mq4", "dflash_draft": [str(draft)],
+           "dflash_draft_sha256": "0" * 64}
+    argv, res = _dflash_env(tmp_path, monkeypatch, fix, "battery-dflash", [])
+    assert res["status"] == "fail", res
+    assert "sha256 mismatch" in res["reason"]
+    assert argv is None  # never speculated with the wrong draft
+
+
+def test_manifest_pins_the_canonical_xt_draft():
+    manifest = json.loads((Path(run_mod.__file__).parent / "fixtures.json").read_text())
+    xt = [f for f in manifest["fixtures"] if f["tag"] == "qwen3.8:27b-mq4-xt"][0]
+    assert xt["dflash_draft"] == ["~/qcal/ladder-v2/drafts/qwen3.8-27b-dflash.mq4v2.hfq"]
+    assert xt["dflash_draft_sha256"] == "d0a74a232a0e2166d889f823e91e0fbf778d21dd9668d7de055cdecb065401bc"


### PR DESCRIPTION
You were right — I was looking in the wrong place. #718 concluded DFlash coverage was asymmetric (hiptrx holding a qwen36 draft, hipx a qwen38 one) and left one lane recording `skip`. That conclusion came from looking only in `~/.hipfire/models`.

**Both hosts carry the whole 3.8 V2 draft ladder under `~/qcal/ladder-v2/drafts`:**

```
qwen3.8-27b-dflash.mq2v2.hfq   760353792
qwen3.8-27b-dflash.mq3v2.hfq   984978432
qwen3.8-27b-dflash.mq4v2.hfq  1209603072
qwen3.8-27b-dflash.mq5v2.hfq  1434227712
qwen3.8-27b-dflash.mq6v2.hfq  1658852352
```

Byte-identical across hosts, verified just now. And the mq4v2 draft is *the* one the canonical identity was measured with — md5 `013395583cd0` against target `e45d15bfe0c9` (`~/qcal/ladder-v2/artifacts/qwen3.8-27b.mq4v2.xt.hfq`), giving 157 tokens / 11 cycles / τ 13.1818 / accept 0.8788. So there was nothing to pull; the manifest just could not *name* a draft outside the models dir.

## Change

- `dflash_draft` candidates are path-aware: a bare filename still resolves under the models dir, anything path-shaped or `~`-prefixed is taken as given.
- The xt fixture pins `~/qcal/ladder-v2/drafts/qwen3.8-27b-dflash.mq4v2.hfq` **with its sha256**, so both lanes speculate against the same artifact the identity was measured with, and `battery-dflash`/`chain-dflash` never skip.
- The draft is verified like the target: **sha256 mismatch is a hard fail, not a skip.** A wrong draft doesn't fail loudly, it silently changes τ — and τ is exactly the number that ends up quoted.
- `qwen3.6:27b` no longer declares a draft: 3.8 mq4v2 supersedes it, and the xt fixture carries the route on both lanes.

## Tests

Draft outside the models dir resolves and reaches the harness; a mismatched sha256 fails *without ever speculating*; the manifest pins the canonical draft and hash. **132/132** hw-gate tests pass.

Policy-floor by construction, so it cannot self-merge.