### PR TITLE
fix(hw-gate): do not re-gate a head that is already on staging

### DIFF
--- a/.github/workflows/hw-gate.yml
+++ b/.github/workflows/hw-gate.yml
@@ -80,7 +80,10 @@ jobs:
       # true when this event should (re)run the seats and hardware: every code
       # event, plus the `hw-run` label. Other label events only re-evaluate
       # the recorded decision.
-      run_hw: ${{ steps.pr.outputs.run_hw }}
+      # `false` when the head is already on the staging branch, so a rung that
+      # merged to `beta` (and stays OPEN until the maintainer promotes) does
+      # not re-gate itself on every later touch of its branch.
+      run_hw: ${{ steps.staged.outputs.staged == 'true' && 'false' || steps.pr.outputs.run_hw }}
     steps:
       - name: Base checkout (gate scripts come from the base branch)
         uses: actions/checkout@v4
@@ -118,6 +121,24 @@ jobs:
           fi
       - name: Fetch PR head
         run: git fetch --no-tags origin "${{ steps.pr.outputs.head_sha }}"
+      - name: Skip a head already merged to staging
+        id: staged
+        # A rung that merged to `beta` stays OPEN by design: promoting
+        # beta -> master is the maintainer's call, so the PR is not closed and
+        # `pull_request.merged` is false. Every later touch of its branch then
+        # re-gates work that is already staged -- #692 and #723 both re-ran
+        # within minutes of their staging merges on 2026-09-04, taking the
+        # runner from live rungs. If the head is an ancestor of the staging
+        # branch, the evidence exists and the hardware has nothing to add.
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --quiet origin "$HW_GATE_STAGING"
+          if git merge-base --is-ancestor "${{ steps.pr.outputs.head_sha }}" "origin/$HW_GATE_STAGING"; then
+            echo "staged=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::head ${{ steps.pr.outputs.head_sha }} is already on $HW_GATE_STAGING; skipping hardware"
+          else
+            echo "staged=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Select buckets and parse the author's request
         id: sel
         run: |


### PR DESCRIPTION
A rung that merges to `beta` stays **OPEN** by design — promoting `beta → master` is your call — so `pull_request.merged` is false and #712's merged-PR guard does not apply. Every later touch of that branch re-runs the full gate on work that is already staged.

Observed twice in the last hour: **#692 and #723 both re-ran within minutes of their staging merges**, taking the runner from live rungs. The same pattern accounts for several of the runs I cancelled by hand tonight.

## Change

`select` asks whether the head is an ancestor of the staging branch. If it is, the evidence exists and the hardware has nothing to add, so `run_hw` is false: lanes, Sol's verdict and the decide phase all skip, and the recorded decision still governs the status. The PR is untouched, no labels change.

An **ancestor** test rather than SHA equality, deliberately: a rung merges as a staging commit whose *parent* is the head, so equality would never match — and an ancestor test also covers a branch that was merged and then pushed again with no new work.

`workflow_dispatch` is unaffected, so a manual re-gate of a staged rung still runs. That is the escape hatch for re-measuring after a gate fix, which is exactly what #702 needed tonight.

**132/132** hw-gate tests pass; the workflow parses and the `select` job's step list and `run_hw` expression were both checked.

Policy-floor by construction, so it cannot self-merge.