### PR TITLE
fix(probe): find daemon binary with .exe on Windows

### DIFF
--- a/crates/hipfire-runtime/examples/coherence_probe.rs
+++ b/crates/hipfire-runtime/examples/coherence_probe.rs
@@ -175,6 +175,8 @@ fn find_daemon_binary() -> Result<PathBuf, String> {
     // Prefer release; fall back to debug. Mirror the gate scripts'
     // discovery behaviour.
     let candidates = [
+        "target/release/daemon.exe",
+        "target/debug/daemon.exe",
         "target/release/daemon",
         "target/debug/daemon",
     ];


### PR DESCRIPTION
## Problem

`find_daemon_binary()` probes `target/release/daemon` and `target/debug/daemon` without the `.exe` extension, so `coherence_probe` always exits with "daemon binary not found" on Windows.

## Fix

Add the `.exe` candidates first (release + debug), keeping the extensionless ones for Unix. Two-line change, no behavior change on non-Windows (the `.exe` paths simply don't exist there and `exists()` falls through).

## Validation

Verified locally on Windows 11: probe now locates `target/release/daemon.exe` and proceeds past binary discovery.

## HW-gate routes

- `scripts/serve_harness.py`: generation/state-lifecycle changed? **No**
- `scripts/redline_daemon_harness.py`: kernel/dispatch change? **No** (example tooling only)