### PR TITLE
fix(scripts): pass the daemon stderr buffer into load() in audit_swap_memo.py

### DIFF
--- a/scripts/audit_swap_memo.py
+++ b/scripts/audit_swap_memo.py
@@ -26,7 +26,7 @@ def spawn(daemon):
     return p, errs
 
 
-def load(p, model):
+def load(p, model, errs):
     t0 = time.perf_counter()
     p.stdin.write(json.dumps(
         {"type": "load", "model": model, "params": {"max_seq": 2048}}) + "\n")
@@ -52,15 +52,15 @@ def main():
 
     p, errs = spawn(daemon)
     try:
-        print(f"swap1  A={a.split('/')[-1]}: {load(p, a)*1000:.0f} ms")
-        print(f"swap2  A again (warm):   {load(p, a)*1000:.0f} ms")
-        print(f"swap3  B first-in-proc:  {load(p, b)*1000:.0f} ms")
+        print(f"swap1  A={a.split('/')[-1]}: {load(p, a, errs)*1000:.0f} ms")
+        print(f"swap2  A again (warm):   {load(p, a, errs)*1000:.0f} ms")
+        print(f"swap3  B first-in-proc:  {load(p, b, errs)*1000:.0f} ms")
     finally:
         p.terminate()
     # fresh-process control for B
-    p2, _ = spawn(daemon)
+    p2, errs2 = spawn(daemon)
     try:
-        print(f"fresh  B new-process:    {load(p2, b)*1000:.0f} ms")
+        print(f"fresh  B new-process:    {load(p2, b, errs2)*1000:.0f} ms")
     finally:
         p2.terminate()
 


### PR DESCRIPTION
### Problem

`scripts/audit_swap_memo.py` spawns the daemon with a reader thread that accumulates its stderr:

```python
def spawn(daemon):
    ...
    errs = []
    threading.Thread(target=lambda: [errs.append(l) for l in p.stderr],
                     daemon=True).start()
    return p, errs
```

`load()` then tries to put that captured stderr into the error it raises when the daemon dies mid-load:

```python
def load(p, model):                                  # L29 — no `errs` parameter
    ...
        line = p.stdout.readline()
        if not line:
            raise RuntimeError("daemon died: " + "".join(errs[-20:] if errs else []))   # L37
```

but `errs` is a local of `spawn()` / `main()`, never of `load()`. The daemon-died branch therefore raises

```
NameError: name 'errs' is not defined
```

instead of the intended `RuntimeError`, and the daemon's stderr — the only reason the reader thread exists — is discarded at exactly the moment it is needed. On this probe that is the common failure: the swap-memo audit is the run where a model is expected to be too big for the card, so `hipfire-daemon` dying during `swap3 B first-in-proc` is the case the script is built to diagnose.

Replay of the daemon-died path with a stubbed process whose stderr holds two OOM lines:

```
--- master ---
NameError: name 'errs' is not defined

--- with fix ---
RuntimeError: daemon died: hipfire-daemon: HSA_STATUS_ERROR_OUT_OF_RESOURCES
hipfire-daemon: aborting model load for qwen3.5:27b
```

### Fix

Thread the stderr buffer through to `load()`, which is what the `raise` already assumes. `main()` already binds it from `spawn()`; the fresh-process control just needs to keep it instead of discarding it into `_`.

Script-only change — no crate, kernel or daemon code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
