### PR TITLE
fix(vmm): map full reservation in one segment on Windows

### DIFF
--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -3065,6 +3065,17 @@ impl Gpu {
             .checked_mul(dtype.size())
             .ok_or_else(|| HipError::new(0, "VMM tensor byte size overflowed"))?;
         let mut arena = VmmArena::reserve(&self.hip, self.device_id, byte_size)?;
+        // WINDOWS FIX (2026-09-09): hipMemCreate/hipMemMap on Windows/ROCm 7.2
+        // (gfx1100) maps a second, later segment onto the SAME physical pages as
+        // the first (vmm_arena_smoke boundary-growth assert fails; every
+        // subsequent KV growth corrupts all prior KV -> token soup). Single
+        // segment maps are proven correct. So on Windows, map the FULL
+        // reservation in one map_next up front instead of growing in small
+        // segments; grow_vmm_tensor then becomes a no-op (already fully
+        // mapped). Costs up-front VRAM for the whole reservation; correctness
+        // over on-demand commit on the platform whose driver breaks growth.
+        #[cfg(windows)]
+        let initial_mapped_bytes = byte_size;
         if initial_mapped_bytes > 0 {
             if let Err(err) = arena.map_next(&self.hip, initial_mapped_bytes, access_devices) {
                 return Err(self.retain_failed_vmm_arena(arena, err));

--- a/crates/rdna-compute/src/dispatch.rs
+++ b/crates/rdna-compute/src/dispatch.rs
@@ -3075,7 +3075,14 @@ impl Gpu {
         // mapped). Costs up-front VRAM for the whole reservation; correctness
         // over on-demand commit on the platform whose driver breaks growth.
         #[cfg(windows)]
-        let initial_mapped_bytes = byte_size;
+        let initial_mapped_bytes = {
+            // map_next requires a multiple of the allocation granularity
+            let granularity = arena.granularity();
+            byte_size
+                .checked_add(granularity - 1)
+                .map(|v| v / granularity * granularity)
+                .unwrap_or(byte_size)
+        };
         if initial_mapped_bytes > 0 {
             if let Err(err) = arena.map_next(&self.hip, initial_mapped_bytes, access_devices) {
                 return Err(self.retain_failed_vmm_arena(arena, err));


### PR DESCRIPTION
## Problem

`hipMemCreate`/`hipMemMap` on Windows/ROCm 7.2 (gfx1100) maps a second, later segment onto the **same physical pages** as the first. The repo's own `vmm_arena_smoke` example panics at its boundary-growth assert (line 68) after the 2nd `map_next` — segment 1 aliases segment 2's pages — while single-segment maps pass.

The KV cache grows in ~1900 small `map_next` steps, so on Windows every growth corrupts all prior KV. This surfaces as token soup (`"!!!!!!!!"`) from every model (qwen3.8:27b, qwen3.5:0.8b, lfm2.5:1.2b) in `hipfire serve`. Full repro and discussion: #655, #644.

## Fix

Under `#[cfg(windows)]`, `alloc_vmm_tensor` maps the **full reservation in one `map_next`** instead of growing in small segments. Linux behavior is byte-identical to before (the `cfg` block does not exist there).

Trade-off: costs full VRAM up front (no on-demand commit) on Windows only. This is a workaround for what looks like a ROCm-Windows VMM runtime bug — both mappings report distinct virtual addresses via `hipMemGetAddressRange`, yet share physical pages.

## Validation (gfx1100, RX 7900 XTX, Windows 11, ROCm 7.2)

- Output correct after fix: `17*23` → `391`, fluent prose, no token soup
- `vmm_arena_smoke` passes on the single-segment path; multi-segment growth assert is the repro for the underlying runtime issue
- AR decode ~40 t/s, DFlash draft ~48 t/s, 40k+ prefill completes without #635 crash
- No perf claim vs baseline (baseline output was corrupt by construction)

## HW-gate routes

- `scripts/serve_harness.py`: generation/state-lifecycle changed? **No** (dispatch/VMM allocation only)
- `scripts/redline_daemon_harness.py`: kernel/dispatch change? **Yes** — dispatch-layer VMM allocation path