### PR TITLE
perf(gfx1100): eliminate MQ4V2 residual scratch/spills for +2.7–2.9% Qwen3.8-27B decode

### DIFF
--- a/kernels/src/gemv_mq4g256v2_residual.hip
+++ b/kernels/src/gemv_mq4g256v2_residual.hip
@@ -127,8 +127,43 @@ extern "C" __global__ void HIPFIRE_RESIDUAL_KERNEL(
 
         // Weight MEMORY phase: sequential along row0 then row1 (8 headers).
         float sc0a, zp0a, sc1a, zp1a, sc2a, zp2a, sc3a, zp3a;
+        unsigned int pk0a, pk1a, pk2a, pk3a;
         float sc0b, zp0b, sc1b, zp1b, sc2b, zp2b, sc3b, zp3b;
-        unsigned int pk0a, pk1a, pk2a, pk3a, pk0b, pk1b, pk2b, pk3b;
+        unsigned int pk0b, pk1b, pk2b, pk3b;
+
+#if defined(__gfx1100__)
+        LOAD_W(row_ptr0 + g * 136, row_weight_offset0 + g * 136, sc0a, zp0a, pk0a);
+        LOAD_W(row_ptr0 + (g + 1) * 136, row_weight_offset0 + (g + 1) * 136, sc1a, zp1a, pk1a);
+        LOAD_W(row_ptr0 + (g + 2) * 136, row_weight_offset0 + (g + 2) * 136, sc2a, zp2a, pk2a);
+        LOAD_W(row_ptr0 + (g + 3) * 136, row_weight_offset0 + (g + 3) * 136, sc3a, zp3a, pk3a);
+
+        // Finish row0 before making row1's headers live. The empty exact-gfx1100
+        // dependency barrier prevents LLVM from hoisting the second row's loads
+        // back across this point; it emits no ISA instruction.
+        DOG_X8(sc0a, zp0a, pk0a, acc0,
+               xv0a.x, xv0a.y, xv0a.z, xv0a.w, xv0b.x, xv0b.y, xv0b.z, xv0b.w);
+        DOG_X8(sc1a, zp1a, pk1a, acc1,
+               xv1a.x, xv1a.y, xv1a.z, xv1a.w, xv1b.x, xv1b.y, xv1b.z, xv1b.w);
+        DOG_X8(sc2a, zp2a, pk2a, acc2,
+               xv2a.x, xv2a.y, xv2a.z, xv2a.w, xv2b.x, xv2b.y, xv2b.z, xv2b.w);
+        DOG_X8(sc3a, zp3a, pk3a, acc3,
+               xv3a.x, xv3a.y, xv3a.z, xv3a.w, xv3b.x, xv3b.y, xv3b.z, xv3b.w);
+
+        asm volatile("" : "+v"(acc0), "+v"(acc1), "+v"(acc2), "+v"(acc3) :: "memory");
+
+        LOAD_W(row_ptr1 + g * 136, row_weight_offset1 + g * 136, sc0b, zp0b, pk0b);
+        LOAD_W(row_ptr1 + (g + 1) * 136, row_weight_offset1 + (g + 1) * 136, sc1b, zp1b, pk1b);
+        LOAD_W(row_ptr1 + (g + 2) * 136, row_weight_offset1 + (g + 2) * 136, sc2b, zp2b, pk2b);
+        LOAD_W(row_ptr1 + (g + 3) * 136, row_weight_offset1 + (g + 3) * 136, sc3b, zp3b, pk3b);
+        DOG_X8(sc0b, zp0b, pk0b, bcc0,
+               xv0a.x, xv0a.y, xv0a.z, xv0a.w, xv0b.x, xv0b.y, xv0b.z, xv0b.w);
+        DOG_X8(sc1b, zp1b, pk1b, bcc1,
+               xv1a.x, xv1a.y, xv1a.z, xv1a.w, xv1b.x, xv1b.y, xv1b.z, xv1b.w);
+        DOG_X8(sc2b, zp2b, pk2b, bcc2,
+               xv2a.x, xv2a.y, xv2a.z, xv2a.w, xv2b.x, xv2b.y, xv2b.z, xv2b.w);
+        DOG_X8(sc3b, zp3b, pk3b, bcc3,
+               xv3a.x, xv3a.y, xv3a.z, xv3a.w, xv3b.x, xv3b.y, xv3b.z, xv3b.w);
+#else
         LOAD_W(row_ptr0 + g * 136, row_weight_offset0 + g * 136, sc0a, zp0a, pk0a);
         LOAD_W(row_ptr0 + (g + 1) * 136, row_weight_offset0 + (g + 1) * 136, sc1a, zp1a, pk1a);
         LOAD_W(row_ptr0 + (g + 2) * 136, row_weight_offset0 + (g + 2) * 136, sc2a, zp2a, pk2a);
@@ -138,26 +173,23 @@ extern "C" __global__ void HIPFIRE_RESIDUAL_KERNEL(
         LOAD_W(row_ptr1 + (g + 2) * 136, row_weight_offset1 + (g + 2) * 136, sc2b, zp2b, pk2b);
         LOAD_W(row_ptr1 + (g + 3) * 136, row_weight_offset1 + (g + 3) * 136, sc3b, zp3b, pk3b);
 
-        // Pure FMA phase: same dual-row DOG order and acc slots as baseline.
         DOG_X8(sc0a, zp0a, pk0a, acc0,
                xv0a.x, xv0a.y, xv0a.z, xv0a.w, xv0b.x, xv0b.y, xv0b.z, xv0b.w);
         DOG_X8(sc0b, zp0b, pk0b, bcc0,
                xv0a.x, xv0a.y, xv0a.z, xv0a.w, xv0b.x, xv0b.y, xv0b.z, xv0b.w);
-
         DOG_X8(sc1a, zp1a, pk1a, acc1,
                xv1a.x, xv1a.y, xv1a.z, xv1a.w, xv1b.x, xv1b.y, xv1b.z, xv1b.w);
         DOG_X8(sc1b, zp1b, pk1b, bcc1,
                xv1a.x, xv1a.y, xv1a.z, xv1a.w, xv1b.x, xv1b.y, xv1b.z, xv1b.w);
-
         DOG_X8(sc2a, zp2a, pk2a, acc2,
                xv2a.x, xv2a.y, xv2a.z, xv2a.w, xv2b.x, xv2b.y, xv2b.z, xv2b.w);
         DOG_X8(sc2b, zp2b, pk2b, bcc2,
                xv2a.x, xv2a.y, xv2a.z, xv2a.w, xv2b.x, xv2b.y, xv2b.z, xv2b.w);
-
         DOG_X8(sc3a, zp3a, pk3a, acc3,
                xv3a.x, xv3a.y, xv3a.z, xv3a.w, xv3b.x, xv3b.y, xv3b.z, xv3b.w);
         DOG_X8(sc3b, zp3b, pk3b, bcc3,
                xv3a.x, xv3a.y, xv3a.z, xv3a.w, xv3b.x, xv3b.y, xv3b.z, xv3b.w);
+#endif
     }
 
     if (tail >= 1) {


### PR DESCRIPTION
## Summary

On exact gfx1100, stage the two MQ4V2 residual row-header groups separately so LLVM no longer keeps both rows' scale/zero/packed-weight values live across the FMA phase. A zero-instruction compiler dependency barrier prevents the second row's loads from being hoisted back across that boundary.

This removes private scratch and spills from `gemv_mq4g256v2_residual` while preserving the existing launch geometry and occupancy plateau:

| gfx1100 resource | beta | this PR |
|---|---:|---:|
| VGPR | 96 | 81 |
| private scratch | 24 B/lane | 0 |
| VGPR spills | 5 | 0 |
| waves/SIMD | 16 | 16 |

The new schedule is guarded by `__gfx1100__`. Recompiled gfx1151 and gfx1201 instruction streams are SHA-identical to beta.

## Which surface(s) does this touch?

- [x] **kernel** — `kernels/src/gemv_mq4g256v2_residual.hip`
- [ ] **load**
- [ ] **serve**
- [ ] **arch crate(s)**
- [ ] `crates/hipfire-quantize` / quant formats
- [ ] control plane
- [ ] docs / CI / scripts only
- [ ] **policy files**

## Test plan

- [ ] `./scripts/no-gpu-ci.sh` passes, or the CI jobs are green
- [x] `cargo build --release` clean
- [x] `cargo test --lib --workspace` passes
- [x] **load / serve / kernel changes:** `serve_harness.py --mode battery` passed on the exact target/model route; evidence below
- [ ] `./scripts/speed-gate.sh` within ±2% of locked baselines
- [ ] ratchet raise (not applicable)

`./scripts/no-gpu-ci.sh` reaches the Python suite but currently fails 5 pre-existing `tests/test_mq4c_repack.py` cases because beta's test expects `HfqmError`, `parse_hfqm_index`, and `main`, while beta's `tools/quant-design/mq4c_repack.py` does not define them. The same 5/5 failures reproduce unchanged on clean `origin/beta@5773f6249`; this PR does not touch either file. All Rust workspace library tests pass. The initially noisy global-free-VRAM assertion was also rerun under the GPU lock and passed.

The GitHub advisory clippy job also currently fails on unchanged beta code: `crates/hipfire-arch-qwen35/examples/test_dflash_hidden_scatter_gfx1100.rs:29` uses `3.1415927`, which stable Clippy now denies as `clippy::approx_constant`. This PR does not touch that example or any Rust source.

<details><summary>local serve_harness battery evidence</summary>

Hardware and route: RX W7900 (gfx1100), HIP 7.14, Qwen3.8-27B MQ4V2, Q8 VMM KV, AR/speculation off, greedy, thinking off, max_seq=65536, max_tokens=512.

- turns: 5/5
- finish: 5/5 `stop`
- runaway: 0
- empty: 0
- attractor: 0
- retrieval_miss: 0
- daemon MD5: `b29d09e9d0b40da4d11fa5465cd47b16`

```json
[
  {"genre":"code","finish":"stop","empty":false,"attractor":false,"expected_substrings":[],"prompt_md5":"43ca0d15712d3dfb777b51ae76d8fd5f","request_md5":"cd89974d90d6a16ca93cfc57a6a916e0","assistant_content":"```python\ndef merge_sorted(a, b):\n    \"\"\"Merge two sorted lists into a single sorted list.\"\"\"\n    result = []\n    i, j = 0, 0\n\n    while i < len(a) and j < len(b):\n        if a[i] <= b[j]:\n            result.append(a[i])\n            i += 1\n        else:\n            result.append(b[j])\n            j += 1\n\n    result.extend(a[i:])\n    result.extend(b[j:])\n\n    return result\n```"},
  {"genre":"reason","finish":"stop","empty":false,"attractor":false,"expected_substrings":[],"prompt_md5":"640e0fd4f55996cb175a422f0a12cef5","request_md5":"9355a829e4406f6c8a93d55162ebaaba","assistant_content":"Step 1: Distance for the first part  \n\\(60 \\text{ mph} \\times 2.5 \\text{ hours} = 150 \\text{ miles}\\)\n\nStep 2: Distance for the second part  \n\\(40 \\text{ mph} \\times 1.5 \\text{ hours} = 60 \\text{ miles}\\)\n\nStep 3: Total distance  \n\\(150 + 60 = 210 \\text{ miles}\\)\n\n**Final answer: 210 miles**"},
  {"genre":"factual","finish":"stop","empty":false,"attractor":false,"expected_substrings":[],"prompt_md5":"8f66b4c97988825bd8e7840aaf44357e","request_md5":"1843ab3a4f70ae13ade5318705a55e93","assistant_content":"Earth's seasons are caused mainly by the tilt of its rotational axis relative to its orbital plane. As Earth orbits the Sun, different hemispheres receive more direct sunlight and longer days at different times of the year. This variation in sunlight angle and day length creates the seasonal changes in temperature and weather."},
  {"genre":"prose","finish":"stop","empty":false,"attractor":false,"expected_substrings":[],"prompt_md5":"8fe0ad36f61bcf4992cc9df81cdf3817","request_md5":"b340c04223c1908d43534bafd87c81ec","assistant_content":"Every morning, Elias climbed the black rocks to check for driftwood and broken glass.  \nToday, he found a brass key, warm to the touch, with a name he had never seen engraved on its bow.  \nThe tide was rising, and the key seemed to pull gently in his palm, as if it wanted to be carried somewhere.  \nHe pocketed it, knowing the lighthouse would never be quite the same again."},
  {"genre":"instruct","finish":"stop","empty":false,"attractor":false,"expected_substrings":[],"prompt_md5":"8bed8e2d056dc1d47dccae9d32dbecf4","request_md5":"c1ab99560f6753032d343196deef9d4e","assistant_content":"1. Write clear, descriptive names for variables, functions, and modules.\n2. Keep functions small and focused on a single responsibility.\n3. Add concise comments only where intent or complexity is not obvious.\n4. Write automated tests to document behavior and prevent regressions.\n5. Refactor regularly and remove dead code to keep the codebase current."}
]
```

</details>

## Numeric and replay correctness

- `test_kernels`: **16 passed / 0 failed / 0 skipped** on gfx1100.
- Dedicated MQ4V2 residual oracle: worst relative error `2.426e-7`; nonzero-residual output hash exactly `a5005ec8ba097cdb`; all canaries intact.
- Redline daemon harness: stable 659-launch capture, 16/16 AQL contracts, exact HIP/PM4 output parity, exact GDN-frame parity.
- `rdna-compute`: 244/244 tests passed; crate maps, fmt-bomb, and diff-check passed.
- gfx1151 and gfx1201 disassembly hashes are unchanged from beta.

## Performance

Hardware: RX W7900 (gfx1100), HIP 7.14. Model: Qwen3.8-27B MQ4V2, SHA256 `9f91556f7e0431a077d03756a7102d0154108757289e6e5fe9a2d204c0c9eeb7`. Q8 KV, speculation off, temperature 0. Baseline is clean beta `5773f6249`; candidate is `f599bf49d`.

### Fresh-process short decode

Three fresh processes per arm, five measured 256-token runs per process:

| arm | process medians | median |
|---|---|---:|
| beta | 37.9 / 37.7 / 37.6 tok/s | 37.7 tok/s |
| this PR | 38.7 / 38.8 / 38.8 tok/s | 38.8 tok/s |

Median improvement: **+2.9%**. Prompt MD5 `d94d3115a3001f08a654d91461d6bdc4`; model MD5 `e45d15bfe0c9a87132697101d17cbed6`; baseline daemon MD5 `c44179c31792e9e0e4283847e1fb8a9d`; candidate daemon MD5 `b29d09e9d0b40da4d11fa5465cd47b16`.

### LongBench-v2 hard30, 20K-30K-token prompts

Dataset fixture SHA256 `839a19be0b3b1c801a0ca58d388996faff34704e34dd196d54346adf17a1dce9`; max_seq=65536, max_tokens=96.

| metric | beta | this PR | paired result |
|---|---:|---:|---:|
| valid / errors | 30 / 0 | 30 / 0 | — |
| scored accuracy | 8/19 (42.1%) | 8/19 (42.1%) | identical |
| prefill median | 539.3 tok/s | 538.75 tok/s | 0.999x |
| decode median | 30.6 tok/s | 31.1 tok/s | **1.016x** |
| wall median | 50.653 s | 50.605 s | 1.000x |

All **30/30 decoded-output SHA256 hashes are identical**. Wall time is intentionally flat because these cases spend roughly 35-62 seconds in 20K-30K prefill and emit only 8 or 96 tokens; this kernel is a decode-only change.

### Six-task long decode

Fixture SHA256 `38578bb6b11c8e0b322584c40857211520770949f52b9387ceb501bdcd71c72e`; generated lengths 1,536 to 8,192 tokens.

| task | tokens | beta | this PR | speedup |
|---|---:|---:|---:|---:|
| KV Cache guide | 1,536 | 38.1 | 39.3 tok/s | 1.031x |
| SGLang guide | 1,536 | 37.9 | 38.9 tok/s | 1.026x |
| story | 1,561 | 38.0 | 38.9 tok/s | 1.024x |
| Snake code | 2,549 | 37.8 | 38.7 tok/s | 1.024x |
| Tetris code | 4,780 | 37.3 | 38.3 tok/s | 1.027x |
| responsive webpage | 8,192 | 36.7 | 37.7 tok/s | 1.027x |

Paired median improvement: **+2.66% decode throughput and +2.62% wall time**. All six tasks improved, token counts match, and **6/6 output SHA256 hashes are identical**. I read all six outputs plus five LongBench samples; there was no corruption, rollover, or token attractor.

Long-run daemon SHA256: beta `27b06d800443127865f1e7985177ba42cfe0833b1cfac4aef13fd4da7ed37156`; candidate `cac8624e6790714b3945e63024fcde29bc16af12f6dd1d5d0f930ef19e10b907`.

## Architecture-trait change?

No.
